### PR TITLE
Implements hotkey command to enter the manual placement mode.

### DIFF
--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -74,6 +74,26 @@ class PNGScreenCaptureCommandClass : public ViniferaCommandClass
 
 
 /**
+ *  Enter the manual placement mode when a building is complete
+ *  and pending placement on the sidebar.
+ */
+class ManualPlaceCommandClass : public ViniferaCommandClass
+{
+    public:
+        ManualPlaceCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~ManualPlaceCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_Z); }
+};
+
+
+/**
  *  Produces a memory dump on request.
  */
 class MemoryDumpCommandClass : public ViniferaCommandClass

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -28,6 +28,8 @@
 #include "commandext.h"
 #include "vinifera_globals.h"
 #include "tibsun_functions.h"
+#include "ccfile.h"
+#include "ccini.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -46,10 +48,13 @@ void Init_Vinifera_Commands()
     /**
      *  Initialises any new commands here.
      */
-    //DEBUG_INFO("Initialising new commands.\n");
+    DEBUG_INFO("Initialising new commands.\n");
 
     //cmdptr = new PNGScreenCaptureCommandClass;
     //Commands.Add(cmdptr);
+
+    cmdptr = new ManualPlaceCommandClass;
+    Commands.Add(cmdptr);
     
     /**
      *  Next, initialised any new commands here if the developer mode is enabled.
@@ -168,6 +173,29 @@ void Init_Vinifera_Commands()
     DEBUG_INFO("Init_Vinifera_Commands(exit).\n");
 }
 
+/**
+ *  Set the default key assignments.
+ * 
+ *  @author: CCHyper
+ */
+static void Process_Vinifera_Hotkeys()
+{
+    CommandClass *cmdptr = nullptr;
+    KeyNumType key;
+
+    CCFileClass file("KEYBOARD.INI");
+    CCINIClass ini;
+
+    ini.Load(file, false);
+
+    if (!ini.Is_Present("Hotkey", "ManualPlace")) {
+        cmdptr = CommandClass::From_Name("ManualPlace");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+}
 
 /**
  *  Patch for initialising the new hotkey commands.
@@ -183,6 +211,8 @@ DECLARE_PATCH(_Init_Commands_Patch)
      */
 original_code:
     Load_Keyboard_Hotkeys();
+
+    Process_Vinifera_Hotkeys();
 
     JMP(0x004E6FAE);
 }


### PR DESCRIPTION
Closes #112 

This pull request implements a new hotkey command to enter the manual placement mode when a building is complete and pending on the sidebar.

An enhancement compared to the ts-patches implementation is that EVA will now report _"Unable to comply..."_ if the key is pressed but the building is not ready.

The default key for this new command is **"Z"**.