### PR TITLE
Adds various developer mode hotkey commands.

### DIFF
--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -586,3 +586,43 @@ bool SpecialWeaponsCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Hands out free money to the player.
+ * 
+ *  @author: CCHyper
+ */
+const char *FreeMoneyCommandClass::Get_Name() const
+{
+    return "FreeMoney";
+}
+
+const char *FreeMoneyCommandClass::Get_UI_Name() const
+{
+    return "Free Money";
+}
+
+const char *FreeMoneyCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *FreeMoneyCommandClass::Get_Description() const
+{
+    return "Gives free money to the player.";
+}
+
+bool FreeMoneyCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Give 10,000 credits to the player.
+     */
+    PlayerPtr->Refund_Money(10000);
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1911,3 +1911,43 @@ bool PlaceCrateCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Displays cell coordinates of the mouse cursor.
+ * 
+ *  @author: CCHyper
+ */
+const char *CursorPositionCommandClass::Get_Name() const
+{
+    return "CursorPosition";
+}
+
+const char *CursorPositionCommandClass::Get_UI_Name() const
+{
+    return "Cursor Position";
+}
+
+const char *CursorPositionCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *CursorPositionCommandClass::Get_Description() const
+{
+    return "Displays cell coordinates of the mouse cursor.";
+}
+
+bool CursorPositionCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Toggle the show cursor position flag.
+     */
+    Vinifera_Developer_ShowCursorPosition = !Vinifera_Developer_ShowCursorPosition;
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -28,8 +28,10 @@
 #include "commandext.h"
 #include "tibsun_globals.h"
 #include "vinifera_globals.h"
+#include "iomap.h"
 #include "dsurface.h"
 #include "wwmouse.h"
+#include "house.h"
 #include "unit.h"
 #include "unittype.h"
 #include "infantry.h"
@@ -360,4 +362,118 @@ bool AIInstantBuildCommandClass::Process()
     Vinifera_Developer_AIInstantBuild = !Vinifera_Developer_AIInstantBuild;
 
     return true;
+}
+
+
+/**
+ *  Forces the player to win the current game session.
+ * 
+ *  @author: CCHyper
+ */
+const char *ForceWinCommandClass::Get_Name() const
+{
+    return "ForceWin";
+}
+
+const char *ForceWinCommandClass::Get_UI_Name() const
+{
+    return "To Win";
+}
+
+const char *ForceWinCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ForceWinCommandClass::Get_Description() const
+{
+    return "Forces the player to win the current game session.";
+}
+
+bool ForceWinCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Player wins.
+     */
+    return PlayerPtr->Flag_To_Win();
+}
+
+
+/**
+ *  Forces the player to lose the current game session.
+ * 
+ *  @author: CCHyper
+ */
+const char *ForceLoseCommandClass::Get_Name() const
+{
+    return "ForceLose";
+}
+
+const char *ForceLoseCommandClass::Get_UI_Name() const
+{
+    return "To Lose";
+}
+
+const char *ForceLoseCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ForceLoseCommandClass::Get_Description() const
+{
+    return "Forces the player to lose the current game session.";
+}
+
+bool ForceLoseCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Player loses
+     */
+    return PlayerPtr->Flag_To_Lose();
+}
+
+
+/**
+ *  Forces the player to blowup and lose the current game session.
+ * 
+ *  @author: CCHyper
+ */
+const char *ForceDieCommandClass::Get_Name() const
+{
+    return "ForceDie";
+}
+
+const char *ForceDieCommandClass::Get_UI_Name() const
+{
+    return "To Die";
+}
+
+const char *ForceDieCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ForceDieCommandClass::Get_Description() const
+{
+    return "Forces the player to blowup, loosing the current game session.";
+}
+
+bool ForceDieCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Player dies.
+     */
+    return PlayerPtr->Flag_To_Die();
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -52,6 +52,7 @@
 #include "ionblast.h"
 #include "combat.h"
 #include "scenarioini.h"
+#include "scenario.h"
 #include "wwcrc.h"
 #include "filepcx.h"
 #include "filepng.h"
@@ -1506,6 +1507,47 @@ bool HealCommandClass::Process()
     }
 
     Map.Recalc();
+
+    return true;
+}
+
+
+/**
+ *  Toggles if weapons do damage or not.
+ * 
+ *  @author: CCHyper
+ */
+const char *ToggleInertCommandClass::Get_Name() const
+{
+    return "ToggleInert";
+}
+
+const char *ToggleInertCommandClass::Get_UI_Name() const
+{
+    return "Toggle Inert";
+}
+
+const char *ToggleInertCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ToggleInertCommandClass::Get_Description() const
+{
+    return "Toggles if weapons are inert or not.";
+}
+
+bool ToggleInertCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  This flags controls whether weapons are inert. An inert weapon doesn't do
+     *  any damage. Effectively, if this is true, then units will never die.
+     */
+    Scen->SpecialFlags.IsInert = !Scen->SpecialFlags.IsInert;
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -477,3 +477,60 @@ bool ForceDieCommandClass::Process()
      */
     return PlayerPtr->Flag_To_Die();
 }
+
+
+/**
+ *  Take ownership of any selected objects.
+ * 
+ *  @author: CCHyper
+ */
+const char *CaptureObjectCommandClass::Get_Name() const
+{
+    return "CaptureObject";
+}
+
+const char *CaptureObjectCommandClass::Get_UI_Name() const
+{
+    return "Capture Object";
+}
+
+const char *CaptureObjectCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *CaptureObjectCommandClass::Get_Description() const
+{
+    return "Take ownership of any selected objects.";
+}
+
+bool CaptureObjectCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Iterate over all currently selected objects and take ownership of them.
+     */
+    for (int i = 0; i < CurrentObjects.Count(); ++i) {
+        ObjectClass * object = CurrentObjects[i];
+        if (!object || !object->Is_Techno()) {
+            continue;
+        }
+
+        /**
+         *  We own this object already, skip it.
+         */
+        if (object->Owning_House() == PlayerPtr) {
+            continue;
+        }
+
+        TechnoClass *techno = dynamic_cast<TechnoClass *>(object);
+        techno->Captured(PlayerPtr);
+    }
+
+    Map.Recalc();
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1346,3 +1346,65 @@ bool ToggleEliteCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Unlock all available build options for the player house.
+ * 
+ *  @author: CCHyper
+ */
+const char *BuildCheatCommandClass::Get_Name() const
+{
+    return "BuildCheat";
+}
+
+const char *BuildCheatCommandClass::Get_UI_Name() const
+{
+    return "Build Cheat";
+}
+
+const char *BuildCheatCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *BuildCheatCommandClass::Get_Description() const
+{
+    return "Unlock all available build options for the player house.";
+}
+
+bool BuildCheatCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Toggle the build cheat flag.
+     */
+    Vinifera_Developer_BuildCheat = !Vinifera_Developer_BuildCheat;
+
+    /**
+     *  Flag the player house to recalculate buildables.
+     */
+    PlayerPtr->IsRecalcNeeded = true;
+
+    if (!ScenarioInit) {
+
+        /**
+         *  Update all factories.
+         */
+        for (int index = 0; index < Buildings.Count(); index++) {
+            BuildingClass *building = Buildings[index];
+            if (building) {
+                if (building->Owning_House() == PlayerPtr) {
+                    building->Update_Buildables();
+                }
+            }
+        }
+    }
+
+    Map.Recalc();
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -27,7 +27,9 @@
  ******************************************************************************/
 #include "commandext.h"
 #include "tibsun_globals.h"
+#include "tibsun_util.h"
 #include "vinifera_globals.h"
+#include "vinifera_util.h"
 #include "iomap.h"
 #include "dsurface.h"
 #include "wwmouse.h"
@@ -42,6 +44,7 @@
 #include "aircraft.h"
 #include "aircrafttype.h"
 #include "session.h"
+#include "ionstorm.h"
 #include "wwcrc.h"
 #include "filepcx.h"
 #include "filepng.h"
@@ -623,6 +626,45 @@ bool FreeMoneyCommandClass::Process()
      *  Give 10,000 credits to the player.
      */
     PlayerPtr->Refund_Money(10000);
+
+    return true;
+}
+
+
+/**
+ *  Fires a lightning bolt at the current mouse cursor location.
+ * 
+ *  @author: CCHyper
+ */
+const char *LightningBoltCommandClass::Get_Name() const
+{
+    return "LightningBolt";
+}
+
+const char *LightningBoltCommandClass::Get_UI_Name() const
+{
+    return "Lightning Bolt";
+}
+
+const char *LightningBoltCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *LightningBoltCommandClass::Get_Description() const
+{
+    return "Fires a lightning bolt at the current mouse location.";
+}
+
+bool LightningBoltCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Cell mouse_cell = Get_Cell_Under_Mouse();
+
+    IonStorm_Lightning_Strike_At(mouse_cell);
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -33,8 +33,11 @@
 #include "iomap.h"
 #include "dsurface.h"
 #include "wwmouse.h"
+#include "rules.h"
 #include "house.h"
 #include "super.h"
+#include "anim.h"
+#include "animtype.h"
 #include "unit.h"
 #include "unittype.h"
 #include "infantry.h"
@@ -43,9 +46,11 @@
 #include "buildingtype.h"
 #include "aircraft.h"
 #include "aircrafttype.h"
+#include "warheadtype.h"
 #include "session.h"
 #include "ionstorm.h"
 #include "ionblast.h"
+#include "combat.h"
 #include "wwcrc.h"
 #include "filepcx.h"
 #include "filepng.h"
@@ -706,6 +711,142 @@ bool IonBlastCommandClass::Process()
     mouse_coord.Z = Map.Get_Cell_Height(mouse_coord);
 
     new IonBlastClass(mouse_coord);
+
+    return true;
+}
+
+
+/**
+ *  Spawns an explosion at the mouse cursor location.
+ * 
+ *  @author: CCHyper
+ */
+const char *ExplosionCommandClass::Get_Name() const
+{
+    return "Explosion";
+}
+
+const char *ExplosionCommandClass::Get_UI_Name() const
+{
+    return "Explosion";
+}
+
+const char *ExplosionCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ExplosionCommandClass::Get_Description() const
+{
+    return "Spawns a explosion at the mouse location.";
+}
+
+bool ExplosionCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Coordinate mouse_coord = Get_Coord_Under_Mouse();
+    mouse_coord.Z = Map.Get_Cell_Height(mouse_coord);
+
+    const CellClass *cellptr = &Map[mouse_coord];
+    if (!cellptr) {
+        return false;
+    }
+
+    /**
+     *  The damage to deal at the coord.
+     */
+    int damage = Rule->MaxDamage;
+
+    /**
+     *  Pick a random warhead from the list, using C4Warhead as a backup.
+     */
+    const WarheadTypeClass *warheadtypeptr = WarheadTypeClass::As_Pointer(Percent_Chance(50) ? "AP" : "HE");
+    if (!warheadtypeptr) {
+        warheadtypeptr = Rule->C4Warhead;
+    }
+
+    /**
+     *  What anim should we use for this criteria.
+     */
+    const AnimTypeClass *cellanim = Combat_Anim(damage, warheadtypeptr, cellptr->Land_Type(), &mouse_coord);
+    if (!cellanim) {
+        return false;
+    }
+
+    new AnimClass(cellanim, mouse_coord);
+
+    Explosion_Damage(&mouse_coord, damage, nullptr, warheadtypeptr);
+
+    return true;
+}
+
+
+/**
+ *  Spawns a large explosion at the mouse cursor location.
+ * 
+ *  @author: CCHyper
+ */
+const char *SuperExplosionCommandClass::Get_Name() const
+{
+    return "SuperExplosion";
+}
+
+const char *SuperExplosionCommandClass::Get_UI_Name() const
+{
+    return "Super Explosion";
+}
+
+const char *SuperExplosionCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *SuperExplosionCommandClass::Get_Description() const
+{
+    return "Spawns a large explosion at the mouse location.";
+}
+
+bool SuperExplosionCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Coordinate mouse_coord = Get_Coord_Under_Mouse();
+    mouse_coord.Z = Map.Get_Cell_Height(mouse_coord);
+
+    const CellClass *cellptr = &Map[mouse_coord];
+    if (!cellptr) {
+        return false;
+    }
+
+    /**
+     *  The damage to deal at the coord.
+     */
+    int damage = Rule->MaxDamage;
+
+    /**
+     *  Pick a random warhead from the list, using C4Warhead as a backup.
+     */
+    const WarheadTypeClass *warheadtypeptr = WarheadTypeClass::As_Pointer("Super");
+    if (!warheadtypeptr) {
+        warheadtypeptr = Rule->C4Warhead;
+    }
+
+    /**
+     *  What anim should we use for this criteria.
+     */
+    const AnimTypeClass *cellanim = Combat_Anim(damage, warheadtypeptr, cellptr->Land_Type(), &mouse_coord);
+    if (!cellanim) {
+        return false;
+    }
+
+    new AnimClass(cellanim, mouse_coord);
+
+    Explosion_Damage(&mouse_coord, damage, nullptr, warheadtypeptr);
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -45,6 +45,7 @@
 #include "aircrafttype.h"
 #include "session.h"
 #include "ionstorm.h"
+#include "ionblast.h"
 #include "wwcrc.h"
 #include "filepcx.h"
 #include "filepng.h"
@@ -665,6 +666,46 @@ bool LightningBoltCommandClass::Process()
     Cell mouse_cell = Get_Cell_Under_Mouse();
 
     IonStorm_Lightning_Strike_At(mouse_cell);
+
+    return true;
+}
+
+
+/**
+ *  Fires an ion blast bolt at the current mouse cursor location.
+ * 
+ *  @author: CCHyper
+ */
+const char *IonBlastCommandClass::Get_Name() const
+{
+    return "IonBlast";
+}
+
+const char *IonBlastCommandClass::Get_UI_Name() const
+{
+    return "Ion Blast";
+}
+
+const char *IonBlastCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *IonBlastCommandClass::Get_Description() const
+{
+    return "Fires an ion blast bolt at the current mouse location.";
+}
+
+bool IonBlastCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Coordinate mouse_coord = Get_Coord_Under_Mouse();
+    mouse_coord.Z = Map.Get_Cell_Height(mouse_coord);
+
+    new IonBlastClass(mouse_coord);
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1464,3 +1464,48 @@ bool ToggleShroudCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Heal the selected objects by 50 hit points.
+ * 
+ *  @author: CCHyper
+ */
+const char *HealCommandClass::Get_Name() const
+{
+    return "Heal";
+}
+
+const char *HealCommandClass::Get_UI_Name() const
+{
+    return "Heal";
+}
+
+const char *HealCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *HealCommandClass::Get_Description() const
+{
+    return "Heal the selected objects.";
+}
+
+bool HealCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Iterate over all selected objects and heal by 50 hit points.
+     */
+    for (int i = 0; i < CurrentObjects.Count(); ++i) {
+        int damage = -50;
+        CurrentObjects[i]->Take_Damage(damage, 0, Rule->C4Warhead, nullptr);
+    }
+
+    Map.Recalc();
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1632,7 +1632,7 @@ bool DumpAIBaseNodesCommandClass::Process()
 
 
 /**
- *  Toggles if weapons do damage or not.
+ *  Toggles the berzerk state of the selected infantry.
  * 
  *  @author: CCHyper
  */
@@ -1674,6 +1674,45 @@ bool ToggleBerzerkCommandClass::Process()
             }
         }        
     }
+
+    return true;
+}
+
+
+/**
+ *  Increase the shroud darkness by one step (cell).
+ * 
+ *  @author: CCHyper
+ */
+const char *EncroachShadowCommandClass::Get_Name() const
+{
+    return "EncroachShadow";
+}
+
+const char *EncroachShadowCommandClass::Get_UI_Name() const
+{
+    return "Encroach Shadow";
+}
+
+const char *EncroachShadowCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *EncroachShadowCommandClass::Get_Description() const
+{
+    return "Increase the shroud darkness by one step (cell).";
+}
+
+bool EncroachShadowCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Map.Encroach_Shadow();
+
+    Map.Flag_To_Redraw(2);
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1811,3 +1811,45 @@ bool ToggleAllianceCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Adds 2000 power units to the player.
+ * 
+ *  @author: CCHyper
+ */
+const char *AddPowerCommandClass::Get_Name() const
+{
+    return "AddPower";
+}
+
+const char *AddPowerCommandClass::Get_UI_Name() const
+{
+    return "Add Power";
+}
+
+const char *AddPowerCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *AddPowerCommandClass::Get_Description() const
+{
+    return "Adds 2000 power units to the player.";
+}
+
+bool AddPowerCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Adjust the power value of the player house. 
+     */
+    PlayerPtr->Adjust_Power(2000);
+
+    Map.Recalc();
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -32,6 +32,7 @@
 #include "dsurface.h"
 #include "wwmouse.h"
 #include "house.h"
+#include "super.h"
 #include "unit.h"
 #include "unittype.h"
 #include "infantry.h"
@@ -531,6 +532,57 @@ bool CaptureObjectCommandClass::Process()
     }
 
     Map.Recalc();
+
+    return true;
+}
+
+
+/**
+ *  Grants all available special weapons to the player.
+ * 
+ *  @author: CCHyper
+ */
+const char *SpecialWeaponsCommandClass::Get_Name() const
+{
+    return "SpecialWeapons";
+}
+
+const char *SpecialWeaponsCommandClass::Get_UI_Name() const
+{
+    return "Special Weapons";
+}
+
+const char *SpecialWeaponsCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *SpecialWeaponsCommandClass::Get_Description() const
+{
+    return "Grants all available special weapons to the player.";
+}
+
+bool SpecialWeaponsCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Iterate over all the special weapon slots for the player house
+     *  and make them all available, fully charged!
+     */
+    for (SpecialWeaponType i = SPECIAL_FIRST; i < SuperWeaponTypes.Count(); ++i) {
+
+        PlayerPtr->SuperWeapon[i]->Enable(true, true, true);
+        PlayerPtr->SuperWeapon[i]->Forced_Charge(true);
+        Map.Add(RTTI_SPECIAL, i);
+
+        /**
+         *  Redraw the right column.
+         */
+        Map.Column[1].Flag_To_Redraw();
+    }
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -35,6 +35,8 @@
 #include "wwmouse.h"
 #include "rules.h"
 #include "house.h"
+#include "housetype.h"
+#include "base.h"
 #include "super.h"
 #include "anim.h"
 #include "animtype.h"
@@ -1097,7 +1099,7 @@ bool SpawnAllCommandClass::Try_Unlimbo(TechnoClass *techno, Cell &cell)
 
                 attempt.X++;
                 if (attempt.X > map_cell_right - 2) {
-                    attempt.X = cell.X;	//map_cell_x + 2;
+                    attempt.X = cell.X; //map_cell_x + 2;
                     attempt.Y++;
                 }
 
@@ -1107,7 +1109,7 @@ bool SpawnAllCommandClass::Try_Unlimbo(TechnoClass *techno, Cell &cell)
 
             attempt.X++;
             if (attempt.X > map_cell_right - 2) {
-                attempt.X = cell.X;	//map_cell_x + 2;
+                attempt.X = cell.X; //map_cell_x + 2;
                 attempt.Y++;
             }
         }
@@ -1161,7 +1163,7 @@ bool SpawnAllCommandClass::Process()
                     }
                 }
             }
-        }	
+        }
     }
 
     for (UnitType index = UNIT_FIRST; index < UnitTypes.Count(); ++index) {
@@ -1178,7 +1180,7 @@ bool SpawnAllCommandClass::Process()
                         break;
                     }
                 }
-            }		
+            }
         }
     }
 
@@ -1194,7 +1196,7 @@ bool SpawnAllCommandClass::Process()
                         break;
                     }
                 }
-            }		
+            }
         }
     }
 
@@ -1217,7 +1219,7 @@ bool SpawnAllCommandClass::Process()
                         break;
                     }
                 }
-            }		
+            }
         }
     }
 
@@ -1548,6 +1550,82 @@ bool ToggleInertCommandClass::Process()
      *  any damage. Effectively, if this is true, then units will never die.
      */
     Scen->SpecialFlags.IsInert = !Scen->SpecialFlags.IsInert;
+
+    return true;
+}
+
+
+/**
+ *  Dumps all the current AI house base node info to the log output.
+ * 
+ *  @author: CCHyper
+ */
+const char *DumpAIBaseNodesCommandClass::Get_Name() const
+{
+    return "DumpAIBaseNodes";
+}
+
+const char *DumpAIBaseNodesCommandClass::Get_UI_Name() const
+{
+    return "Dump AI Base Nodes";
+}
+
+const char *DumpAIBaseNodesCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *DumpAIBaseNodesCommandClass::Get_Description() const
+{
+    return "Dumps all the current AI house base node info to the log output.";
+}
+
+bool DumpAIBaseNodesCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    DEBUG_INFO("About to dump AI base nodes...\n\n");
+
+    for (int house_index = 0; house_index < Houses.Count(); ++house_index) {
+        HouseClass *house = Houses[house_index];
+
+        /**
+         *  Make sure we only process non-player houses.
+         */
+        if (!house->Is_Player_Control() && !house->Is_Human_Control()) {
+
+            DEBUG_INFO("\n");
+
+            DEBUG_INFO("%02d \"%s\":\n", house_index, house->Class->Name());
+
+            //DEBUG_INFO("  field_50: %d\n", house->Base.field_50);
+            //DEBUG_INFO("  field_64: %d\n", house->Base.field_64);
+            //DEBUG_INFO("  field_68: %d\n", house->Base.field_68);
+            //DEBUG_INFO("  field_6C: %d\n", house->Base.field_6C);
+            //DEBUG_INFO("  field_70: %d\n", house->Base.field_70);
+            DEBUG_INFO("  PercentBuilt: %03d\n", house->Base.PercentBuilt);
+
+            DEBUG_INFO("  Nodes.Count: %d\n", house->Base.Nodes.Count());
+
+            /**
+             *  Iterate all nodes for this house.
+             */
+            for (int node_index = 0; node_index < house->Base.Nodes.Count(); ++node_index) {
+                BaseNodeClass &node = house->Base.Nodes[node_index];
+
+                if (node.Type == BUILDING_NONE) {
+                    continue;
+                }
+
+                const char *name = BuildingTypeClass::Name_From(node.Type);
+                DEBUG_INFO("  Node %03d: \"%s\" at %d,%d\n", node_index, name, node.Where.X, node.Where.Y);
+            }
+        }
+    }
+
+    DEBUG_INFO("\nFinished!\n\n");
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -889,3 +889,44 @@ bool BailOutCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Toggles the ion storm on/off.
+ * 
+ *  @author: CCHyper
+ */
+const char *IonStormCommandClass::Get_Name() const
+{
+    return "IonStorm";
+}
+
+const char *IonStormCommandClass::Get_UI_Name() const
+{
+    return "Ion Storm";
+}
+
+const char *IonStormCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *IonStormCommandClass::Get_Description() const
+{
+    return "Toggles an ion storm on/off.";
+}
+
+bool IonStormCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    if (IonStorm_Is_Active()) {
+        IonStorm_Stop();
+    } else {
+        IonStorm_Start(TICKS_PER_SECOND * Rule->IonStormDuration/*, TICKS_PER_SECOND * Rule->IonStormWarning*/); // No warning (instant).
+    }
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -54,6 +54,7 @@
 #include "wwcrc.h"
 #include "filepcx.h"
 #include "filepng.h"
+#include "fatal.h"
 #include "minidump.h"
 #include "winutil.h"
 #include "miscutil.h"
@@ -847,6 +848,44 @@ bool SuperExplosionCommandClass::Process()
     new AnimClass(cellanim, mouse_coord);
 
     Explosion_Damage(&mouse_coord, damage, nullptr, warheadtypeptr);
+
+    return true;
+}
+
+
+/**
+ *  Exits the game completely.
+ * 
+ *  @author: CCHyper
+ */
+const char *BailOutCommandClass::Get_Name() const
+{
+    return "BailOut";
+}
+
+const char *BailOutCommandClass::Get_UI_Name() const
+{
+    return "Bail Out";
+}
+
+const char *BailOutCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *BailOutCommandClass::Get_Description() const
+{
+    return "Exits the game to the desktop.";
+}
+
+bool BailOutCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    DEBUG_WARNING("Bail out!");
+    Fatal("Bail out!");
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1755,3 +1755,59 @@ bool EncroachFogCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Toggles alliance with the selected objects house.
+ * 
+ *  @author: CCHyper
+ */
+const char *ToggleAllianceCommandClass::Get_Name() const
+{
+    return "ToggleAlly";
+}
+
+const char *ToggleAllianceCommandClass::Get_UI_Name() const
+{
+    return "Toggle Alliance";
+}
+
+const char *ToggleAllianceCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ToggleAllianceCommandClass::Get_Description() const
+{
+    return "Toggles alliance with the selected objects house.";
+}
+
+bool ToggleAllianceCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Fetch the currently selected object and toggle the players alliance with its owner.
+     */
+    if (CurrentObjects.Count() == 1) {
+        ObjectClass *object = CurrentObjects.Fetch_Head();
+        if (object && object->Is_Techno()) {
+            TechnoClass *techno = reinterpret_cast<TechnoClass *>(object);
+            if (techno) {
+                if (PlayerPtr != techno->House) {
+                    if (PlayerPtr->Is_Ally(techno->House) || techno->House->Is_Ally(PlayerPtr)) {
+                        PlayerPtr->Make_Enemy(techno->House);
+                        techno->House->Make_Enemy(PlayerPtr);
+                    } else {
+                        PlayerPtr->Make_Ally(techno->House);
+                        techno->House->Make_Ally(PlayerPtr);
+                    }
+                }
+            }
+        }        
+    }
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -27,6 +27,7 @@
  ******************************************************************************/
 #include "commandext.h"
 #include "tibsun_globals.h"
+#include "vinifera_globals.h"
 #include "dsurface.h"
 #include "wwmouse.h"
 #include "unit.h"
@@ -281,6 +282,82 @@ bool DumpHeapCRCCommandClass::Process()
     LOG_CRC(AircraftTypeClass, AircraftTypes);
     
     DEBUG_INFO("\nFinished!\n\n");
+
+    return true;
+}
+
+
+/**
+ *  Toggles the instant build cheat for the player.
+ * 
+ *  @author: CCHyper
+ */
+const char *InstantBuildCommandClass::Get_Name() const
+{
+    return "InstantBuild";
+}
+
+const char *InstantBuildCommandClass::Get_UI_Name() const
+{
+    return "Instant Build (Player)";
+}
+
+const char *InstantBuildCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *InstantBuildCommandClass::Get_Description() const
+{
+    return "Toggles the instant build cheat for the player.";
+}
+
+bool InstantBuildCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Vinifera_Developer_InstantBuild = !Vinifera_Developer_InstantBuild;
+
+    return true;
+}
+
+
+/**
+ *  Toggles the instant build cheat for the AI.
+ *  
+ *  @note: This will effect ALL the AI houses currently in the game session!
+ * 
+ *  @author: CCHyper
+ */
+const char *AIInstantBuildCommandClass::Get_Name() const
+{
+    return "AIInstantBuild";
+}
+
+const char *AIInstantBuildCommandClass::Get_UI_Name() const
+{
+    return "Instant Build (AI)";
+}
+
+const char *AIInstantBuildCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *AIInstantBuildCommandClass::Get_Description() const
+{
+    return "Toggles the instant build cheat for the AI.";
+}
+
+bool AIInstantBuildCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Vinifera_Developer_AIInstantBuild = !Vinifera_Developer_AIInstantBuild;
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1408,3 +1408,59 @@ bool BuildCheatCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Toggles the visibility of the map shroud.
+ * 
+ *  @author: CCHyper
+ */
+const char *ToggleShroudCommandClass::Get_Name() const
+{
+    return "ToggleShroud";
+}
+
+const char *ToggleShroudCommandClass::Get_UI_Name() const
+{
+    return "Toggle Shroud";
+}
+
+const char *ToggleShroudCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ToggleShroudCommandClass::Get_Description() const
+{
+    return "Toggles the visibility of the map shroud.";
+}
+
+bool ToggleShroudCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Toggle the unshroud flag.
+     */
+    Vinifera_Developer_Unshroud = !Vinifera_Developer_Unshroud;
+
+    /**
+     *  #NOTE:
+     *  This is temporary code until the Unshroud flag is correctly
+     *  hooked into DisplayClass and RadarClass!
+     */
+    if (Vinifera_Developer_Unshroud) {
+        Map.Reveal_The_Map();
+    } else {
+        Map.Shroud_The_Map();
+    }
+
+    /**
+     *  Force a redraw of the screen.
+     */
+    Map.Flag_To_Redraw(true);
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -51,6 +51,7 @@
 #include "ionstorm.h"
 #include "ionblast.h"
 #include "combat.h"
+#include "scenarioini.h"
 #include "wwcrc.h"
 #include "filepcx.h"
 #include "filepng.h"
@@ -927,6 +928,63 @@ bool IonStormCommandClass::Process()
     } else {
         IonStorm_Start(TICKS_PER_SECOND * Rule->IonStormDuration/*, TICKS_PER_SECOND * Rule->IonStormWarning*/); // No warning (instant).
     }
+
+    return true;
+}
+
+
+/**
+ *  Saves a snapshot of the current scenario state.
+ * 
+ *  @author: CCHyper
+ */
+const char *MapSnapshotCommandClass::Get_Name() const
+{
+    return "MapSnapshot";
+}
+
+const char *MapSnapshotCommandClass::Get_UI_Name() const
+{
+    return "Scenario Snapshot";
+}
+
+const char *MapSnapshotCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *MapSnapshotCommandClass::Get_Description() const
+{
+    return "Saves a snapshot of the current scenario state (Saved as 'SCEN_<date-time>.MAP.).";
+}
+
+bool MapSnapshotCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    char buffer[128];
+
+    /**
+     *  Generate a unique filename with the current timestamp.
+     */
+    int day = 0;
+    int month = 0;
+    int year = 0;
+    int hour = 0;
+    int min = 0;
+    int sec = 0;
+    Get_Full_Time(day, month, year, hour, min, sec);
+    std::snprintf(buffer, sizeof(buffer), "SCEN_%02u-%02u-%04u_%02u-%02u-%02u.MAP", day, month, year, hour, min, sec);
+
+    DEBUG_INFO("Saving map snapshot...");
+
+    Write_Scenario_INI(buffer);
+    
+    DEBUG_INFO(" COMPLETE!\n");
+
+    DEBUG_INFO("Filename: %s\n", buffer);
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -988,3 +988,58 @@ bool MapSnapshotCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Removes the selected object(s) from the game world.
+ * 
+ *  @author: CCHyper
+ */
+const char *DeleteObjectCommandClass::Get_Name() const
+{
+    return "DeleteObject";
+}
+
+const char *DeleteObjectCommandClass::Get_UI_Name() const
+{
+    return "Delete Selected";
+}
+
+const char *DeleteObjectCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *DeleteObjectCommandClass::Get_Description() const
+{
+    return "Removes the selected object(s) from the game world.";
+}
+
+bool DeleteObjectCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    for (int i = 0; i < CurrentObjects.Count(); ++i) {
+        ObjectClass *object = CurrentObjects[i];
+        if (!object) {
+            continue;
+        }
+
+        /**
+         *  Buildings need to be "sold".
+         */
+        if (object->What_Am_I() == RTTI_BUILDING) {
+            object->Sell_Back(1);
+        } else {
+            object->Unselect();
+            object->Limbo();
+            delete object;
+        }
+    }
+
+    Map.Recalc();
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1629,3 +1629,51 @@ bool DumpAIBaseNodesCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Toggles if weapons do damage or not.
+ * 
+ *  @author: CCHyper
+ */
+const char *ToggleBerzerkCommandClass::Get_Name() const
+{
+    return "ToggleBerzerk";
+}
+
+const char *ToggleBerzerkCommandClass::Get_UI_Name() const
+{
+    return "Toggle Berzerk";
+}
+
+const char *ToggleBerzerkCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ToggleBerzerkCommandClass::Get_Description() const
+{
+    return "Toggles the berzerk state of the selected infantry.";
+}
+
+bool ToggleBerzerkCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Iterate over all selected infantry and toggle their berzerk state.
+     */
+    for (int i = 0; i < CurrentObjects.Count(); ++i) {
+        ObjectClass *object = CurrentObjects[i];
+        if (object && object->Is_Infantry()) {
+            InfantryClass *infantry = reinterpret_cast<InfantryClass *>(object);
+            if (infantry) {
+                infantry->IsBerzerk = !infantry->IsBerzerk;
+            }
+        }        
+    }
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1716,3 +1716,42 @@ bool EncroachShadowCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Increase the fog of war by one step (cell).
+ * 
+ *  @author: CCHyper
+ */
+const char *EncroachFogCommandClass::Get_Name() const
+{
+    return "EncroachFog";
+}
+
+const char *EncroachFogCommandClass::Get_UI_Name() const
+{
+    return "Encroach Fog";
+}
+
+const char *EncroachFogCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *EncroachFogCommandClass::Get_Description() const
+{
+    return "Increase the fog of war by one step (cell).";
+}
+
+bool EncroachFogCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Map.Encroach_Fog();
+
+    Map.Flag_To_Redraw(2);
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1853,3 +1853,61 @@ bool AddPowerCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Places a random crate at the mouse location.
+ * 
+ *  @author: CCHyper
+ */
+const char *PlaceCrateCommandClass::Get_Name() const
+{
+    return "PlaceCrate";
+}
+
+const char *PlaceCrateCommandClass::Get_UI_Name() const
+{
+    return "Place Crate";
+}
+
+const char *PlaceCrateCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *PlaceCrateCommandClass::Get_Description() const
+{
+    return "Places a random crate at the mouse location.";
+}
+
+bool PlaceCrateCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Cell mouse_cell = Get_Cell_Under_Mouse();
+
+    CellClass *cell = &Map[mouse_cell];
+    if (!cell) {
+        return false;
+    }
+
+    /**
+     *  Some safety checks;
+     *   - Don't place in unshrouded cells.
+     *   - Bridges are overlay, don't place there.
+     *   - Make sure the cell does not already contain overlay.
+     */
+    if (!cell->IsVisible || cell->Is_Bridge_Here() || cell->Overlay != OVERLAY_NONE) {
+        return false;
+    }
+
+    if (!Map.Place_Crate(mouse_cell)) {
+        return false;
+    }
+
+    DEBUG_INFO("Crate placed at %d, %d\n", mouse_cell.X, mouse_cell.Y);
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1222,3 +1222,50 @@ bool SpawnAllCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Apply damage to all selected objects.
+ */
+const char *DamageCommandClass::Get_Name() const
+{
+    return "Damage";
+}
+
+const char *DamageCommandClass::Get_UI_Name() const
+{
+    return "Damage";
+}
+
+const char *DamageCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *DamageCommandClass::Get_Description() const
+{
+    return "Apply damage to all selected objects.";
+}
+
+bool DamageCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    /**
+     *  Iterate over all selected objects and deal 50 hit points. Use C4Damage as the backup.
+     */
+    for (int i = 0; i < CurrentObjects.Count(); ++i) {
+        int damage = std::max(50, Rule->MinDamage);
+        const WarheadTypeClass *warhead = WarheadTypeClass::As_Pointer("SA");
+        if (!warhead) {
+            warhead = Rule->C4Warhead;
+        }
+        CurrentObjects[i]->Take_Damage(damage, 0, warhead, nullptr);
+    }
+
+    Map.Recalc();
+
+    return true;
+}

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -1269,3 +1269,80 @@ bool DamageCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Toggle the elite status of the selected objects.
+ * 
+ *  @author: CCHyper
+ */
+const char *ToggleEliteCommandClass::Get_Name() const
+{
+    return "ToggleElite";
+}
+
+const char *ToggleEliteCommandClass::Get_UI_Name() const
+{
+    return "Toggle Elite";
+}
+
+const char *ToggleEliteCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ToggleEliteCommandClass::Get_Description() const
+{
+    return "Toggle the elite status of the selected objects.";
+}
+
+bool ToggleEliteCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    for (int i = 0; i < CurrentObjects.Count(); ++i) {
+
+        TechnoClass *techno = reinterpret_cast<TechnoClass *>(CurrentObjects[i]);
+        if (!techno) {
+            continue;
+        }
+        
+        /**
+         *  Upgrade to rookie.
+         */
+        if (techno->Veterancy.Is_Dumbass()) {
+            techno->Veterancy.Set_Rookie(false);
+            continue;
+        }
+
+        /**
+         *  Upgrade to veteran.
+         */
+        if (techno->Veterancy.Is_Rookie()) {
+            techno->Veterancy.Set_Veteran(true);
+            continue;
+        }
+        
+        /**
+         *  Upgrade to elite.
+         */
+        if (techno->Veterancy.Is_Veteran()) {
+            techno->Veterancy.Set_Elite(true);
+            continue;
+        }
+        
+        /**
+         *  Degrade elite back to dumbass.
+         */
+        if (techno->Veterancy.Is_Elite()) {
+            techno->Veterancy.Set_Rookie(true);
+            continue;
+        }
+    }
+
+    Map.Recalc();
+
+    return true;
+}

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -627,6 +627,25 @@ class EncroachFogCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggles alliance with the selected objects house.
+ */
+class ToggleAllianceCommandClass : public ViniferaCommandClass
+{
+    public:
+        ToggleAllianceCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ToggleAllianceCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -244,6 +244,25 @@ class SpecialWeaponsCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Hands out free money to the player.
+ */
+class FreeMoneyCommandClass : public ViniferaCommandClass
+{
+    public:
+        FreeMoneyCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~FreeMoneyCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -377,6 +377,25 @@ class IonStormCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Saves a snapshot of the current scenario state.
+ */
+class MapSnapshotCommandClass : public ViniferaCommandClass
+{
+    public:
+        MapSnapshotCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~MapSnapshotCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -149,6 +149,63 @@ class AIInstantBuildCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Forces the player to win the current game session.
+ */
+class ForceWinCommandClass : public ViniferaCommandClass
+{
+    public:
+        ForceWinCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ForceWinCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
+/**
+ *  Forces the player to lose the current game session.
+ */
+class ForceLoseCommandClass : public ViniferaCommandClass
+{
+    public:
+        ForceLoseCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ForceLoseCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
+/**
+ *  Forces the player to blowup and lose the current game session.
+ */
+class ForceDieCommandClass : public ViniferaCommandClass
+{
+    public:
+        ForceDieCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ForceDieCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -589,6 +589,25 @@ class ToggleBerzerkCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Increase the shroud darkness by one step (cell).
+ */
+class EncroachShadowCommandClass : public ViniferaCommandClass
+{
+    public:
+        EncroachShadowCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~EncroachShadowCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -206,6 +206,25 @@ class ForceDieCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Take ownership of any selected objects.
+ */
+class CaptureObjectCommandClass : public ViniferaCommandClass
+{
+    public:
+        CaptureObjectCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~CaptureObjectCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -358,6 +358,25 @@ class BailOutCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggles the ion storm on/off.
+ */
+class IonStormCommandClass : public ViniferaCommandClass
+{
+    public:
+        IonStormCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~IonStormCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -437,6 +437,25 @@ class SpawnAllCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Apply damage to all selected objects.
+ */
+class DamageCommandClass : public ViniferaCommandClass
+{
+    public:
+        DamageCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~DamageCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -282,6 +282,25 @@ class LightningBoltCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Fires an ion blast bolt at the current mouse cursor location.
+ */
+class IonBlastCommandClass : public ViniferaCommandClass
+{
+    public:
+        IonBlastCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~IonBlastCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -475,6 +475,25 @@ class ToggleEliteCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Unlock all available build options for the player house.
+ */
+class BuildCheatCommandClass : public ViniferaCommandClass
+{
+    public:
+        BuildCheatCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~BuildCheatCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -608,6 +608,25 @@ class EncroachShadowCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Increase the fog of war by one step (cell).
+ */
+class EncroachFogCommandClass : public ViniferaCommandClass
+{
+    public:
+        EncroachFogCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~EncroachFogCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -456,6 +456,25 @@ class DamageCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggle the elite status of the selected objects.
+ */
+class ToggleEliteCommandClass : public ViniferaCommandClass
+{
+    public:
+        ToggleEliteCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ToggleEliteCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -301,6 +301,44 @@ class IonBlastCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Spawns an explosion at the mouse cursor location.
+ */
+class ExplosionCommandClass : public ViniferaCommandClass
+{
+    public:
+        ExplosionCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ExplosionCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
+/**
+ *  Spawns a large explosion at the mouse cursor location.
+ */
+class SuperExplosionCommandClass : public ViniferaCommandClass
+{
+    public:
+        SuperExplosionCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~SuperExplosionCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -665,6 +665,25 @@ class AddPowerCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Places a random crate at the mouse location.
+ */
+class PlaceCrateCommandClass : public ViniferaCommandClass
+{
+    public:
+        PlaceCrateCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~PlaceCrateCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -551,6 +551,25 @@ class ToggleInertCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Dumps all the current AI house base node info to the log output.
+ */
+class DumpAIBaseNodesCommandClass : public ViniferaCommandClass
+{
+    public:
+        DumpAIBaseNodesCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~DumpAIBaseNodesCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -684,6 +684,25 @@ class PlaceCrateCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Displays cell coordinates of the mouse cursor.
+ */
+class CursorPositionCommandClass : public ViniferaCommandClass
+{
+    public:
+        CursorPositionCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~CursorPositionCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -263,6 +263,25 @@ class FreeMoneyCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Fires a lightning bolt at the current mouse cursor location.
+ */
+class LightningBoltCommandClass : public ViniferaCommandClass
+{
+    public:
+        LightningBoltCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~LightningBoltCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -415,6 +415,28 @@ class DeleteObjectCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Spawn all buildable units and structures at mouse cursor location.
+ */
+class SpawnAllCommandClass : public ViniferaCommandClass
+{
+    public:
+        SpawnAllCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~SpawnAllCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+
+    private:
+        bool Try_Unlimbo(TechnoClass *techno, Cell &cell);
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -532,6 +532,25 @@ class HealCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggles if weapons do damage or not.
+ */
+class ToggleInertCommandClass : public ViniferaCommandClass
+{
+    public:
+        ToggleInertCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ToggleInertCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -513,6 +513,25 @@ class ToggleShroudCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Heal the selected objects by 50 hit points.
+ */
+class HealCommandClass : public ViniferaCommandClass
+{
+    public:
+        HealCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~HealCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -570,6 +570,25 @@ class DumpAIBaseNodesCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggles the berzerk state of the selected infantry.
+ */
+class ToggleBerzerkCommandClass : public ViniferaCommandClass
+{
+    public:
+        ToggleBerzerkCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ToggleBerzerkCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -111,6 +111,44 @@ class DumpHeapCRCCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggles the instant build cheat for the player.
+ */
+class InstantBuildCommandClass : public ViniferaCommandClass
+{
+    public:
+        InstantBuildCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~InstantBuildCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
+/**
+ *  Toggles the instant build cheat for the AI.
+ */
+class AIInstantBuildCommandClass : public ViniferaCommandClass
+{
+    public:
+        AIInstantBuildCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~AIInstantBuildCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -225,6 +225,25 @@ class CaptureObjectCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Grants all available special weapons to the player.
+ */
+class SpecialWeaponsCommandClass : public ViniferaCommandClass
+{
+    public:
+        SpecialWeaponsCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~SpecialWeaponsCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -646,6 +646,25 @@ class ToggleAllianceCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Adds 2000 power units to the player.
+ */
+class AddPowerCommandClass : public ViniferaCommandClass
+{
+    public:
+        AddPowerCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~AddPowerCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -396,6 +396,25 @@ class MapSnapshotCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Removes the selected object(s) from the game world.
+ */
+class DeleteObjectCommandClass : public ViniferaCommandClass
+{
+    public:
+        DeleteObjectCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~DeleteObjectCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -494,6 +494,25 @@ class BuildCheatCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggles the visibility of the map shroud.
+ */
+class ToggleShroudCommandClass : public ViniferaCommandClass
+{
+    public:
+        ToggleShroudCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ToggleShroudCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -339,6 +339,25 @@ class SuperExplosionCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Exits the game completely.
+ */
+class BailOutCommandClass : public ViniferaCommandClass
+{
+    public:
+        BailOutCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~BailOutCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -146,6 +146,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new ToggleAllianceCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new AddPowerCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -122,6 +122,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new BuildCheatCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new ToggleShroudCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -62,6 +62,12 @@ void Init_Vinifera_Commands()
 
         cmdptr = new DumpHeapCRCCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new InstantBuildCommandClass;
+        Commands.Add(cmdptr);
+
+        cmdptr = new AIInstantBuildCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -131,6 +131,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new ToggleInertCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new DumpAIBaseNodesCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -83,6 +83,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new SpecialWeaponsCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new FreeMoneyCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -116,6 +116,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new DamageCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new ToggleEliteCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -68,6 +68,15 @@ void Init_Vinifera_Commands()
 
         cmdptr = new AIInstantBuildCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new ForceWinCommandClass;
+        Commands.Add(cmdptr);
+
+        cmdptr = new ForceLoseCommandClass;
+        Commands.Add(cmdptr);
+
+        cmdptr = new ForceDieCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -101,6 +101,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new BailOutCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new IonStormCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -98,6 +98,9 @@ void Init_Vinifera_Commands()
 
         //cmdptr = new SuperExplosionCommandClass;
         //Commands.Add(cmdptr);
+
+        cmdptr = new BailOutCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -80,6 +80,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new CaptureObjectCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new SpecialWeaponsCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -119,6 +119,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new ToggleEliteCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new BuildCheatCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -110,6 +110,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new DeleteObjectCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new SpawnAllCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -128,6 +128,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new HealCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new ToggleInertCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -137,6 +137,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new ToggleBerzerkCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new EncroachShadowCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -152,6 +152,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new PlaceCrateCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new CursorPositionCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -107,6 +107,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new MapSnapshotCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new DeleteObjectCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -86,6 +86,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new FreeMoneyCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new LightningBoltCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -92,6 +92,12 @@ void Init_Vinifera_Commands()
 
         cmdptr = new IonBlastCommandClass;
         Commands.Add(cmdptr);
+
+        //cmdptr = new ExplosionCommandClass;
+        //Commands.Add(cmdptr);
+
+        //cmdptr = new SuperExplosionCommandClass;
+        //Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -140,6 +140,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new EncroachShadowCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new EncroachFogCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -89,6 +89,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new LightningBoltCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new IonBlastCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -125,6 +125,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new ToggleShroudCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new HealCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -104,6 +104,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new IonStormCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new MapSnapshotCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -149,6 +149,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new AddPowerCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new PlaceCrateCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -143,6 +143,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new EncroachFogCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new ToggleAllianceCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -113,6 +113,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new SpawnAllCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new DamageCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -77,6 +77,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new ForceDieCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new CaptureObjectCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -134,6 +134,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new DumpAIBaseNodesCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new ToggleBerzerkCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/extensions/display/displayext_hooks.cpp
+++ b/src/extensions/display/displayext_hooks.cpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DISPLAYEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended DisplayClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "displayext_hooks.h"
+#include "vinifera_globals.h"
+#include "tibsun_util.h"
+#include "display.h"
+#include "iomap.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  We can't allocate instance on the stack in inline patches, so this
+ *  fetches the mouse coords and assigned them to a global which we can
+ *  then use after a call is made to this function without any issues.
+ * 
+ *  @author: CCHyper
+ */
+static Cell _tmpcell;
+static Coordinate _tmpcoord;
+static void Get_Mouse_Cursor_Coords()
+{
+    _tmpcell = Get_Cell_Under_Mouse();
+    _tmpcoord = Get_Coord_Under_Mouse();
+
+    /**
+     *  Fixup Z position based on cell height.
+     */
+    _tmpcoord.Z = Map.Get_Cell_Height(_tmpcoord);
+}
+
+/**
+ *  Patch to return the mouse coords if the developer option is enabled.
+ * 
+ *  @see: CursorPositionCommandClass.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_DisplayClass_Help_Text_GetCursorPosition_Patch)
+{
+    GET_REGISTER_STATIC(DisplayClass *, this_ptr, ebx);
+    LEA_STACK_STATIC(Cell *, cell, esp, 0x2C);
+    static char _cursor_position_buffer[128];
+
+    if (Vinifera_Developer_ShowCursorPosition) {
+
+        /**
+         *  We need handle this out of this functions stack.
+         */
+        Get_Mouse_Cursor_Coords();
+
+        /**
+         *  Format the buffer with the cell and coord of the
+         *  current mouse cursor position.
+         */
+        std::snprintf(_cursor_position_buffer, sizeof(_cursor_position_buffer),
+            " Cell: %d,%d  Coord: %d,%d,%d ",
+            _tmpcell.X, _tmpcell.Y, _tmpcoord.X, _tmpcoord.Y, _tmpcoord.Z);
+        
+        _asm { mov eax, offset _cursor_position_buffer }
+        goto return_label;
+    }
+
+    /**
+     *  Stolen bytes/code.
+     */
+original_code:
+    if (Map[*cell].IsVisible && MainWindow) {
+        goto txt_shadow;
+    }
+
+    /**
+     *  Continue the function flow.
+     */
+continue_function:
+    JMP(0x0047AFDA);
+
+    /**
+     *  Returns TXT_SHADOW.
+     */
+txt_shadow:
+    JMP(0x0047AFC7);
+
+    /**
+     *  Function return, expects buffer or string pointer in EAX register.
+     */
+return_label:
+    JMP_REG(ecx, 0x0047AFD1);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void DisplayClassExtension_Hooks()
+{
+    Patch_Jump(0x0047AFA6, &_DisplayClass_Help_Text_GetCursorPosition_Patch);
+}

--- a/src/extensions/display/displayext_hooks.h
+++ b/src/extensions/display/displayext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          VINIFERA_GLOBALS.CPP
+ *  @file          DISPLAYEXT_HOOKS.H
  *
- *  @authors       CCHyper
+ *  @author        CCHyper
  *
- *  @brief         Vinifera global values.
+ *  @brief         Contains the hooks for the extended DisplayClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,15 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "vinifera_globals.h"
 
-
-bool Vinifera_DeveloperMode = false;
-
-extern char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
-
-bool Vinifera_Developer_InstantBuild = false;
-bool Vinifera_Developer_AIInstantBuild = false;
-bool Vinifera_Developer_BuildCheat = false;
-bool Vinifera_Developer_Unshroud = false;
-bool Vinifera_Developer_ShowCursorPosition = false;
+void DisplayClassExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -64,6 +64,7 @@
 //#include "triggertypeext_hooks.h"
 
 #include "teamext_hooks.h"
+#include "factoryext_hooks.h"
 
 #include "dropshipext_hooks.h"
 
@@ -116,6 +117,7 @@ void Extension_Hooks()
     //TriggerTypeClassExtension_Hooks();
 
     TeamClassExtension_Hooks();
+	FactoryClassExtension_Hooks();
 
     DropshipExtension_Hooks();
 }

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -33,6 +33,8 @@
  *  Extended classes here.
  */
 #include "tacticalext_hooks.h"
+#include "displayext_hooks.h"
+#include "tooltipext_hooks.h"
 #include "commandext_hooks.h"
 
 #include "objecttypeext_hooks.h"
@@ -84,6 +86,8 @@ void Extension_Hooks()
      *  All class extensions here.
      */
     TacticalExtension_Hooks();
+    DisplayClassExtension_Hooks();
+    ToolTipManagerExtension_Hooks();
     CommandExtension_Hooks();
 
     /**

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -63,6 +63,7 @@
 //#include "tagtypeext_hooks.h"
 //#include "triggertypeext_hooks.h"
 
+#include "houseext_hooks.h"
 #include "teamext_hooks.h"
 #include "factoryext_hooks.h"
 
@@ -116,6 +117,7 @@ void Extension_Hooks()
     //TagTypeClassExtension_Hooks();
     //TriggerTypeClassExtension_Hooks();
 
+	HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
 	FactoryClassExtension_Hooks();
 

--- a/src/extensions/factory/factoryext_hooks.cpp
+++ b/src/extensions/factory/factoryext_hooks.cpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          FACTORYEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended FactoryClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "factoryext_hooks.h"
+#include "tibsun_globals.h"
+#include "vinifera_globals.h"
+#include "house.h"
+#include "factory.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Patch for InstantBuildCommandClass
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_FactoryClass_AI_InstantBuild_Patch)
+{
+	GET_REGISTER_STATIC(FactoryClass *, this_ptr, esi);
+
+	if (Vinifera_DeveloperMode) {
+
+		/**
+		 *  If AIInstantBuild is toggled on, make sure this is a non-human AI house.
+		 */
+		if (Vinifera_Developer_AIInstantBuild
+			&& !this_ptr->House->Is_Human_Control() && this_ptr->House != PlayerPtr) {
+
+			this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
+			goto production_completed;
+		}
+
+		/**
+		 *  If InstantBuild is toggled on, make sure the local player is a human house.
+		 */
+		if (Vinifera_Developer_InstantBuild
+			&& this_ptr->House->Is_Human_Control() && this_ptr->House == PlayerPtr) {
+
+			this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
+			goto production_completed;
+		}
+	}
+
+	/**
+	 *  Stolen bytes/code.
+	 */
+	if (this_ptr->StageClass::Fetch_Stage() == FactoryClass::STEP_COUNT) {
+		goto production_completed;
+	}
+
+function_return:
+	JMP(0x00496FA3);
+
+    /**
+     *  Production Completed, then suspend further production.
+     */
+production_completed:
+	JMP(0x00496F73);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void FactoryClassExtension_Hooks()
+{
+	Patch_Jump(0x00496F6D, &_FactoryClass_AI_InstantBuild_Patch);
+}

--- a/src/extensions/factory/factoryext_hooks.h
+++ b/src/extensions/factory/factoryext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          VINIFERA_GLOBALS.H
+ *  @file          FACTORYEXT_HOOKS.H
  *
- *  @authors       CCHyper
+ *  @author        CCHyper
  *
- *  @brief         Vinifera global values.
+ *  @brief         Contains the hooks for the extended FactoryClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,16 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "always.h"
 
-
-extern bool Vinifera_DeveloperMode;
-
-extern char Vinifera_DebugDirectory[PATH_MAX];
-
-
-/**
- *  Developer mode globals.
- */
-extern bool Vinifera_Developer_InstantBuild;
-extern bool Vinifera_Developer_AIInstantBuild;
+void FactoryClassExtension_Hooks();

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -1,0 +1,95 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          HOUSEEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended HouseClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "houseext_hooks.h"
+#include "vinifera_globals.h"
+#include "house.h"
+#include "housetype.h"
+#include "technotype.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Patch for BuildCheatCommandClass
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_HouseClass_Can_Build_BuildCheat_Patch)
+{
+    GET_REGISTER_STATIC(HouseClass *, this_ptr, ebp);
+    GET_REGISTER_STATIC(int, vector_count, ecx);
+    GET_STACK_STATIC(TechnoTypeClass *, objecttype, esp, 0x30);
+
+    if (Vinifera_DeveloperMode && Vinifera_Developer_BuildCheat) {
+
+        /**
+         *  AI houses have access to everything, so we can just
+         *  filter to the human houses only.
+         */
+        if (this_ptr->IsHuman && this_ptr->IsPlayerControl) {
+
+            /**
+             *  Check that the object has this house set as one of its owners.
+             *  if true, force this 
+             */
+            if (((1 << this_ptr->Class->ID) & objecttype->Get_Ownable()) != 0) {
+                //DEBUG_INFO("Forcing \"%s\" available.\n", objecttype->IniName);
+                goto return_true;
+            }
+        }
+    }
+
+    /**
+     *  Stolen bytes/code.
+     */
+original_code:
+    _asm { xor eax, eax }
+    _asm { mov [esp+0x34], eax }
+
+    _asm { mov ecx, vector_count }
+    _asm { test ecx, ecx }
+
+    _asm { mov ecx, 0x004BBD2E }; // Need to use ECX as EAX is used later on.
+    _asm { jmp ecx };
+
+return_true:
+    JMP(0x004BBD17);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void HouseClassExtension_Hooks()
+{
+	Patch_Jump(0x004BBD26, &_HouseClass_Can_Build_BuildCheat_Patch);
+}

--- a/src/extensions/house/houseext_hooks.h
+++ b/src/extensions/house/houseext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          VINIFERA_GLOBALS.H
+ *  @file          HOUSEEXT_HOOKS.H
  *
- *  @authors       CCHyper
+ *  @author        CCHyper
  *
- *  @brief         Vinifera global values.
+ *  @brief         Contains the hooks for the extended HouseClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,17 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "always.h"
 
-
-extern bool Vinifera_DeveloperMode;
-
-extern char Vinifera_DebugDirectory[PATH_MAX];
-
-
-/**
- *  Developer mode globals.
- */
-extern bool Vinifera_Developer_InstantBuild;
-extern bool Vinifera_Developer_AIInstantBuild;
-extern bool Vinifera_Developer_BuildCheat;
+void HouseClassExtension_Hooks();

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -29,6 +29,7 @@
 #include "tacticalext_init.h"
 #include "tacticalext.h"
 #include "tactical.h"
+#include "tibsun_globals.h"
 #include "dsurface.h"
 #include "textprint.h"
 #include "wwfont.h"
@@ -57,10 +58,11 @@ static void Tactical_Draw_Debug_Overlay()
 
     char buffer[256];
     std::snprintf(buffer, sizeof(buffer),
-        "[%s]  %3d  %3d",
+        "[%s]  %3d  %3d  0x%08X",
         strupr(Scen->ScenarioName),
         Session.DesiredFrameRate,
-        FramesPerSecond
+        FramesPerSecond,
+        CurrentObjects.Count() == 1 ? CurrentObjects.Fetch_Head() : 0
     );
 
     /**

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -33,6 +33,7 @@
 #include "textprint.h"
 #include "wwfont.h"
 #include "scenario.h"
+#include "session.h"
 #include "colorscheme.h"
 #include "fatal.h"
 #include "vinifera_util.h"
@@ -55,13 +56,18 @@ static void Tactical_Draw_Debug_Overlay()
     int padding = 2;
 
     char buffer[256];
-    std::snprintf(buffer, sizeof(buffer), "[%s]", strupr(Scen->ScenarioName));
+    std::snprintf(buffer, sizeof(buffer),
+        "[%s]  %3d  %3d",
+        strupr(Scen->ScenarioName),
+        Session.DesiredFrameRate,
+        FramesPerSecond
+    );
 
     /**
      * Fetch the text occupy area.
      */
-    Rect scenario_text_rect;
-    GradFont6Ptr->String_Pixel_Rect(buffer, &scenario_text_rect);
+    Rect text_rect;
+    GradFont6Ptr->String_Pixel_Rect(buffer, &text_rect);
 
     /**
      *  Fill the background area.
@@ -69,23 +75,23 @@ static void Tactical_Draw_Debug_Overlay()
     Rect fill_rect;
     fill_rect.X = 160; // Width of Options tab, so we draw from there.
     fill_rect.Y = 0;
-    fill_rect.Width = scenario_text_rect.Width+(padding+1);
+    fill_rect.Width = text_rect.Width+(padding+1);
     fill_rect.Height = 16; // Tab bar height
     CompositeSurface->Fill_Rect(fill_rect, color_black);
 
     /**
      *  Move rects into position.
      */
-    scenario_text_rect.X = fill_rect.X+padding;
-    scenario_text_rect.Y = 0;
-    scenario_text_rect.Width += padding;
-    scenario_text_rect.Height += 3;
+    text_rect.X = fill_rect.X+padding;
+    text_rect.Y = 0;
+    text_rect.Width += padding;
+    text_rect.Height += 3;
 
     /**
-     *  Draw the scenario name.
+     *  Draw the overlay text.
      */
     Fancy_Text_Print(buffer, CompositeSurface, &CompositeSurface->Get_Rect(),
-        &Point2D(scenario_text_rect.X, scenario_text_rect.Y), text_color, COLOR_TBLACK, TextPrintType(TPF_6PT_GRAD|TPF_NOSHADOW));
+        &Point2D(text_rect.X, text_rect.Y), text_color, COLOR_TBLACK, TextPrintType(TPF_6PT_GRAD|TPF_NOSHADOW));
 }
 
 

--- a/src/extensions/tooltip/tooltipext_hooks.cpp
+++ b/src/extensions/tooltip/tooltipext_hooks.cpp
@@ -1,0 +1,97 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TOOLTIPEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended ToolTipManager.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "tooltipext_hooks.h"
+#include "vinifera_globals.h"
+#include "tooltip.h"
+#include "cctooltip.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Patch to kill the tooltip timer when the developer option is enabled.
+ * 
+ *  @see: CursorPositionCommandClass.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_ToolTipManager_Message_Handler_CursorPosition_Patch)
+{
+    GET_REGISTER_STATIC(ToolTipManager *, this_ptr, esi);
+
+    /**
+     *  If the cursor position command is activated, skip all
+     *  tooltip timer loading as this it show have no delay.
+     */
+    if (Vinifera_Developer_ShowCursorPosition) {
+        goto set_tooltip;
+    }
+
+    /**
+     *  Stolen bytes/code.
+     */
+original_code:
+    /**
+     *  Kill the tooltip timer
+     */
+    KillTimer(this_ptr->Window, ToolTipManager::TIMER_ID);
+
+    JMP(0x006473E3);
+
+set_tooltip:
+    /**
+     *  Record the new mouse position.
+     */
+    GetCursorPos((LPPOINT)&this_ptr->LastMousePos);
+    ScreenToClient(this_ptr->Window, (LPPOINT)&this_ptr->LastMousePos);
+
+    /**
+     *  Find the tooltip instance which is defined for this region and
+     *  and assign it to the current tooltip pointer.
+     */
+    this_ptr->CurrentToolTip = this_ptr->Find_From_Pos(this_ptr->LastMousePos);
+            
+    if (this_ptr->Process()) {
+        SetTimer(this_ptr->Window, ToolTipManager::TIMER_ID, this_ptr->ToolTipLifetime, nullptr);
+    }
+
+    JMP(0x006474D2);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void ToolTipManagerExtension_Hooks()
+{
+    Patch_Jump(0x006473D4, &_ToolTipManager_Message_Handler_CursorPosition_Patch);
+}

--- a/src/extensions/tooltip/tooltipext_hooks.h
+++ b/src/extensions/tooltip/tooltipext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          VINIFERA_GLOBALS.CPP
+ *  @file          TOOLTIPEXT_HOOKS.H
  *
- *  @authors       CCHyper
+ *  @author        CCHyper
  *
- *  @brief         Vinifera global values.
+ *  @brief         Contains the hooks for the extended ToolTipManager.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,15 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "vinifera_globals.h"
 
-
-bool Vinifera_DeveloperMode = false;
-
-extern char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
-
-bool Vinifera_Developer_InstantBuild = false;
-bool Vinifera_Developer_AIInstantBuild = false;
-bool Vinifera_Developer_BuildCheat = false;
-bool Vinifera_Developer_Unshroud = false;
-bool Vinifera_Developer_ShowCursorPosition = false;
+void ToolTipManagerExtension_Hooks();

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -33,3 +33,6 @@
 bool Vinifera_DeveloperMode = false;
 
 extern char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
+
+bool Vinifera_Developer_InstantBuild = false;
+bool Vinifera_Developer_AIInstantBuild = false;

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -37,3 +37,4 @@ extern char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
 bool Vinifera_Developer_InstantBuild = false;
 bool Vinifera_Developer_AIInstantBuild = false;
 bool Vinifera_Developer_BuildCheat = false;
+bool Vinifera_Developer_Unshroud = false;

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -36,3 +36,4 @@ extern char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
 
 bool Vinifera_Developer_InstantBuild = false;
 bool Vinifera_Developer_AIInstantBuild = false;
+bool Vinifera_Developer_BuildCheat = false;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -41,3 +41,4 @@ extern char Vinifera_DebugDirectory[PATH_MAX];
 extern bool Vinifera_Developer_InstantBuild;
 extern bool Vinifera_Developer_AIInstantBuild;
 extern bool Vinifera_Developer_BuildCheat;
+extern bool Vinifera_Developer_Unshroud;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -42,3 +42,4 @@ extern bool Vinifera_Developer_InstantBuild;
 extern bool Vinifera_Developer_AIInstantBuild;
 extern bool Vinifera_Developer_BuildCheat;
 extern bool Vinifera_Developer_Unshroud;
+extern bool Vinifera_Developer_ShowCursorPosition;

--- a/src/vinifera_hooks.cpp
+++ b/src/vinifera_hooks.cpp
@@ -213,6 +213,7 @@ DECLARE_PATCH(_Select_Game_Clear_Globals_Patch)
      */
     Vinifera_Developer_AIInstantBuild = false;
     Vinifera_Developer_InstantBuild = false;
+    Vinifera_Developer_BuildCheat = false;
 
     /**
      *  Stolen bytes/code.

--- a/src/vinifera_hooks.cpp
+++ b/src/vinifera_hooks.cpp
@@ -28,6 +28,7 @@
 #include "vinifera_hooks.h"
 #include "tibsun_globals.h"
 #include "tibsun_functions.h"
+#include "vinifera_globals.h"
 #include "vinifera_util.h"
 #include "vinifera_functions.h"
 #include "dsurface.h"
@@ -35,6 +36,7 @@
 #include "blowfish.h"
 #include "blowstraw.h"
 #include "blowpipe.h"
+#include "iomap.h"
 #include "vinifera_gitinfo.h"
 #include "hooker.h"
 #include "hooker_macros.h"
@@ -199,6 +201,28 @@ static void _Remove_External_Blowfish_Dependency_Patch()
 }
 
 
+/**
+ *  Clear any game session and global variables before next game.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Select_Game_Clear_Globals_Patch)
+{
+    /**
+     *  Clear any developer mode globals.
+     */
+    Vinifera_Developer_AIInstantBuild = false;
+    Vinifera_Developer_InstantBuild = false;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    Map.Set_Default_Mouse(MOUSE_NORMAL);
+
+    JMP(0x004E1F30);
+}
+
+
 void Vinifera_Hooks()
 {
     /**
@@ -219,4 +243,9 @@ void Vinifera_Hooks()
      *  Remove the requirement for BLOWFISH.DLL (Blowfish encryption).
      */
     _Remove_External_Blowfish_Dependency_Patch();
+
+    /**
+     *  Clear any game session and global variables before next game.
+     */
+    Patch_Jump(0x004E1F24, &_Select_Game_Clear_Globals_Patch);
 }

--- a/src/vinifera_hooks.cpp
+++ b/src/vinifera_hooks.cpp
@@ -214,6 +214,7 @@ DECLARE_PATCH(_Select_Game_Clear_Globals_Patch)
     Vinifera_Developer_AIInstantBuild = false;
     Vinifera_Developer_InstantBuild = false;
     Vinifera_Developer_BuildCheat = false;
+    Vinifera_Developer_Unshroud = false;
 
     /**
      *  Stolen bytes/code.


### PR DESCRIPTION
This pull request implements various developer mode hotkey commands.

Under the **Keyboard** settings from the options menu, you will find a new category;
![image](https://user-images.githubusercontent.com/73803386/120906952-7efd9580-c655-11eb-87bd-f80a498ed326.png)

![image](https://user-images.githubusercontent.com/73803386/120906963-92a8fc00-c655-11eb-82ba-a9d0c29ff5c4.png)

You will find the following hotkey commands in this category;

**BuildCheatCommandClass**
Unlocks all available build options for the player house.

**ToggleEliteCommandClass**
Toggle the elite status of the selected objects.

**DamageCommandClass**
Apply damage to all selected objects.

**SpawnAllCommandClass**
Spawn all buildable units and structures at mouse cursor location.

**DeleteObjectCommandClass**
Removes the selected object(s) from the game world.

**MapSnapshotCommandClass**
Saves a snapshot of the current scenario state.

**IonStormCommandClass**
Toggles the ion storm on/off.

**BailOutCommandClass**
Exits the game completely.

**ExplosionCommandClass**
Spawns an explosion at the mouse cursor location.

**SuperExplosionCommandClass**
Spawns a large explosion at the mouse cursor location.

**IonBlastCommandClass**
Fires an ion blast bolt at the current mouse cursor location.

**LightningBoltCommandClass**
Fires a lightning bolt at the current mouse cursor location.

**FreeMoneyCommandClass**
Hands out free money to the player.

**SpecialWeaponsCommandClass**
Grants all available special weapons to the player.

**CaptureObjectCommandClass**
Take ownership of any selected objects.

**ForceWinCommandClass**
Forces the player to win the current game session.

**ForceLoseCommandClass**
Forces the player to lose the current game session.

**ForceDieCommandClass**
Forces the player to blowup and lose the current game session.

**InstantBuildCommandClass**
Toggles the instant build cheat for the player.

**AIInstantBuildCommandClass**
Toggles the instant build cheat for the AI.

**ToggleShroudCommandClass**
Toggles the visibility of the map shroud.

**HealCommandClass**
Heal the selected objects by 50 hit points.

**ToggleInertCommandClass**
Toggles if weapons are inert or not.

**DumpAIBaseNodesCommandClass**
Dumps all the current AI house base node info to the log output.

**ToggleAllianceCommandClass**
Toggles alliance with the selected objects house.

**EncroachFogCommandClass**
Increase the fog of war by one step (cell).

**EncroachShadowCommandClass**
Increase the shroud darkness by one step (cell).

**ToggleBerzerkCommandClass**
Toggles the berzerk state of the selected infantry.

**PlaceCrateCommandClass**
Places a random crate at the mouse location.

**AddPowerCommandClass**
Adds 2000 power units to the player.

**CursorPositionCommandClass**
Displays cell coordinates of the mouse cursor.

Please Note:
_ExplosionCommandClass_ and _SuperExplosionCommandClass_ are currently disabled due to possible engine bug.

You can enable the developer mode by running Vinifera (`LaunchVinifera.exe`) with the command line argument `-DEVELOPER`.
