### PR TITLE
Adds keyboard commands to reproduce the last items that were built.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -119,6 +119,7 @@ This page lists all the individual contributions to the project by their author.
   - Change the default value of AllowHiResModes to true.
   - Implement CnCNet4 support.
   - Implement CnCNet5 support.
+  - Adds keyboard commands to reproduce the last items that were built.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Rampastring**:

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -21,6 +21,22 @@ This page lists all user interface additions, changes, fixes that are implemente
 
 - Toggles the visibility of Super Weapon timers. Defaults to `<none>`.
 
+### `[ ]` Repeat Last Building
+
+- Queue the last structure that was built. Defaults to `Ctrl` + `Z`.
+
+### `[ ]` Repeat Last Infantry
+
+- Queue the last infantry that was built. Defaults to `Ctrl` + `X`.
+
+### `[ ]` Repeat Last Unit
+
+- Queue the last vehicle that was built. Defaults to `Ctrl` + `C`.
+
+### `[ ]` Repeat Last Aircraft
+
+- Queue the last aircraft that was built. Defaults to `Ctrl` + `V`.
+
 ### `[ ]` Jump Camera West
 
 - Jump the tactical map camera to the west edge of the map. Defaults to `Ctrl` + `Left Arrow`.

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -27,15 +27,15 @@ This page lists all user interface additions, changes, fixes that are implemente
 
 ### `[ ]` Repeat Last Infantry
 
-- Queue the last infantry that was built. Defaults to `Ctrl` + `X`.
+- Queue the last infantry that was built. Defaults to `<none>`.
 
 ### `[ ]` Repeat Last Unit
 
-- Queue the last vehicle that was built. Defaults to `Ctrl` + `C`.
+- Queue the last vehicle that was built. Defaults to `<none>`.
 
 ### `[ ]` Repeat Last Aircraft
 
-- Queue the last aircraft that was built. Defaults to `Ctrl` + `V`.
+- Queue the last aircraft that was built. Defaults to `<none>`.
 
 ### `[ ]` Jump Camera West
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -2,7 +2,7 @@
 
 This page lists the history of changes across stable Vinifera releases and also all the stuff that requires modders to change something in their mods to accommodate.
 
-% ## Migrating
+## Migrating
 
 % ```{hint}
 % You can use the migration utility (can be found on [Vinifera supplementaries repo](https://github.com/Vinifera-Developers/ViniferaSupplementaries)) to apply most of the changes automatically using a corresponding sed script file.
@@ -12,7 +12,9 @@ This page lists the history of changes across stable Vinifera releases and also 
 
 % ### When updating Vinifera
 
-% ### From TS Patches
+### From TS Patches
+
+- [place_building_hotkey.c](https://github.com/CnCNet/ts-patches/blob/master/src/place_building_hotkey.c) and [repeat_last_building_hotkey.c](https://github.com/CnCNet/ts-patches/blob/master/src/repeat_last_building_hotkey.c) should be disabled to avoid conflict with the analogous Vinifera keyboard commands.
 
 % ### New user settings in `SUN.ini`
 % 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -116,6 +116,7 @@ New:
 - Change the default value of AllowHiResModes to true (by CCHyper/tomsons26)
 - Implement CnCNet4 support (by CCHyper/tomsons26)
 - Implement CnCNet5 support (by CCHyper/tomsons26)
+- Adds keyboard commands to reproduce the last items that were built (by CCHyper/tomsons26)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -439,27 +439,27 @@ bool ManualPlaceCommandClass::Process()
  * 
  *  @author: CCHyper (based on research by dkeeton)
  */
-const char *JustBuiltBuildingCommandClass::Get_Name() const
+const char *RepeatLastBuildingCommandClass::Get_Name() const
 {
-    return "JustBuiltBuilding";
+    return "RepeatLastBuilding";
 }
 
-const char *JustBuiltBuildingCommandClass::Get_UI_Name() const
+const char *RepeatLastBuildingCommandClass::Get_UI_Name() const
 {
-    return "Reproduce Last Building";
+    return "Repeat Last Building";
 }
 
-const char *JustBuiltBuildingCommandClass::Get_Category() const
+const char *RepeatLastBuildingCommandClass::Get_Category() const
 {
     return Text_String(TXT_INTERFACE);
 }
 
-const char *JustBuiltBuildingCommandClass::Get_Description() const
+const char *RepeatLastBuildingCommandClass::Get_Description() const
 {
-    return "Reproduce the last structure that was built.";
+    return "Queue the last structure that was built.";
 }
 
-bool JustBuiltBuildingCommandClass::Process()
+bool RepeatLastBuildingCommandClass::Process()
 {
     if (!PlayerPtr) {
         return false;
@@ -470,7 +470,7 @@ bool JustBuiltBuildingCommandClass::Process()
      *  done to make sure the house still has a factory.
      */
     if (!PlayerPtr->Factory_Count(RTTI_BUILDING)) {
-        DEV_DEBUG_WARNING("JustBuiltBuildingCommandClass - Unable to fetch primary factory!\n");
+        DEV_DEBUG_WARNING("RepeatLastBuildingCommandClass - Unable to fetch primary factory!\n");
         return false;
     }
     
@@ -501,9 +501,9 @@ bool JustBuiltBuildingCommandClass::Process()
         return false;
     }
 
-    DEBUG_INFO("JustBuiltBuildingCommandClass - \"%s\"\n", buildingtype->Full_Name());
+    DEBUG_INFO("RepeatLastBuildingCommandClass - \"%s\"\n", buildingtype->Full_Name());
 
-    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_BUILDINGTYPE, building));
+    OutList.Add(EventClass(PlayerPtr->ID, EVENT_PRODUCE, RTTI_BUILDINGTYPE, building));
 
     return true;
 }
@@ -516,27 +516,27 @@ bool JustBuiltBuildingCommandClass::Process()
  * 
  *  @author: CCHyper (based on research by dkeeton)
  */
-const char *JustBuiltInfantryCommandClass::Get_Name() const
+const char *RepeatLastInfantryCommandClass::Get_Name() const
 {
-    return "JustBuiltInfantry";
+    return "RepeatLastInfantry";
 }
 
-const char *JustBuiltInfantryCommandClass::Get_UI_Name() const
+const char *RepeatLastInfantryCommandClass::Get_UI_Name() const
 {
-    return "Reproduce Last Infantry";
+    return "Repeat Last Infantry";
 }
 
-const char *JustBuiltInfantryCommandClass::Get_Category() const
+const char *RepeatLastInfantryCommandClass::Get_Category() const
 {
     return Text_String(TXT_INTERFACE);
 }
 
-const char *JustBuiltInfantryCommandClass::Get_Description() const
+const char *RepeatLastInfantryCommandClass::Get_Description() const
 {
-    return "Reproduce the last infantry that was built.";
+    return "Queue the last infantry that was built.";
 }
 
-bool JustBuiltInfantryCommandClass::Process()
+bool RepeatLastInfantryCommandClass::Process()
 {
     if (!PlayerPtr) {
         return false;
@@ -547,7 +547,7 @@ bool JustBuiltInfantryCommandClass::Process()
      *  done to make sure the house still has a factory.
      */
     if (!PlayerPtr->Factory_Count(RTTI_INFANTRY)) {
-        DEV_DEBUG_WARNING("JustBuiltInfantryCommandClass - Unable to fetch primary factory!\n");
+        DEV_DEBUG_WARNING("RepeatLastInfantryCommandClass - Unable to fetch primary factory!\n");
         return false;
     }
     
@@ -578,9 +578,9 @@ bool JustBuiltInfantryCommandClass::Process()
         return false;
     }
 
-    DEBUG_INFO("JustBuiltInfantryCommandClass - \"%s\"\n", infantrytype->Full_Name());
+    DEBUG_INFO("RepeatLastInfantryCommandClass - \"%s\"\n", infantrytype->Full_Name());
 
-    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_INFANTRYTYPE, infantry));
+    OutList.Add(EventClass(PlayerPtr->ID, EVENT_PRODUCE, RTTI_INFANTRYTYPE, infantry));
 
     return true;
 }
@@ -593,27 +593,27 @@ bool JustBuiltInfantryCommandClass::Process()
  * 
  *  @author: CCHyper (based on research by dkeeton)
  */
-const char *JustBuiltUnitCommandClass::Get_Name() const
+const char *RepeatLastUnitCommandClass::Get_Name() const
 {
-    return "JustBuiltUnit";
+    return "RepeatLastUnit";
 }
 
-const char *JustBuiltUnitCommandClass::Get_UI_Name() const
+const char *RepeatLastUnitCommandClass::Get_UI_Name() const
 {
-    return "Reproduce Last Vehicle";
+    return "Repeat Last Vehicle";
 }
 
-const char *JustBuiltUnitCommandClass::Get_Category() const
+const char *RepeatLastUnitCommandClass::Get_Category() const
 {
     return Text_String(TXT_INTERFACE);
 }
 
-const char *JustBuiltUnitCommandClass::Get_Description() const
+const char *RepeatLastUnitCommandClass::Get_Description() const
 {
-    return "Reproduce the last vehicle that was built.";
+    return "Queue the last vehicle that was built.";
 }
 
-bool JustBuiltUnitCommandClass::Process()
+bool RepeatLastUnitCommandClass::Process()
 {
     if (!PlayerPtr) {
         return false;
@@ -624,7 +624,7 @@ bool JustBuiltUnitCommandClass::Process()
      *  done to make sure the house still has a factory.
      */
     if (!PlayerPtr->Factory_Count(RTTI_UNIT)) {
-        DEV_DEBUG_WARNING("JustBuiltUnitCommandClass - Unable to fetch primary factory!\n");
+        DEV_DEBUG_WARNING("RepeatLastUnitCommandClass - Unable to fetch primary factory!\n");
         return false;
     }
     
@@ -655,9 +655,9 @@ bool JustBuiltUnitCommandClass::Process()
         return false;
     }
 
-    DEBUG_INFO("JustBuiltUnitCommandClass - \"%s\"\n", unittype->Full_Name());
+    DEBUG_INFO("RepeatLastUnitCommandClass - \"%s\"\n", unittype->Full_Name());
 
-    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_UNITTYPE, unit));
+    OutList.Add(EventClass(PlayerPtr->ID, EVENT_PRODUCE, RTTI_UNITTYPE, unit));
 
     return true;
 }
@@ -670,27 +670,27 @@ bool JustBuiltUnitCommandClass::Process()
  * 
  *  @author: CCHyper (based on research by dkeeton)
  */
-const char *JustBuiltAircraftCommandClass::Get_Name() const
+const char *RepeatLastAircraftCommandClass::Get_Name() const
 {
-    return "JustBuiltAircraft";
+    return "RepeatLastAircraft";
 }
 
-const char *JustBuiltAircraftCommandClass::Get_UI_Name() const
+const char *RepeatLastAircraftCommandClass::Get_UI_Name() const
 {
-    return "Reproduce Last Aircraft";
+    return "Repeat Last Aircraft";
 }
 
-const char *JustBuiltAircraftCommandClass::Get_Category() const
+const char *RepeatLastAircraftCommandClass::Get_Category() const
 {
     return Text_String(TXT_INTERFACE);
 }
 
-const char *JustBuiltAircraftCommandClass::Get_Description() const
+const char *RepeatLastAircraftCommandClass::Get_Description() const
 {
-    return "Reproduce the last aircraft that was built.";
+    return "Queue the last aircraft that was built.";
 }
 
-bool JustBuiltAircraftCommandClass::Process()
+bool RepeatLastAircraftCommandClass::Process()
 {
     if (!PlayerPtr) {
         return false;
@@ -701,7 +701,7 @@ bool JustBuiltAircraftCommandClass::Process()
      *  done to make sure the house still has a factory.
      */
     if (!PlayerPtr->Factory_Count(RTTI_AIRCRAFT)) {
-        DEV_DEBUG_WARNING("JustBuiltAircraftCommand - Unable to fetch primary factory!\n");
+        DEV_DEBUG_WARNING("RepeatLastAircraftCommandClass - Unable to fetch primary factory!\n");
         return false;
     }
     
@@ -732,9 +732,9 @@ bool JustBuiltAircraftCommandClass::Process()
         return false;
     }
 
-    DEBUG_INFO("JustBuiltAircraftCommand - \"%s\"\n", aircrafttype->Full_Name());
+    DEBUG_INFO("RepeatLastAircraftCommandClass - \"%s\"\n", aircrafttype->Full_Name());
 
-    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_AIRCRAFTTYPE, aircraft));
+    OutList.Add(EventClass(PlayerPtr->ID, EVENT_PRODUCE, RTTI_AIRCRAFTTYPE, aircraft));
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -62,6 +62,8 @@
 #include "scenarioini.h"
 #include "scenario.h"
 #include "vox.h"
+#include "event.h"
+#include "queue.h"
 #include "language.h"
 #include "wwcrc.h"
 #include "filepcx.h"
@@ -427,6 +429,314 @@ bool ManualPlaceCommandClass::Process()
      *  Go into placement mode.
      */
     return PlayerPtr->Manual_Place(builder, pending_bptr);
+}
+
+
+/**
+ *  #issue-168
+ * 
+ *  Reproduces the last structure that was built.
+ * 
+ *  @author: CCHyper (based on research by dkeeton)
+ */
+const char *JustBuiltBuildingCommandClass::Get_Name() const
+{
+    return "JustBuiltBuilding";
+}
+
+const char *JustBuiltBuildingCommandClass::Get_UI_Name() const
+{
+    return "Reproduce Last Building";
+}
+
+const char *JustBuiltBuildingCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JustBuiltBuildingCommandClass::Get_Description() const
+{
+    return "Reproduce the last structure that was built.";
+}
+
+bool JustBuiltBuildingCommandClass::Process()
+{
+    if (!PlayerPtr) {
+        return false;
+    }
+
+    /**
+     *  Fetch the houses factory associated with producing building. This is
+     *  done to make sure the house still has a factory.
+     */
+    if (!PlayerPtr->Factory_Count(RTTI_BUILDING)) {
+        DEV_DEBUG_WARNING("JustBuiltBuildingCommandClass - Unable to fetch primary factory!\n");
+        return false;
+    }
+    
+    /**
+     *  Nothing built? Nothing to reproduce...
+     */
+    BuildingType building = PlayerPtr->JustBuiltStructure;
+    if (building == BUILDING_NONE) {
+        return false;
+    }
+
+    const BuildingTypeClass *buildingtype = BuildingTypeClass::As_Pointer(building);
+    if (!buildingtype) {
+        return false;
+    }
+    
+    /**
+     *  Do an extra check to make sure we can produce this item.
+     */
+    if (((1 << PlayerPtr->ID) & buildingtype->Ownable) == 0) {
+        return false;
+    }
+
+    /**
+     *  Is the item currently available to build on the sidebar?
+     */
+    if (!Map.Is_On_Sidebar(RTTI_BUILDINGTYPE, building)) {
+        return false;
+    }
+
+    DEBUG_INFO("JustBuiltBuildingCommandClass - \"%s\"\n", buildingtype->Full_Name());
+
+    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_BUILDINGTYPE, building));
+
+    return true;
+}
+
+
+/**
+ *  #issue-168
+ * 
+ *  Reproduces the last infantry that was built.
+ * 
+ *  @author: CCHyper (based on research by dkeeton)
+ */
+const char *JustBuiltInfantryCommandClass::Get_Name() const
+{
+    return "JustBuiltInfantry";
+}
+
+const char *JustBuiltInfantryCommandClass::Get_UI_Name() const
+{
+    return "Reproduce Last Infantry";
+}
+
+const char *JustBuiltInfantryCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JustBuiltInfantryCommandClass::Get_Description() const
+{
+    return "Reproduce the last infantry that was built.";
+}
+
+bool JustBuiltInfantryCommandClass::Process()
+{
+    if (!PlayerPtr) {
+        return false;
+    }
+
+    /**
+     *  Fetch the houses factory associated with producing infantry. This is
+     *  done to make sure the house still has a factory.
+     */
+    if (!PlayerPtr->Factory_Count(RTTI_INFANTRY)) {
+        DEV_DEBUG_WARNING("JustBuiltInfantryCommandClass - Unable to fetch primary factory!\n");
+        return false;
+    }
+    
+    /**
+     *  Nothing built? Nothing to reproduce...
+     */
+    InfantryType infantry = PlayerPtr->JustBuiltInfantry;
+    if (infantry == INFANTRY_NONE) {
+        return false;
+    }
+
+    const InfantryTypeClass *infantrytype = InfantryTypeClass::As_Pointer(infantry);
+    if (!infantrytype) {
+        return false;
+    }
+    
+    /**
+     *  Do an extra check to make sure we can produce this item.
+     */
+    if (((1 << PlayerPtr->ID) & infantrytype->Ownable) == 0) {
+        return false;
+    }
+    
+    /**
+     *  Is the item currently available to build on the sidebar?
+     */
+    if (!Map.Is_On_Sidebar(RTTI_INFANTRYTYPE, infantry)) {
+        return false;
+    }
+
+    DEBUG_INFO("JustBuiltInfantryCommandClass - \"%s\"\n", infantrytype->Full_Name());
+
+    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_INFANTRYTYPE, infantry));
+
+    return true;
+}
+
+
+/**
+ *  #issue-168
+ * 
+ *  Reproduces the last unit that was built.
+ * 
+ *  @author: CCHyper (based on research by dkeeton)
+ */
+const char *JustBuiltUnitCommandClass::Get_Name() const
+{
+    return "JustBuiltUnit";
+}
+
+const char *JustBuiltUnitCommandClass::Get_UI_Name() const
+{
+    return "Reproduce Last Vehicle";
+}
+
+const char *JustBuiltUnitCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JustBuiltUnitCommandClass::Get_Description() const
+{
+    return "Reproduce the last vehicle that was built.";
+}
+
+bool JustBuiltUnitCommandClass::Process()
+{
+    if (!PlayerPtr) {
+        return false;
+    }
+
+    /**
+     *  Fetch the houses factory associated with producing unit. This is
+     *  done to make sure the house still has a factory.
+     */
+    if (!PlayerPtr->Factory_Count(RTTI_UNIT)) {
+        DEV_DEBUG_WARNING("JustBuiltUnitCommandClass - Unable to fetch primary factory!\n");
+        return false;
+    }
+    
+    /**
+     *  Nothing built? Nothing to reproduce...
+     */
+    UnitType unit = PlayerPtr->JustBuiltUnit;
+    if (unit == UNIT_NONE) {
+        return false;
+    }
+
+    const UnitTypeClass *unittype = UnitTypeClass::As_Pointer(unit);
+    if (!unittype) {
+        return false;
+    }
+    
+    /**
+     *  Do an extra check to make sure we can produce this item.
+     */
+    if (((1 << PlayerPtr->ID) & unittype->Ownable) == 0) {
+        return false;
+    }
+    
+    /**
+     *  Is the item currently available to build on the sidebar?
+     */
+    if (!Map.Is_On_Sidebar(RTTI_UNITTYPE, unit)) {
+        return false;
+    }
+
+    DEBUG_INFO("JustBuiltUnitCommandClass - \"%s\"\n", unittype->Full_Name());
+
+    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_UNITTYPE, unit));
+
+    return true;
+}
+
+
+/**
+ *  #issue-168
+ * 
+ *  Reproduces the last aircraft that was built.
+ * 
+ *  @author: CCHyper (based on research by dkeeton)
+ */
+const char *JustBuiltAircraftCommandClass::Get_Name() const
+{
+    return "JustBuiltAircraft";
+}
+
+const char *JustBuiltAircraftCommandClass::Get_UI_Name() const
+{
+    return "Reproduce Last Aircraft";
+}
+
+const char *JustBuiltAircraftCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JustBuiltAircraftCommandClass::Get_Description() const
+{
+    return "Reproduce the last aircraft that was built.";
+}
+
+bool JustBuiltAircraftCommandClass::Process()
+{
+    if (!PlayerPtr) {
+        return false;
+    }
+
+    /**
+     *  Fetch the houses factory associated with producing aircraft. This is
+     *  done to make sure the house still has a factory.
+     */
+    if (!PlayerPtr->Factory_Count(RTTI_AIRCRAFT)) {
+        DEV_DEBUG_WARNING("JustBuiltAircraftCommand - Unable to fetch primary factory!\n");
+        return false;
+    }
+    
+    /**
+     *  Nothing built? Nothing to reproduce...
+     */
+    AircraftType aircraft = PlayerPtr->JustBuiltAircraft;
+    if (aircraft == AIRCRAFT_NONE) {
+        return false;
+    }
+
+    const AircraftTypeClass *aircrafttype = AircraftTypeClass::As_Pointer(aircraft);
+    if (!aircrafttype) {
+        return false;
+    }
+    
+    /**
+     *  Do an extra check to make sure we can produce this item.
+     */
+    if (((1 << PlayerPtr->ID) & aircrafttype->Ownable) == 0) {
+        return false;
+    }
+    
+    /**
+     *  Is the item currently available to build on the sidebar?
+     */
+    if (!Map.Is_On_Sidebar(RTTI_AIRCRAFTTYPE, aircraft)) {
+        return false;
+    }
+
+    DEBUG_INFO("JustBuiltAircraftCommand - \"%s\"\n", aircrafttype->Full_Name());
+
+    OutList.Add(EventClass(PlayerPtr->ID, EventType::PRODUCE, RTTI_AIRCRAFTTYPE, aircraft));
+
+    return true;
 }
 
 

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -135,7 +135,7 @@ class RepeatLastInfantryCommandClass : public ViniferaCommandClass
         virtual const char *Get_Description() const override;
         virtual bool Process() override;
 
-        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_X|KN_CTRL_BIT); }
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
 };
 
 
@@ -154,7 +154,7 @@ class RepeatLastUnitCommandClass : public ViniferaCommandClass
         virtual const char *Get_Description() const override;
         virtual bool Process() override;
 
-        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_C|KN_CTRL_BIT); }
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
 };
 
 
@@ -173,7 +173,7 @@ class RepeatLastAircraftCommandClass : public ViniferaCommandClass
         virtual const char *Get_Description() const override;
         virtual bool Process() override;
 
-        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_V|KN_CTRL_BIT); }
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
 };
 
 

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -102,6 +102,82 @@ class ManualPlaceCommandClass : public ViniferaCommandClass
 
 
 /**
+ *  Reproduces the last structure that was built.
+ */
+class JustBuiltBuildingCommandClass : public ViniferaCommandClass
+{
+    public:
+        JustBuiltBuildingCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JustBuiltBuildingCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_Z|KN_CTRL_BIT); }
+};
+
+
+/**
+ *  Reproduces the last infantry that was built.
+ */
+class JustBuiltInfantryCommandClass : public ViniferaCommandClass
+{
+    public:
+        JustBuiltInfantryCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JustBuiltInfantryCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_X|KN_CTRL_BIT); }
+};
+
+
+/**
+ *  Reproduces the last unit that was built.
+ */
+class JustBuiltUnitCommandClass : public ViniferaCommandClass
+{
+    public:
+        JustBuiltUnitCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JustBuiltUnitCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_C|KN_CTRL_BIT); }
+};
+
+
+/**
+ *  Reproduces the last aircraft that was built.
+ */
+class JustBuiltAircraftCommandClass : public ViniferaCommandClass
+{
+    public:
+        JustBuiltAircraftCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JustBuiltAircraftCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_V|KN_CTRL_BIT); }
+};
+
+
+/**
  *  Skip to the previous playable music track.
  */
 class PrevThemeCommandClass : public ViniferaCommandClass

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -104,11 +104,11 @@ class ManualPlaceCommandClass : public ViniferaCommandClass
 /**
  *  Reproduces the last structure that was built.
  */
-class JustBuiltBuildingCommandClass : public ViniferaCommandClass
+class RepeatLastBuildingCommandClass : public ViniferaCommandClass
 {
     public:
-        JustBuiltBuildingCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
-        virtual ~JustBuiltBuildingCommandClass() {}
+        RepeatLastBuildingCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~RepeatLastBuildingCommandClass() {}
 
         virtual const char *Get_Name() const override;
         virtual const char *Get_UI_Name() const override;
@@ -123,11 +123,11 @@ class JustBuiltBuildingCommandClass : public ViniferaCommandClass
 /**
  *  Reproduces the last infantry that was built.
  */
-class JustBuiltInfantryCommandClass : public ViniferaCommandClass
+class RepeatLastInfantryCommandClass : public ViniferaCommandClass
 {
     public:
-        JustBuiltInfantryCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
-        virtual ~JustBuiltInfantryCommandClass() {}
+        RepeatLastInfantryCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~RepeatLastInfantryCommandClass() {}
 
         virtual const char *Get_Name() const override;
         virtual const char *Get_UI_Name() const override;
@@ -142,11 +142,11 @@ class JustBuiltInfantryCommandClass : public ViniferaCommandClass
 /**
  *  Reproduces the last unit that was built.
  */
-class JustBuiltUnitCommandClass : public ViniferaCommandClass
+class RepeatLastUnitCommandClass : public ViniferaCommandClass
 {
     public:
-        JustBuiltUnitCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
-        virtual ~JustBuiltUnitCommandClass() {}
+        RepeatLastUnitCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~RepeatLastUnitCommandClass() {}
 
         virtual const char *Get_Name() const override;
         virtual const char *Get_UI_Name() const override;
@@ -161,11 +161,11 @@ class JustBuiltUnitCommandClass : public ViniferaCommandClass
 /**
  *  Reproduces the last aircraft that was built.
  */
-class JustBuiltAircraftCommandClass : public ViniferaCommandClass
+class RepeatLastAircraftCommandClass : public ViniferaCommandClass
 {
     public:
-        JustBuiltAircraftCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
-        virtual ~JustBuiltAircraftCommandClass() {}
+        RepeatLastAircraftCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~RepeatLastAircraftCommandClass() {}
 
         virtual const char *Get_Name() const override;
         virtual const char *Get_UI_Name() const override;

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -213,16 +213,16 @@ void Init_Vinifera_Commands()
     cmdptr = new ManualPlaceCommandClass;
     Commands.Add(cmdptr);
 
-    cmdptr = new JustBuiltBuildingCommandClass;
+    cmdptr = new RepeatLastBuildingCommandClass;
     Commands.Add(cmdptr);
 
-    cmdptr = new JustBuiltInfantryCommandClass;
+    cmdptr = new RepeatLastInfantryCommandClass;
     Commands.Add(cmdptr);
 
-    cmdptr = new JustBuiltUnitCommandClass;
+    cmdptr = new RepeatLastUnitCommandClass;
     Commands.Add(cmdptr);
 
-    cmdptr = new JustBuiltAircraftCommandClass;
+    cmdptr = new RepeatLastAircraftCommandClass;
     Commands.Add(cmdptr);
 
     cmdptr = new PrevThemeCommandClass;
@@ -460,32 +460,32 @@ static void Process_Vinifera_Hotkeys()
     }
 #endif
 
-    if (!ini.Is_Present("Hotkey", "JustBuiltBuilding")) {
-        cmdptr = CommandClass::From_Name("JustBuiltBuilding");
+    if (!ini.Is_Present("Hotkey", "RepeatLastBuilding")) {
+        cmdptr = CommandClass::From_Name("RepeatLastBuilding");
         if (cmdptr) {
             key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
             HotkeyIndex.Add_Index(key, cmdptr);
         }
     }
 
-    if (!ini.Is_Present("Hotkey", "JustBuiltInfantry")) {
-        cmdptr = CommandClass::From_Name("JustBuiltInfantry");
+    if (!ini.Is_Present("Hotkey", "RepeatLastInfantry")) {
+        cmdptr = CommandClass::From_Name("RepeatLastInfantry");
         if (cmdptr) {
             key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
             HotkeyIndex.Add_Index(key, cmdptr);
         }
     }
 
-    if (!ini.Is_Present("Hotkey", "JustBuiltUnit")) {
-        cmdptr = CommandClass::From_Name("JustBuiltUnit");
+    if (!ini.Is_Present("Hotkey", "RepeatLastUnit")) {
+        cmdptr = CommandClass::From_Name("RepeatLastUnit");
         if (cmdptr) {
             key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
             HotkeyIndex.Add_Index(key, cmdptr);
         }
     }
 
-    if (!ini.Is_Present("Hotkey", "JustBuiltInfantry")) {
-        cmdptr = CommandClass::From_Name("JustBuiltInfantry");
+    if (!ini.Is_Present("Hotkey", "RepeatLastAircraft")) {
+        cmdptr = CommandClass::From_Name("RepeatLastAircraft");
         if (cmdptr) {
             key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
             HotkeyIndex.Add_Index(key, cmdptr);

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -213,6 +213,18 @@ void Init_Vinifera_Commands()
     cmdptr = new ManualPlaceCommandClass;
     Commands.Add(cmdptr);
 
+    cmdptr = new JustBuiltBuildingCommandClass;
+    Commands.Add(cmdptr);
+
+    cmdptr = new JustBuiltInfantryCommandClass;
+    Commands.Add(cmdptr);
+
+    cmdptr = new JustBuiltUnitCommandClass;
+    Commands.Add(cmdptr);
+
+    cmdptr = new JustBuiltAircraftCommandClass;
+    Commands.Add(cmdptr);
+
     cmdptr = new PrevThemeCommandClass;
     Commands.Add(cmdptr);
 
@@ -447,6 +459,38 @@ static void Process_Vinifera_Hotkeys()
 #if defined(TS_CLIENT)
     }
 #endif
+
+    if (!ini.Is_Present("Hotkey", "JustBuiltBuilding")) {
+        cmdptr = CommandClass::From_Name("JustBuiltBuilding");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "JustBuiltInfantry")) {
+        cmdptr = CommandClass::From_Name("JustBuiltInfantry");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "JustBuiltUnit")) {
+        cmdptr = CommandClass::From_Name("JustBuiltUnit");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "JustBuiltInfantry")) {
+        cmdptr = CommandClass::From_Name("JustBuiltInfantry");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
 
     if (!ini.Is_Present("Hotkey", "PrevTheme")) {
         cmdptr = CommandClass::From_Name("PrevTheme");

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -468,30 +468,6 @@ static void Process_Vinifera_Hotkeys()
         }
     }
 
-    if (!ini.Is_Present("Hotkey", "RepeatLastInfantry")) {
-        cmdptr = CommandClass::From_Name("RepeatLastInfantry");
-        if (cmdptr) {
-            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
-            HotkeyIndex.Add_Index(key, cmdptr);
-        }
-    }
-
-    if (!ini.Is_Present("Hotkey", "RepeatLastUnit")) {
-        cmdptr = CommandClass::From_Name("RepeatLastUnit");
-        if (cmdptr) {
-            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
-            HotkeyIndex.Add_Index(key, cmdptr);
-        }
-    }
-
-    if (!ini.Is_Present("Hotkey", "RepeatLastAircraft")) {
-        cmdptr = CommandClass::From_Name("RepeatLastAircraft");
-        if (cmdptr) {
-            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
-            HotkeyIndex.Add_Index(key, cmdptr);
-        }
-    }
-
     if (!ini.Is_Present("Hotkey", "PrevTheme")) {
         cmdptr = CommandClass::From_Name("PrevTheme");
         if (cmdptr) {


### PR DESCRIPTION
Closes #168

This pull request implements four new quality of life keyboard commands;

**"Reproduce Last Building"**
Reproduces the last structure that was built. Defaults to **Ctrl+Z**.

**"Reproduce Last Infantry"**
Reproduces the last infantry that was built. Defaults to **Ctrl+X**.

**"Reproduce Last Vehicle"**
Reproduces the last vehicle that was built. Defaults to **Ctrl+C**.

**"Reproduce Last Aircraft"**
Reproduces the last aircraft that was built. Defaults to **Ctrl+V**.

