### PR TITLE
Adds a "Load Game" button to the retry dialog on mission failure.

### DIFF
--- a/src/bugfix/bugfix_hooks.cpp
+++ b/src/bugfix/bugfix_hooks.cpp
@@ -29,16 +29,90 @@
 #include "bugfixes.h"
 
 #include "tibsun_globals.h"
+#include "vinifera_util.h"
 #include "campaign.h"
 #include "scenario.h"
 #include "playmovie.h"
 #include "ccfile.h"
 #include "cd.h"
 #include "vqa.h"
+#include "language.h"
+#include "theme.h"
+#include "msgbox.h"
+#include "loadoptions.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-269
+ * 
+ *  Adds a "Load Game" button to the dialog shown on mission lose.
+ * 
+ *  @author: CCHyper
+ */
+static bool _Save_Games_Available()
+{
+    return LoadOptionsClass().Read_Save_Files();
+}
+
+static bool _Do_Load_Dialog()
+{
+    return LoadOptionsClass().Load_Dialog();
+}
+
+DECLARE_PATCH(_Do_Lose_Create_Lose_WWMessageBox)
+{
+    static bool saves_found;
+    static int ret;
+
+    /**
+     *  Show the message box.
+     */
+retry_dialog:
+    ret = Vinifera_Do_WWMessageBox(Text_String(TXT_TO_REPLAY), Text_String(TXT_YES), Text_String(TXT_NO), "Load Game");
+    switch (ret) {
+        default:
+        case 0: // User pressed "Yes"
+            JMP(0x005DCE1A);
+
+        case 1: // User pressed "No"
+            JMP(0x005DCE56);
+
+        case 2: // User pressed "Load Game"
+        {
+            /**
+             *  If no save games are available, notify the user and return back
+             *  and reissue the main dialog.
+             */
+            if (!_Save_Games_Available()) {
+                Vinifera_Do_WWMessageBox("No saved games available.", Text_String(TXT_OK));
+                goto retry_dialog;
+            }
+
+            /**
+             *  Show the load game dialog.
+             */
+            ret = _Do_Load_Dialog();
+            if (ret) {
+                Theme.Stop();
+                JMP(0x005DCE48);
+            }
+
+            /**
+             *  Reissue the dialog if the user pressed cancel on the load dialog.
+             */
+            goto retry_dialog;
+        }
+    };
+}
+
+static void _Show_Load_Game_On_Mission_Failure()
+{
+    Patch_Jump(0x005DCDFD, &_Do_Lose_Create_Lose_WWMessageBox);
+}
 
 
 /**
@@ -228,4 +302,5 @@ void BugFix_Hooks()
 {
     _OptionsClass_Constructor_AllowHiResModes_Default_Patch();
     _Intro_Movie_Patchies();
+    _Show_Load_Game_On_Mission_Failure();
 }

--- a/src/vinifera_util.cpp
+++ b/src/vinifera_util.cpp
@@ -35,6 +35,7 @@
 #include "textprint.h"
 #include "dsurface.h"
 #include "wwfont.h"
+#include "msgbox.h"
 #include "minidump.h"
 #include "winutil.h"
 #include <cstdio>
@@ -226,4 +227,18 @@ bool Vinifera_Generate_Mini_Dump()
 
     MessageBox(MainWindow, "Failed to create crash dump!\n\n", "Crash dump", MB_OK|MB_ICONASTERISK);
     return false;
+}
+
+
+/**
+ *  Shows a in-game message box.
+ * 
+ *  This has been made its own function because we can not allocate on the stack with
+ *  our patches, so this handles all that within this function scope.
+ * 
+ *  @author: CCHyper
+ */
+int Vinifera_Do_WWMessageBox(const char *msg, const char *btn1, const char *btn2, const char *btn3)
+{
+    return WWMessageBox().Process(msg, 0, btn1, btn2, btn3);
 }

--- a/src/vinifera_util.h
+++ b/src/vinifera_util.h
@@ -37,3 +37,5 @@ const char *TSpp_Version_String();
 void Vinifera_Draw_Version_Text(XSurface *surface, bool pre_init = false);
 
 bool Vinifera_Generate_Mini_Dump();
+
+int Vinifera_Do_WWMessageBox(const char *msg, const char *btn1, const char *btn2 = nullptr, const char *btn3 = nullptr);


### PR DESCRIPTION
Closed #269 

This Pull requested adds a "Load Game" button to the retry dialog shown after a failed mission.

Currently, Vinifera does not support save games due to the extension classes still work in progress, but this has been tested locally.

Below are some demonstrative screenshots;

New dialog layout with the "Load Game" button;
![image](https://user-images.githubusercontent.com/73803386/120727630-ed661a80-c4d2-11eb-9fae-b320afa643db.png)

When "Load Game" has been pressed and there are save files available;
![image](https://user-images.githubusercontent.com/73803386/120727653-ffe05400-c4d2-11eb-8d85-6c75687a1cb1.png)

When "Load Game" has been pressed and there are not any save files available;
![image](https://user-images.githubusercontent.com/73803386/120727661-04a50800-c4d3-11eb-82a6-92f54c2ace2d.png)


