### PR TITLE
Changes the default value of `IsScoreShuffle` to `true`.

### DIFF
--- a/src/bugfix/bugfix_hooks.cpp
+++ b/src/bugfix/bugfix_hooks.cpp
@@ -52,6 +52,19 @@
 
 
 /**
+ *  #issue-212
+ * 
+ *  Changes the default value of "IsScoreShuffle" to "true".
+ * 
+ *  @author: CCHyper
+ */
+static void _OptionsClass_Constructor_IsScoreShuffle_Default_Patch()
+{
+    Patch_Byte(0x005899F1+1, 0x50); // "cl" (zero) to "dl" (1)
+}
+
+
+/**
  *  #issue-8
  *  
  *  Fixes MultiMission "MaxPlayers" incorrectly loaded with "MinPlayers".
@@ -529,4 +542,5 @@ void BugFix_Hooks()
     _Scale_Movies_By_Ratio_Patch();
     _Dropship_Loadout_Show_Mouse_Patch();
     _MultiMission_Constructor_MaxPlayers_Typo_Patch();
+    _OptionsClass_Constructor_IsScoreShuffle_Default_Patch();
 }


### PR DESCRIPTION
Closes #212

This changes the default value of `IsScoreShuffle` to true. See the issue for more information.

Can easily be tested by backing up the current `SUN.INI`, starting the game and going to the in-game music dialog.