### PR TITLE
Fixes a limitation where returning to the Skirmish dialog after a game clamps the chosen side between 0 (GDI) and 1 (NOD).

### DIFF
--- a/src/extensions/skirmishdlg/skirmishdlg_hooks.cpp
+++ b/src/extensions/skirmishdlg/skirmishdlg_hooks.cpp
@@ -40,6 +40,39 @@
 
 
 /**
+ *  #issue-346
+ * 
+ *  Fixes a limitation where returning to the Skirmish dialog after a game
+ *  clamps the chosen side between 0 (GDI) and 1 (NOD). This means the player
+ *  would be forced back to index 1 (NOD) on the combo box if they played as
+ *  a new side which was added in a mod for example.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_SkirmishDialog_InitDialog_RestoreSideIndex_Patch)
+{
+    GET_REGISTER_STATIC(HWND, hSideComboBox, edi);
+    static int side_index;
+
+    /**
+     *  Clamp the chosen House index within the range of known houses. If the
+     *  value is out of range for any reason, set back to index 0 (GDI).
+     */
+    side_index = Session.House;
+    if (side_index >= HouseTypes.Count()) {
+        side_index = 0;
+    }
+    
+    /**
+     *  Set the combo box entry.
+     */
+    SendMessage(hSideComboBox, CB_SETCURSEL, (WPARAM)side_index, (LPARAM)0);
+
+    JMP(0x005F782C);
+}
+
+
+/**
  *  #issue-324
  * 
  *  When the game is running in developer mode, allow Skirmish games to be
@@ -92,4 +125,5 @@ DECLARE_PATCH(_SkirmishDialog_InitDialog_AIPlayers_Patch)
 void SkirmishDialog_Hooks()
 {
     Patch_Jump(0x005F7759, &_SkirmishDialog_InitDialog_AIPlayers_Patch);
+    Patch_Jump(0x005F7812, &_SkirmishDialog_InitDialog_RestoreSideIndex_Patch);
 }


### PR DESCRIPTION
Closes #346 

This pull request fixes a limitation where returning to the Skirmish dialog after a game clamps the chosen side between 0 (GDI) and 1 (NOD).

This can easily be tested by making the following changes to RULES.INI to enable two new sides;
```
[Houses]
0=GDI
1=Nod
2=ThirdHouse
3=FourthHouse
4=Neutral
5=Special

[Sides]
GDI=GDI
Nod=Nod
ThirdSide=ThirdHouse
FourthSide=FourthHouse
Civilian=Neutral
Mutant=Special

[ThirdHouse]
Name=Third House
Suffix=Third
Prefix=T
Color=Orange
Multiplay=yes
Side=ThirdSide

[FourthHouse]
Name=Fourth House
Suffix=Fourth
Prefix=F
Color=Purple
Multiplay=yes
Side=FourthSide

[MCV]
Owner=GDI,Nod,ThirdHouse,FourthHouse

[E1]
Owner=GDI,Nod,ThirdHouse,FourthHouse

[GACNST]
Owner=GDI,Nod,ThirdHouse,FourthHouse
```