### PR TITLE
Fixes a bug where `IsTrainable` is not checked when an object picks up a veteracy crate.

### DIFF
--- a/src/extensions/cell/cellext_hooks.cpp
+++ b/src/extensions/cell/cellext_hooks.cpp
@@ -1,0 +1,88 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CELLEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CellClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "houseext_hooks.h"
+#include "techno.h"
+#include "technotype.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  #issue-161
+ * 
+ *  Veterancy crate bonus does not check if a object is un-trainable
+ *  before granting it the veterancy bonus.
+ * 
+ *  @author: CCHyper (based on research by Iran)
+ */
+DECLARE_PATCH(_CellClass_Goodie_Check_Veterency_Trainable_BugFix_Patch)
+{
+	GET_REGISTER_STATIC(ObjectClass *, object, ecx);
+	static TechnoClass *techno;
+	static TechnoTypeClass *technotype;
+
+	/**
+	 *  Make sure the ground layer object is a techno.
+	 */
+	if (!object->Is_Techno()) {
+		goto continue_loop;
+	}
+
+	/**
+	 *  Is this object trainable? If so, grant it the bonus.
+	 */
+	techno = reinterpret_cast<TechnoClass *>(object);
+	if (techno->Techno_Type_Class()->IsTrainable) {
+		goto passes_check;
+	}
+
+	/**
+	 *  Continues the loop over the ground layer objects.
+	 */
+continue_loop:
+	JMP(0x0045894E);
+
+	/**
+	 *  Continue to grant the veterancy bonus.
+	 */
+passes_check:
+	JMP(0x00458839);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void CellClassExtension_Hooks()
+{
+	Patch_Jump(0x0045882C, &_CellClass_Goodie_Check_Veterency_Trainable_BugFix_Patch);
+}

--- a/src/extensions/cell/cellext_hooks.h
+++ b/src/extensions/cell/cellext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CELLEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CellClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void CellClassExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -70,6 +70,7 @@
 #include "unitext_hooks.h"
 #include "buildingext_hooks.h"
 #include "infantryext_hooks.h"
+#include "cellext_hooks.h"
 #include "houseext_hooks.h"
 #include "teamext_hooks.h"
 #include "factoryext_hooks.h"
@@ -137,6 +138,7 @@ void Extension_Hooks()
     UnitClassExtension_Hooks();
     InfantryClassExtension_Hooks();
     BuildingClassExtension_Hooks();
+    CellClassExtension_Hooks();
     HouseClassExtension_Hooks();
 	UnitClassExtension_Hooks();
     BuildingClassExtension_Hooks();


### PR DESCRIPTION
Closes #161 

This pull request fixes a bug where `IsTrainable` is not checked when an object picks up a veterancy crate.