### PR TITLE
Bugfixes and improvements for the Dropship Loadout menu.

### DIFF
--- a/src/bugfix/bugfix_hooks.cpp
+++ b/src/bugfix/bugfix_hooks.cpp
@@ -30,6 +30,7 @@
 
 #include "tibsun_globals.h"
 #include "vinifera_util.h"
+#include "wwmouse.h"
 #include "campaign.h"
 #include "scenario.h"
 #include "playmovie.h"
@@ -41,12 +42,40 @@
 #include "options.h"
 #include "language.h"
 #include "theme.h"
+#include "dropship.h"
 #include "msgbox.h"
 #include "loadoptions.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-262
+ * 
+ *  In certain cases, the mouse might not be shown on the Dropship Loadout menu.
+ *  This patch fixes that by showing the mouse regardless of its current state.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Start_Scenario_Dropship_Loadout_Show_Mouse_Patch)
+{
+    WWMouse->Release_Mouse();
+    WWMouse->Show_Mouse();
+
+    Dropship_Loadout();
+
+    WWMouse->Hide_Mouse();
+    WWMouse->Capture_Mouse();
+
+    JMP(0x005DB3C0);
+}
+
+static void _Dropship_Loadout_Show_Mouse_Patch()
+{
+    Patch_Jump(0x005DB3BB, &_Start_Scenario_Dropship_Loadout_Show_Mouse_Patch);
+}
 
 
 /**
@@ -458,4 +487,5 @@ void BugFix_Hooks()
     _Dont_Stretch_Main_Menu_Video_Patch();
     _MultiScore_Tally_Score_Fix_Loser_Typo_Patch();
     _Scale_Movies_By_Ratio_Patch();
+    _Dropship_Loadout_Show_Mouse_Patch();
 }

--- a/src/bugfix/bugfix_hooks.cpp
+++ b/src/bugfix/bugfix_hooks.cpp
@@ -61,6 +61,27 @@
  */
 DECLARE_PATCH(_Start_Scenario_Dropship_Loadout_Show_Mouse_Patch)
 {
+    /**
+     *  issue-284
+     * 
+     *  Play a background theme during the loadout menu.
+     * 
+     *  @author: CCHyper
+     */
+    if (!Theme.Still_Playing()) {
+
+        /**
+         *  If DSHPLOAD is defined in THEME.INI, play that, otherwise default
+         *  to playing the TS Maps theme.
+         */
+        ThemeType theme = Theme.From_Name("DSHPLOAD");
+        if (theme == THEME_NONE) {
+            theme = Theme.From_Name("MAPS");
+        }
+
+        Theme.Play_Song(theme);
+    }
+
     WWMouse->Release_Mouse();
     WWMouse->Show_Mouse();
 
@@ -68,6 +89,10 @@ DECLARE_PATCH(_Start_Scenario_Dropship_Loadout_Show_Mouse_Patch)
 
     WWMouse->Hide_Mouse();
     WWMouse->Capture_Mouse();
+
+    if (Theme.Still_Playing()) {
+        Theme.Stop(true); // Smoothly fade out the track.
+    }
 
     JMP(0x005DB3C0);
 }

--- a/src/extensions/dropship/dropshipext_hooks.cpp
+++ b/src/extensions/dropship/dropshipext_hooks.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DROPSHIPEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended Dropship loadout.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "dropshipext_hooks.h"
+#include "tibsun_globals.h"
+#include "vinifera_util.h"
+#include "dropship.h"
+#include "dsurface.h"
+#include "gscreen.h"
+#include "colorscheme.h"
+#include "textprint.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+#define TEXT_PRESS_SPACE "Press SPACE to start the mission"
+
+
+/**
+ *  #issue-285
+ * 
+ *  Draws help text on the dropship loadout menu.
+ * 
+ *  @author: CCHyper
+ */
+static void Draw_Dropship_Loadout_Help_Text(XSurface *surface)
+{
+    if (!surface) {
+        return;
+    }
+
+    Rect surfrect = surface->Get_Rect();
+
+    TextPrintType style = (TPF_CENTER|TPF_FULLSHADOW|TPF_6PT_GRAD);
+    ColorScheme *color_white = ColorScheme::As_Pointer("White");
+    ColorType back_color = COLOR_TBLACK;
+
+    Point2D text_pos;
+    text_pos.X = surfrect.Width/2;
+    text_pos.Y = (surfrect.Height/2)+185;
+
+    Fancy_Text_Print(TEXT_PRESS_SPACE, surface, &surfrect, &text_pos, color_white, back_color, style);
+}
+
+DECLARE_PATCH(_Dropship_Loadout_Help_Text_Patch)
+{
+    Draw_Dropship_Loadout_Help_Text(HiddenSurface);
+
+    /**
+     *  Draws the version text over the menu background.
+     */
+    Vinifera_Draw_Version_Text(HiddenSurface);
+
+    /**
+     *  Stolen bytes/code.
+     */
+original_code:
+    GScreenClass::Blit(true, HiddenSurface);
+
+    _asm { mov ebx, Scen }
+    _asm { mov ebx, [ebx] } // Second dereference required due to the global reference in TS++.
+
+    JMP(0x00486910);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void DropshipExtension_Hooks()
+{
+    Patch_Jump(0x004868FB, &_Dropship_Loadout_Help_Text_Patch);
+}

--- a/src/extensions/dropship/dropshipext_hooks.h
+++ b/src/extensions/dropship/dropshipext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DROPSHIPEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended Dropship loadout.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void DropshipExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -63,6 +63,8 @@
 //#include "tagtypeext_hooks.h"
 //#include "triggertypeext_hooks.h"
 
+#include "dropshipext_hooks.h"
+
 #include "hooker.h"
 #include "hooker_macros.h"
 
@@ -110,4 +112,6 @@ void Extension_Hooks()
     //ScriptTypeClassExtension_Hooks();
     //TagTypeClassExtension_Hooks();
     //TriggerTypeClassExtension_Hooks();
+
+    DropshipExtension_Hooks();
 }


### PR DESCRIPTION
Closes #262, Closes #284, Closes #285

This pull request addresses a few items related to the Dropship Loadout menu;
- Fixes a bug with the mouse cursor not correctly showing.
- Plays the Tiberian Sun Map theme (user can now define `DSHPLOAD` in `THEME.INI` to customise this.)
- Shows help text at the bottom of the screen to aid the user.

![image](https://user-images.githubusercontent.com/73803386/120932514-13b3d200-c6ee-11eb-9538-3f812323cb9f.png)

Attached is a modified version of GDI01.MAP that can be placed in the game directory for easily testing these changes.
[dropship_loadout_gdi1a.zip](https://github.com/Vinifera-Developers/Vinifera/files/6604508/dropship_loadout_gdi1a.zip)
