### PR TITLE
Implements the Produce Cash logic for BuildingTypes.

### DIFF
--- a/src/extensions/building/buildingext.cpp
+++ b/src/extensions/building/buildingext.cpp
@@ -44,7 +44,17 @@ ExtensionMap<BuildingClass, BuildingClassExtension> BuildingClassExtensions;
  *  @author: CCHyper
  */
 BuildingClassExtension::BuildingClassExtension(BuildingClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    /**
+     *  #issue-26
+     * 
+     *  Members for the Produce Cash logic.
+     */
+    ProduceCashTimer(),
+    CurrentProduceCashBudget(-1),
+    IsCaptureOneTimeCashGiven(false),
+    IsBudgetDepleted(false)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("BuildingClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -155,4 +165,11 @@ void BuildingClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("BuildingClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    /**
+     *  #issue-26
+     * 
+     *  Members for the Produce Cash logic.
+     */
+    crc(ProduceCashTimer());
 }

--- a/src/extensions/building/buildingext.cpp
+++ b/src/extensions/building/buildingext.cpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended BuildingClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "buildingext.h"
+#include "building.h"
+#include "wwcrc.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+
+/**
+ *  Provides the map for all BuildingClass extension instances.
+ */
+ExtensionMap<BuildingClass, BuildingClassExtension> BuildingClassExtensions;
+
+
+/**
+ *  Class constructor.
+ *  
+ *  @author: CCHyper
+ */
+BuildingClassExtension::BuildingClassExtension(BuildingClass *this_ptr) :
+    Extension(this_ptr)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("BuildingClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("BuildingClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = true;
+}
+
+
+/**
+ *  Class no-init constructor.
+ *  
+ *  @author: CCHyper
+ */
+BuildingClassExtension::BuildingClassExtension(const NoInitClass &noinit) :
+    Extension(noinit)
+{
+    IsInitialized = false;
+}
+
+
+/**
+ *  Class deconstructor.
+ *  
+ *  @author: CCHyper
+ */
+BuildingClassExtension::~BuildingClassExtension()
+{
+    //EXT_DEBUG_TRACE("BuildingClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("BuildingClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = false;
+}
+
+
+/**
+ *  Initializes an object from the stream where it was saved previously.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT BuildingClassExtension::Load(IStream *pStm)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("BuildingClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Load(pStm);
+    if (FAILED(hr)) {
+        return E_FAIL;
+    }
+
+    new (this) BuildingClassExtension(NoInitClass());
+    
+    return hr;
+}
+
+
+/**
+ *  Saves an object to the specified stream.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT BuildingClassExtension::Save(IStream *pStm, BOOL fClearDirty)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("BuildingClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Save(pStm, fClearDirty);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Return the raw size of class data for save/load purposes.
+ *  
+ *  @author: CCHyper
+ */
+int BuildingClassExtension::Size_Of() const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("BuildingClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    return sizeof(*this);
+}
+
+
+/**
+ *  Removes the specified target from any targeting and reference trackers.
+ *  
+ *  @author: CCHyper
+ */
+void BuildingClassExtension::Detach(TARGET target, bool all)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("BuildingClassExtension::Detach - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}
+
+
+/**
+ *  Compute a unique crc value for this instance.
+ *  
+ *  @author: CCHyper
+ */
+void BuildingClassExtension::Compute_CRC(WWCRCEngine &crc) const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("BuildingClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}

--- a/src/extensions/building/buildingext.h
+++ b/src/extensions/building/buildingext.h
@@ -1,0 +1,59 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended BuildingClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "extension.h"
+#include "container.h"
+
+#include "ttimer.h"
+#include "ftimer.h"
+
+
+class BuildingClass;
+class HouseClass;
+
+
+class BuildingClassExtension final : public Extension<BuildingClass>
+{
+    public:
+        BuildingClassExtension(BuildingClass *this_ptr);
+        BuildingClassExtension(const NoInitClass &noinit);
+        ~BuildingClassExtension();
+
+        virtual HRESULT Load(IStream *pStm) override;
+        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
+        virtual int Size_Of() const override;
+
+        virtual void Detach(TARGET target, bool all = true) override;
+        virtual void Compute_CRC(WWCRCEngine &crc) const override;
+
+    public:
+};
+
+
+extern ExtensionMap<BuildingClass, BuildingClassExtension> BuildingClassExtensions;

--- a/src/extensions/building/buildingext.h
+++ b/src/extensions/building/buildingext.h
@@ -53,6 +53,15 @@ class BuildingClassExtension final : public Extension<BuildingClass>
         virtual void Compute_CRC(WWCRCEngine &crc) const override;
 
     public:
+        /**
+         *  #issue-26
+         * 
+         *  Members for the Produce Cash logic.
+         */
+        CDTimerClass<FrameTimerClass> ProduceCashTimer;     // The delay between each cash bonus.
+        int CurrentProduceCashBudget;                       // The remaining budget for the building.
+        bool IsCaptureOneTimeCashGiven;                     // Have we given our "one time" cash bonus on capture?
+        bool IsBudgetDepleted;                              // Has the cash budget been depleted (stops producing cash)?
 };
 
 

--- a/src/extensions/building/buildingext_functions.cpp
+++ b/src/extensions/building/buildingext_functions.cpp
@@ -1,0 +1,153 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT_FUNCTIONS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the supporting functions for the extended BuildingClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "buildingext_functions.h"
+#include "buildingext.h"
+#include "buildingtypeext.h"
+#include "building.h"
+#include "house.h"
+#include "housetype.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+
+/**
+ *  #issue-26
+ * 
+ *  The produce cash per-frame update function.
+ * 
+ *  @author: CCHyper
+ */
+void BuildingClassExtension_Produce_Cash_AI(BuildingClass *this_ptr)
+{
+    /**
+     *  Sanity check for the building class pointer.
+     */
+    if (!this_ptr) {
+        return;
+    }
+
+    /**
+     *  Find the extension instances.
+     */
+    BuildingClassExtension *ext_ptr = BuildingClassExtensions.find(this_ptr);
+    BuildingTypeClassExtension *exttype_ptr = BuildingTypeClassExtensions.find(this_ptr->Class);
+    if (!ext_ptr || !exttype_ptr) {
+        return;
+    }
+
+#if 0
+    /**
+     *  Debugging code.
+     * 
+     *  Only updates player owned buildings.
+     */
+    if (this_ptr->House != PlayerPtr) {
+        return;
+    }
+#endif
+
+    /**
+     *  Is this building able to produce cash?
+     */
+    if (!ext_ptr->IsBudgetDepleted && exttype_ptr->ProduceCashAmount != 0) {
+
+        /**
+         *  Check if this building requires power to produce cash.
+         */
+        if (reinterpret_cast<BuildingTypeClass const *>(this_ptr->Class_Of())->IsPowered) {
+
+            /**
+             *  Stop the timer if the building is offline or has low power.
+             */
+            if (ext_ptr->ProduceCashTimer.Is_Active() && !this_ptr->Is_Powered_On()) {
+                ext_ptr->ProduceCashTimer.Stop();
+            }
+
+            /**
+             *  Restart the timer is if it previously stopped due to low power or is offline.
+             */
+            if (!ext_ptr->ProduceCashTimer.Is_Active() && this_ptr->Is_Powered_On()) {
+                ext_ptr->ProduceCashTimer.Start();
+            }
+
+        }
+
+        /**
+         *  Are we ready to hand out some cash?
+         */
+        if (ext_ptr->ProduceCashTimer.Is_Active() && ext_ptr->ProduceCashTimer.Expired()) {
+
+            /**
+             *  Is the owner a passive house? If so, they should not be receiving cash.
+             */
+            if (!this_ptr->House->Class->IsMultiplayPassive) {
+
+                int amount = exttype_ptr->ProduceCashAmount;
+
+                /**
+                 *  Check we have not depleted our budget first.
+                 */
+                if (ext_ptr->CurrentProduceCashBudget > 0) {
+
+                    /**
+                     *  Adjust the budget tracker (if one as been set).
+                     */
+                    if (ext_ptr->CurrentProduceCashBudget != -1) {
+                        ext_ptr->CurrentProduceCashBudget -= std::max<unsigned>(0, std::abs(amount));
+                    }
+
+                    /**
+                     *  Has the budget been spent?
+                     */
+                    if (ext_ptr->CurrentProduceCashBudget <= 0) {
+                        ext_ptr->IsBudgetDepleted = true;
+                        ext_ptr->CurrentProduceCashBudget = -1;
+                    }
+
+                }
+
+                /**
+                 *  Check if we need to drain cash from the house or provide a bonus.
+                 */
+                if (!ext_ptr->IsBudgetDepleted && amount != 0) {
+                    if (amount < 0) {
+                        this_ptr->House->Spend_Money(std::abs(amount));
+                    } else {
+                        this_ptr->House->Refund_Money(amount);
+                    }
+                }
+
+            }
+
+            /**
+             *  Reset the delay timer.
+             */
+            ext_ptr->ProduceCashTimer = exttype_ptr->ProduceCashDelay;
+        }
+    }
+}

--- a/src/extensions/building/buildingext_functions.h
+++ b/src/extensions/building/buildingext_functions.h
@@ -1,0 +1,36 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT_FUNCTIONS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the supporting functions for the extended BuildingClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "always.h"
+
+
+class BuildingClass;
+
+
+void BuildingClassExtension_Produce_Cash_AI(BuildingClass *this_ptr);

--- a/src/extensions/building/buildingext_init.cpp
+++ b/src/extensions/building/buildingext_init.cpp
@@ -1,0 +1,207 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT_INIT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended BuildingClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "buildingext.h"
+#include "buildingtypeext.h"
+#include "building.h"
+#include "buildingtype.h"
+#include "house.h"
+#include "housetype.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+#include "vinifera_util.h"
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, esi); // Current "this" pointer.
+    static BuildingClassExtension *exttype_ptr;
+
+    /**
+     *  Find existing or create an extended class instance.
+     */
+    exttype_ptr = BuildingClassExtensions.find_or_create(this_ptr);
+    if (!exttype_ptr) {
+        DEBUG_ERROR("Failed to create BuildingClassExtension instance for 0x%08X!\n", (uintptr_t)this_ptr);
+        ShowCursor(TRUE);
+        MessageBoxA(MainWindow, "Failed to create BuildingClassExtensions instance!\n", "Vinifera", MB_OK|MB_ICONEXCLAMATION);
+        Vinifera_Generate_Mini_Dump();
+        Fatal("Failed to create BuildingClassExtensions instance!\n");
+        goto original_code; // Keep this for clean code analysis.
+    }
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { ret 8 }
+}
+
+
+/**
+ *  Patch for including the extended class members in the noinit creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_NoInit_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, esi);
+    GET_STACK_STATIC(const NoInitClass *, noinit, esp, 0x4);
+    static BuildingClassExtension *ext_ptr;
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Patch for including the extended class members in the destruction process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Deconstructor_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, esi);
+
+    /**
+     *  Remove the extended class from the global index.
+     */
+    BuildingClassExtensions.remove(this_ptr);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ecx }
+    _asm { ret }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class detach process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Detach_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, esi);
+    GET_STACK_STATIC(TARGET, target, esp, 0x10);
+    GET_STACK_STATIC8(bool, all, esp, 0x8);
+    static BuildingClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = BuildingClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Detach(target, all);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebx }
+    _asm { ret 8 }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class crc calculation.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Compute_CRC_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, esi);
+    GET_STACK_STATIC(WWCRCEngine *, crc, esp, 0xC);
+    static BuildingClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = BuildingClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Compute_CRC(*crc);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void BuildingClassExtension_Init()
+{
+    Patch_Jump(0x00426615, &_BuildingClass_Constructor_Patch);
+    Patch_Jump(0x00426184, &_BuildingClass_NoInit_Constructor_Patch);
+    Patch_Jump(0x004268BB, &_BuildingClass_Deconstructor_Patch);
+    Patch_Jump(0x00433FA9, &_BuildingClass_Detach_Patch);
+    Patch_Jump(0x0043843D, &_BuildingClass_Compute_CRC_Patch);
+}

--- a/src/extensions/building/buildingext_init.h
+++ b/src/extensions/building/buildingext_init.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT_INIT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended BuildingClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void BuildingClassExtension_Init();

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -48,7 +48,13 @@ BuildingTypeClassExtension::BuildingTypeClassExtension(BuildingTypeClass *this_p
     Extension(this_ptr),
 
     GateUpSound(VOC_NONE),
-    GateDownSound(VOC_NONE)
+    GateDownSound(VOC_NONE),
+    ProduceCashStartup(0),
+    ProduceCashAmount(0),
+    ProduceCashDelay(0),
+    ProduceCashBudget(0),
+    IsStartupCashOneTime(false),
+    IsResetBudgetOnCapture(false)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("BuildingTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -179,13 +185,15 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
         return false;
     }
 
-    /**
-     *  #issue-65
-     * 
-     *  Gate lowering and rising sound overrides for buildings.
-     */
     GateUpSound = ini.Get_VocType(ini_name, "GateUpSound", GateUpSound);
     GateDownSound = ini.Get_VocType(ini_name, "GateDownSound", GateDownSound);
+
+    ProduceCashStartup = ini.Get_Int(ini_name, "ProduceCashStartup", ProduceCashStartup);
+    ProduceCashAmount = ini.Get_Int(ini_name, "ProduceCashAmount", ProduceCashAmount);
+    ProduceCashDelay = ini.Get_Int(ini_name, "ProduceCashDelay", ProduceCashDelay);
+    ProduceCashBudget = ini.Get_Int(ini_name, "ProduceCashBudget", ProduceCashBudget);
+    IsStartupCashOneTime = ini.Get_Int(ini_name, "ProduceCashStartupOneTime", IsStartupCashOneTime);
+    IsResetBudgetOnCapture = ini.Get_Bool(ini_name, "ProduceCashResetOnCapture", IsResetBudgetOnCapture);
     
     return true;
 }

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -61,6 +61,36 @@ class BuildingTypeClassExtension final : public Extension<BuildingTypeClass>
          *  This is the sound effect to play when the animation of the gate is lowering.
          */
         VocType GateDownSound;
+
+        /**
+         *  Credits bonus when captured from a house with "IsMultiplayPassive" set.
+         */
+        unsigned ProduceCashStartup;
+        
+        /**
+         *  Amount every give to/take from the house every delay.
+         */
+        int ProduceCashAmount;
+        
+        /**
+         *  Frame delay between amounts.
+         */
+        unsigned ProduceCashDelay;
+        
+        /**
+         *  The total budget for this building.
+         */
+        unsigned ProduceCashBudget;
+        
+        /**
+         *  Is the capture bonus a "one one" special (further captures will not get the bonus)?
+         */
+        bool IsStartupCashOneTime;
+        
+        /**
+         *  Reset the available budget when captured?
+         */
+        bool IsResetBudgetOnCapture;
 };
 
 

--- a/src/extensions/saveload/saveload.cpp
+++ b/src/extensions/saveload/saveload.cpp
@@ -65,6 +65,7 @@
 //#include "triggertypeext.h"
 
 #include "technoext.h"
+#include "buildingext.h"
 #include "terrainext.h"
 
 
@@ -112,6 +113,7 @@ unsigned ViniferaSaveGameVersion =
             //+ sizeof(TagTypeClassExtension)
             //+ sizeof(TriggerTypeClassExtension)
             + sizeof(TechnoClassExtension)
+            + sizeof(BuildingClassExtension)
             + sizeof(TerrainClassExtension)
 ;
 
@@ -309,6 +311,7 @@ DEFINE_EXTENSION_SAVE(TiberiumClassExtension, TiberiumClassExtensions);
 //DEFINE_EXTENSION_SAVE(TriggerTypeClassExtension, TriggerTypeClassExtensions);
 
 DEFINE_EXTENSION_SAVE(TechnoClassExtension, TechnoClassExtensions);
+DEFINE_EXTENSION_SAVE(BuildingClassExtension, BuildingClassExtensions);
 DEFINE_EXTENSION_SAVE(TerrainClassExtension, TerrainClassExtensions);
 
 DEFINE_EXTENSION_LOAD(ObjectTypeClassExtension, ObjectTypeClassExtensions);
@@ -340,6 +343,7 @@ DEFINE_EXTENSION_LOAD(TiberiumClassExtension, TiberiumClassExtensions);
 //DEFINE_EXTENSION_LOAD(TriggerTypeClassExtension, TriggerTypeClassExtensions);
 
 DEFINE_EXTENSION_LOAD(TechnoClassExtension, TechnoClassExtensions);
+DEFINE_EXTENSION_LOAD(BuildingClassExtension, BuildingClassExtensions);
 DEFINE_EXTENSION_LOAD(TerrainClassExtension, TerrainClassExtensions);
 
 
@@ -544,6 +548,12 @@ bool Vinifera_Put_All(IStream *pStm)
 
     DEBUG_INFO("Saving TechnoClassExtension\n");
     if (!Vinifera_Save_TechnoClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
+
+    DEBUG_INFO("Saving BuildingClassExtension\n");
+    if (!Vinifera_Save_BuildingClassExtension(pStm)) {
         DEBUG_INFO("\t***** FAILED!\n");
         return false;
     }
@@ -786,6 +796,12 @@ bool Vinifera_Load_All(IStream *pStm)
 
     DEBUG_INFO("Loading TechnoClassExtension\n");
     if (!Vinifera_Load_TechnoClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
+
+    DEBUG_INFO("Loading BuildingClassExtension\n");
+    if (!Vinifera_Load_BuildingClassExtension(pStm)) {
         DEBUG_INFO("\t***** FAILED!\n");
         return false;
     }


### PR DESCRIPTION
Closes #26 

This pull request implements the Produce Cash logic from Red Alert 2.

The system works exactly as it does in Red Alert 2, but with the following differences;

-  Ability to set a total budget available to the building.
-  The logic is sensitive to `Powered=yes`, meaning it will stop when the house has low power.

The following INI keys have been added to BuildingTypes;

**ProduceCashStartup=<integer>**
Credits when captured from a house that has `MultiplayPassive=yes` set. Defaults to `0`.

**ProduceCashAmount=<integer>**
Amount every give to/take from the house every delay. This value supports negative values which will deduct money from the house which owns this building. Defaults to `0`.

**ProduceCashDelay=<integer>**
Frame delay between amounts. Defaults to `0` (instant).

**ProduceCashBudget=<integer>**
The total cash budget for this building. Defaults to `0` (infinite budget).

**ProduceCashResetOnCapture=<boolean>**
Reset the buildings available budget when captured. Defaults to `false`.

**ProduceCashStartupOneTime=<boolean>**
Is the bonus on capture a "one one" special _(further captures will not get the bonus)_? Defaults to `false`.
