### PR TITLE
Fixes division by zero crashes when `ShakeScreen` is set to `0`.

### DIFF
--- a/src/base/macros.h
+++ b/src/base/macros.h
@@ -99,6 +99,31 @@
 #endif // !SIZE_OF
 
 /**
+ *  Returns the absolute value of the number.
+ */
+#ifdef ABS
+#undef ABS
+#endif
+#define ABS(a, b) (a < 0) ? -a : a;
+
+/**
+ *  Returns the minimum of the two numbers.
+ */
+#ifdef MIN
+#undef MIN
+#endif
+#define MIN(a, b) (b < a) ? b : a;
+
+/**
+ *  Returns the maximum of the two numbers.
+ */
+#ifdef MAX
+#undef MAX
+#endif
+#define MAX(a, b) (b > a) ? b : a;
+
+
+/**
  *  Defines operator overloads to enable bit operations on enum values, useful for
  *  using an enum to define flags for a bitfield.
  *  

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -139,6 +139,7 @@ void Extension_Hooks()
     BuildingClassExtension_Hooks();
     HouseClassExtension_Hooks();
 	UnitClassExtension_Hooks();
+    BuildingClassExtension_Hooks();
 	HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
     FactoryClassExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -138,6 +138,8 @@ void Extension_Hooks()
     InfantryClassExtension_Hooks();
     BuildingClassExtension_Hooks();
     HouseClassExtension_Hooks();
+	UnitClassExtension_Hooks();
+	HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
     FactoryClassExtension_Hooks();
     FootClassExtension_Hooks();


### PR DESCRIPTION
Closes #333, Closes #334

This pull request fixes two division by zero crashes when `ShakeScreen` is set to `0`. It is assumed that this would have been set to zero to disable the shake screen effects _(although the system was removed in Tiberian Sun)_.

This can easily be tested by changing `ShakeScreen` to `0` under `[AudioVisual]` in RULES.INI, and then destroying a heavy unit in-game _(e.g. Mammoth Mk II)_ and a large building _(e.g. Construction Yard)_.