### PR TITLE
Adds support for playing the renamed intro movies from The First Decade and Freeware TS installations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ endif()
 # Set some handy defines we can use for error messages etc.
 ################################################################################
 set(PROJECT_DLL "${PROJECT_NAME}.dll")
-set(UNSUPPORTED_TARGET_ERROR "(Only TS203EN is currently supported)")
+set(UNSUPPORTED_TARGET_ERROR "(Only TS203EN and Freeware-TS is currently supported)")
 set(TARGET_EXE "GAME.EXE") # Define the EXE to launch.
 set(TARGET_NAME "Tiberian Sun")
 

--- a/src/hooker/launcher.cpp.in
+++ b/src/hooker/launcher.cpp.in
@@ -54,7 +54,18 @@
 /**
  *  Define the SHA hash to compare against.
  */
-#define TARGET_HASH "@TARGET_HASH@"
+const char *BinaryHash[] = {
+	"@TARGET_HASH@",
+	"@TARGET_FTS_HASH@"
+};
+
+/**
+ *  Size of the binaries in bytes.
+ */
+int BinarySize[] = {
+	@TARGET_SIZE@,
+	@TARGET_FTS_SIZE@
+};
 
 /**
  *  The target EXE file to launch (can be changed by a custom argument).
@@ -71,10 +82,6 @@ char *DLLName = "@PROJECT_DLL@";
  */
 char *PDBName = "@PROJECT_NAME@.pdb";
 
-/**
- *  Size of the binary in bytes.
- */
-int BinarySize = @TARGET_SIZE@;
 
 static STARTUPINFOA StartupInfo = {0};
 static PROCESS_INFORMATION ProcessInformation;
@@ -83,7 +90,7 @@ static PROCESS_INFORMATION ProcessInformation;
 /**
  *  Check the target binary SHA hash.
  */
-bool Check_Hash(const char *filename)
+bool Check_Hash(const char *filename, const char *target_hash)
 {
     SHAEngine sha;
     char buffer[1024];
@@ -103,7 +110,7 @@ bool Check_Hash(const char *filename)
 	/**
 	 *  Does the expected hash match the target binary hash?
 	 */
-    return strcmpi(TARGET_HASH, hash) == 0;
+    return strcmpi(target_hash, hash) == 0;
 }
 
 
@@ -431,35 +438,36 @@ int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdL
         return EXIT_FAILURE;
     }
 	
+	bool matches = false;
+	
 	/**
-	 *  Check the filesize matches first before we attempt injection.
+	 *  Iterate over all the possible target binaries to check if
+	 *  they match one we support.
 	 */
-	if (Get_File_Size(EXEName) != BinarySize) {
+	for (int i = 0; i < 2; ++i) {
+		
+		/**
+		 *  Check the filesize and hash matches first before we attempt injection.
+		 */
+		if (Get_File_Size(EXEName) == BinarySize[i]) {
+			if (Check_Hash(EXEName, BinaryHash[i])) {
+				matches = true;
+			}
+		}
+
+	}
+
+	if (!matches) {
 		char buff[1024];
 		std::snprintf(buff, sizeof(buff),
-            "Modified or unsupported version %s detected!\n\n"
-            "Please check you have the correct version of " TARGET_NAME " installed\n"
-            "and that it is up to date " UNSUPPORTED_TARGET ".\n",
+			"Modified or unsupported version of %s detected!\n\n"
+			"Please check you have the correct version of " TARGET_NAME " installed\n"
+			"and that it is up to date " UNSUPPORTED_TARGET ".\n",
 			EXEName
 		);
 		MessageBox(NULL, buff, "Error!", MB_OK|MB_ICONEXCLAMATION);
 		return EXIT_FAILURE;
 	}
-
-	/**
-	 *  Let the user know if the binary they have is not the expected version and then bail.
-	 */
-    if (!Check_Hash(EXEName)) {
-		char buff[1024];
-		std::snprintf(buff, sizeof(buff),
-			"%s's checksum does not match expected value!\n\n"
-            "Please check you have the correct version of " TARGET_NAME " installed\n"
-            "and that it is up to date " UNSUPPORTED_TARGET ".\n",
-			EXEName
-		);
-		MessageBoxA(NULL, buff, "Error!", MB_OK|MB_ICONEXCLAMATION);
-        return EXIT_FAILURE;
-    }
 
 	if (!Inject_Loader(EXEName, DLLName, Make_Args(lpCmdLine))) {
 		MessageBoxA(NULL, "Injection failed!", "Error!", MB_OK|MB_ICONEXCLAMATION);


### PR DESCRIPTION
Closes #95

This pull request enables support for playing the renamed intro movies from The First Decade and Freeware TS installations when starting a new campaign. It also allows Vinifera to be used with Freeware TS installations. While it does not allow Vinifera to work with The First Decade directly, you can use the Freeware TS executable to replace The First Decade executable, therefore it fulfils the requirements for the relevant issue to be closed. 

