### PR TITLE
Fixes a bug where the wrong palette is used to draw the cameo above an enemy spied factory building.

### DIFF
--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -1,0 +1,81 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended BuildingClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "buildingext_hooks.h"
+#include "tibsun_globals.h"
+#include "building.h"
+#include "buildingtype.h"
+#include "dsurface.h"
+#include "convert.h"
+#include "drawshape.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  #issue-72
+ * 
+ *  Fixes the bug where the wrong palette used to draw the cameo of the object
+ *  being produced above a enemy spied factory building.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Draw_Spied_Cameo_Palette_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, factory_obj, eax);
+    GET_REGISTER_STATIC(Point2D *, pos_xy, edi);
+    GET_REGISTER_STATIC(Rect *, window_rect, ebp);
+
+    static TechnoTypeClass *technotype;
+    static const ShapeFileStruct *cameo_shape;
+
+    technotype = factory_obj->Techno_Type_Class();
+    cameo_shape = technotype->Get_Cameo_Data();
+
+    /**
+     *  Draw the cameo shape.
+     * 
+     *  Original code used NormalDrawer, which is the old Red Alert shape
+     *  drawer, so we need to use CameoDrawer here for the correct palette.
+     */
+    CC_Draw_Shape(TempSurface, CameoDrawer, cameo_shape, 0, pos_xy, window_rect, ShapeFlagsType(SHAPE_CENTER|SHAPE_400|SHAPE_ALPHA|SHAPE_NORMAL));
+
+    JMP(0x00428B13);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void BuildingClassExtension_Hooks()
+{
+    Patch_Jump(0x00428AD3, &_BuildingClass_Draw_Spied_Cameo_Palette_Patch);
+}

--- a/src/extensions/building/buildingext_hooks.h
+++ b/src/extensions/building/buildingext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BUILDINGEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended BuildingClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void BuildingClassExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -66,6 +66,7 @@
 //#include "triggertypeext_hooks.h"
 
 #include "unitext_hooks.h"
+#include "buildingext_hooks.h"
 #include "houseext_hooks.h"
 #include "teamext_hooks.h"
 #include "factoryext_hooks.h"
@@ -125,10 +126,11 @@ void Extension_Hooks()
     //TagTypeClassExtension_Hooks();
     //TriggerTypeClassExtension_Hooks();
 
-	UnitClassExtension_Hooks();
-	HouseClassExtension_Hooks();
+    UnitClassExtension_Hooks();
+    BuildingClassExtension_Hooks();
+    HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
-	FactoryClassExtension_Hooks();
+    FactoryClassExtension_Hooks();
     FootClassExtension_Hooks();
 
     DropshipExtension_Hooks();


### PR DESCRIPTION
Closes #72 

This pull request fixes a bug where the wrong palette is used to draw the cameo above an enemy spied factory building.

As per @Rampastring's comments on the issue, this can easily be tested with the following changes in RULES.INI and sending a Rifle infantry into an enemy Construction Yard;
```
[E1]
Infiltrate=yes
```

Screenshot of the spied factory cameo drawing correctly;
![image](https://user-images.githubusercontent.com/73803386/122226099-89b5f700-cead-11eb-83e1-457669a6e9ed.png)
