### PR TITLE
Adds support for more graphic facings for UnitTypes and various associated items.

### DIFF
--- a/src/extensions/ccini/cciniext_hooks.cpp
+++ b/src/extensions/ccini/cciniext_hooks.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CCINIEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CCINIClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "houseext_hooks.h"
+#include "tibsun_globals.h"
+#include "tibsun_functions.h"
+#include "ccini.h"
+#include "housetype.h"
+#include "weapontype.h"
+#include "animtype.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or deconstructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+class CCINIClassFake final : public CCINIClass
+{
+    public:
+        TypeList<AnimTypeClass *> Get_AnimType_List(const char *section, const char *entry, const TypeList<AnimTypeClass *> defvalue);
+};
+
+
+/**
+ *  Fetch a list of AnimTypes.
+ * 
+ *  @author: CCHyper
+ */
+TypeList<AnimTypeClass *> CCINIClassFake::Get_AnimType_List(const char *section, const char *entry, const TypeList<AnimTypeClass *> defvalue)
+{
+    char buffer[128];
+
+    if (CCINIClass::Get_String(section, entry, "", buffer, sizeof(buffer)) > 0) {
+
+        //DEV_DEBUG_INFO("Get_AnimType_List(\"%s\",\"%s\") - \"%s\"\n", section, entry, buffer);
+
+        TypeList<AnimTypeClass *> list;
+
+        char *name = std::strtok(buffer, ",");
+        while (name) {
+            AnimTypeClass *animtype = const_cast<AnimTypeClass *>(AnimTypeClass::Find_Or_Make(name));
+            if (animtype) {
+                list.Add(animtype);
+            }
+            name = std::strtok(nullptr, ",");
+        }
+
+        return list;
+    }
+
+    return defvalue;
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void CCINIClassExtension_Hooks()
+{
+}

--- a/src/extensions/ccini/cciniext_hooks.cpp
+++ b/src/extensions/ccini/cciniext_hooks.cpp
@@ -61,7 +61,15 @@ class CCINIClassFake final : public CCINIClass
  */
 TypeList<AnimTypeClass *> CCINIClassFake::Get_AnimType_List(const char *section, const char *entry, const TypeList<AnimTypeClass *> defvalue)
 {
-    char buffer[128];
+    /**
+     *  #issue-391
+     * 
+     *  Increases the buffer size from 128 to 2048.
+     * 
+     *  @author: CCHyper
+     */
+    //char buffer[128];
+    char buffer[2048];
 
     if (CCINIClass::Get_String(section, entry, "", buffer, sizeof(buffer)) > 0) {
 

--- a/src/extensions/ccini/cciniext_hooks.h
+++ b/src/extensions/ccini/cciniext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CCINIEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CCINIClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void CCINIClassExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -81,6 +81,8 @@
 
 #include "dropshipext_hooks.h"
 
+#include "cciniext_hooks.h"
+
 #include "skirmishdlg_hooks.h"
 
 #include "hooker.h"
@@ -151,6 +153,8 @@ void Extension_Hooks()
     AnimClassExtension_Hooks();
 
     DropshipExtension_Hooks();
+
+    CCINIClassExtension_Hooks();
 
     /**
      *  Dialogs and associated code.

--- a/src/extensions/saveload/saveload.cpp
+++ b/src/extensions/saveload/saveload.cpp
@@ -64,6 +64,8 @@
 //#include "tagtypeext.h"
 //#include "triggertypeext.h"
 
+#include "technoext.h"
+
 
 /**
  *  Constant of the current build version number. This number should be
@@ -108,6 +110,7 @@ unsigned ViniferaSaveGameVersion =
             //+ sizeof(ScriptTypeClassExtension)
             //+ sizeof(TagTypeClassExtension)
             //+ sizeof(TriggerTypeClassExtension)
+            + sizeof(TechnoClassExtension)
 ;
 
 
@@ -303,6 +306,7 @@ DEFINE_EXTENSION_SAVE(TiberiumClassExtension, TiberiumClassExtensions);
 //DEFINE_EXTENSION_SAVE(TagTypeClassExtension, TagTypeClassExtensions);
 //DEFINE_EXTENSION_SAVE(TriggerTypeClassExtension, TriggerTypeClassExtensions);
 
+DEFINE_EXTENSION_SAVE(TechnoClassExtension, TechnoClassExtensions);
 
 DEFINE_EXTENSION_LOAD(ObjectTypeClassExtension, ObjectTypeClassExtensions);
 DEFINE_EXTENSION_LOAD(TechnoTypeClassExtension, TechnoTypeClassExtensions);
@@ -331,6 +335,8 @@ DEFINE_EXTENSION_LOAD(TiberiumClassExtension, TiberiumClassExtensions);
 //DEFINE_EXTENSION_LOAD(ScriptTypeClassExtension, ScriptTypeClassExtensions);
 //DEFINE_EXTENSION_LOAD(TagTypeClassExtension, TagTypeClassExtensions);
 //DEFINE_EXTENSION_LOAD(TriggerTypeClassExtension, TriggerTypeClassExtensions);
+
+DEFINE_EXTENSION_LOAD(TechnoClassExtension, TechnoClassExtensions);
 
 
 /**
@@ -531,6 +537,12 @@ bool Vinifera_Put_All(IStream *pStm)
 //        DEBUG_INFO("\t***** FAILED!\n");
 //        return false;
 //    }
+
+    DEBUG_INFO("Saving TechnoClassExtension\n");
+    if (!Vinifera_Save_TechnoClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
 
     /**
      *  Save global data and values here.
@@ -761,6 +773,12 @@ bool Vinifera_Load_All(IStream *pStm)
 //        DEBUG_INFO("\t***** FAILED!\n");
 //        return false;
 //    }
+
+    DEBUG_INFO("Loading TechnoClassExtension\n");
+    if (!Vinifera_Load_TechnoClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
 
     /**
      *  Load global data and values here.

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TECHNOEXT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended TechnoClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "technoext.h"
+#include "techno.h"
+#include "wwcrc.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+
+/**
+ *  Provides the map for all TechnoClass extension instances.
+ */
+ExtensionMap<TechnoClass, TechnoClassExtension> TechnoClassExtensions;
+
+
+/**
+ *  Class constructor.
+ *  
+ *  @author: CCHyper
+ */
+TechnoClassExtension::TechnoClassExtension(TechnoClass *this_ptr) :
+    Extension(this_ptr)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("TechnoClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = true;
+}
+
+
+/**
+ *  Class no-init constructor.
+ *  
+ *  @author: CCHyper
+ */
+TechnoClassExtension::TechnoClassExtension(const NoInitClass &noinit) :
+    Extension(noinit)
+{
+    IsInitialized = false;
+}
+
+
+/**
+ *  Class deconstructor.
+ *  
+ *  @author: CCHyper
+ */
+TechnoClassExtension::~TechnoClassExtension()
+{
+    //EXT_DEBUG_TRACE("TechnoClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("TechnoClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = false;
+}
+
+
+/**
+ *  Initializes an object from the stream where it was saved previously.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT TechnoClassExtension::Load(IStream *pStm)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Load(pStm);
+    if (FAILED(hr)) {
+        return E_FAIL;
+    }
+
+    new (this) TechnoClassExtension(NoInitClass());
+    
+    return hr;
+}
+
+
+/**
+ *  Saves an object to the specified stream.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT TechnoClassExtension::Save(IStream *pStm, BOOL fClearDirty)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Save(pStm, fClearDirty);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Return the raw size of class data for save/load purposes.
+ *  
+ *  @author: CCHyper
+ */
+int TechnoClassExtension::Size_Of() const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    return sizeof(*this);
+}
+
+
+/**
+ *  Removes the specified target from any targeting and reference trackers.
+ *  
+ *  @author: CCHyper
+ */
+void TechnoClassExtension::Detach(TARGET target, bool all)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension::Detach - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}
+
+
+/**
+ *  Compute a unique crc value for this instance.
+ *  
+ *  @author: CCHyper
+ */
+void TechnoClassExtension::Compute_CRC(WWCRCEngine &crc) const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -1,0 +1,53 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TECHNOEXT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended TechnoClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "extension.h"
+#include "container.h"
+#include "techno.h"
+
+
+class TechnoClassExtension final : public Extension<TechnoClass>
+{
+    public:
+        TechnoClassExtension(TechnoClass *this_ptr);
+        TechnoClassExtension(const NoInitClass &noinit);
+        ~TechnoClassExtension();
+
+        virtual HRESULT Load(IStream *pStm) override;
+        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
+        virtual int Size_Of() const override;
+
+        virtual void Detach(TARGET target, bool all = true) override;
+        virtual void Compute_CRC(WWCRCEngine &crc) const override;
+
+    public:
+};
+
+
+extern ExtensionMap<TechnoClass, TechnoClassExtension> TechnoClassExtensions;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -26,12 +26,15 @@
  *
  ******************************************************************************/
 #include "technoext_hooks.h"
+#include "technoext_init.h"
+#include "technoext.h"
 #include "techno.h"
 #include "technotype.h"
 #include "technotypeext.h"
 #include "rules.h"
 #include "voc.h"
 #include "fatal.h"
+#include "vinifera_util.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -134,6 +137,11 @@ DECLARE_PATCH(_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch)
  */
 void TechnoClassExtension_Hooks()
 {
+    /**
+     *  Initialises the extended class.
+     */
+    TechnoClassExtension_Init();
+
     Patch_Jump(0x00633C78, &_TechnoClass_Do_Cloak_Cloak_Sound_Patch);
     Patch_Jump(0x00633BD4, &_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch);
 }

--- a/src/extensions/techno/technoext_init.cpp
+++ b/src/extensions/techno/technoext_init.cpp
@@ -1,0 +1,205 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TECHNOEXT_INIT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended TechnoClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "technoext.h"
+#include "technotypeext.h"
+#include "techno.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+#include "vinifera_util.h"
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi); // Current "this" pointer.
+    static TechnoClassExtension *exttype_ptr;
+
+    /**
+     *  Find existing or create an extended class instance.
+     */
+    exttype_ptr = TechnoClassExtensions.find_or_create(this_ptr);
+    if (!exttype_ptr) {
+        DEBUG_ERROR("Failed to create TechnoClassExtension instance for 0x%08X!\n", (uintptr_t)this_ptr);
+        ShowCursor(TRUE);
+        MessageBoxA(MainWindow, "Failed to create TechnoClassExtensions instance!\n", "Vinifera", MB_OK|MB_ICONEXCLAMATION);
+        Vinifera_Generate_Mini_Dump();
+        Fatal("Failed to create TechnoClassExtensions instance!\n");
+        goto original_code; // Keep this for clean code analysis.
+    }
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Patch for including the extended class members in the noinit creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_NoInit_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    GET_STACK_STATIC(const NoInitClass *, noinit, esp, 0x4);
+    static TechnoClassExtension *ext_ptr;
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Patch for including the extended class members in the destruction process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Deconstructor_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+
+    /**
+     *  Remove the extended class from the global index.
+     */
+    TechnoClassExtensions.remove(this_ptr);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop esi }
+    _asm { pop ecx }
+    _asm { ret }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class detach process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Detach_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    GET_STACK_STATIC(TARGET, target, esp, 0x10);
+    GET_STACK_STATIC8(bool, all, esp, 0x8);
+    static TechnoClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = TechnoClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Detach(target, all);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { add esp, 0x0C }
+    _asm { ret 8 }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class crc calculation.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Compute_CRC_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    GET_STACK_STATIC(WWCRCEngine *, crc, esp, 0xC);
+    static TechnoClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = TechnoClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Compute_CRC(*crc);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void TechnoClassExtension_Init()
+{
+    Patch_Jump(0x0062A004, _TechnoClass_Constructor_Patch);
+    Patch_Jump(0x0062A8CC, _TechnoClass_NoInit_Constructor_Patch);
+    Patch_Jump(0x0062A968, _TechnoClass_Deconstructor_Patch);
+    Patch_Jump(0x0063641C, _TechnoClass_Detach_Patch);
+    Patch_Jump(0x0063910C, _TechnoClass_Compute_CRC_Patch);
+}

--- a/src/extensions/techno/technoext_init.h
+++ b/src/extensions/techno/technoext_init.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TECHNOEXT_INIT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended TechnoClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void TechnoClassExtension_Init();

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -153,7 +153,20 @@ DECLARE_PATCH(_UnitClass_Draw_Shape_Turret_Facing_Patch)
     /**
      *  Turret frames start directly after the facing frames.
      */
-    start_turret_frame = unittype->Facings;
+    start_turret_frame = unittype->Facings * unittype->WalkFrames;
+
+    unittypeext = UnitTypeClassExtensions.find(unittype);
+    if (unittypeext) {
+
+        /**
+         *  #issue-393
+         * 
+         *  Allow the custom turret facings.
+         * 
+         *  @author: CCHyper
+         */
+        turret_facings = unittypeext->TurretFacings;
+    }
 
     /**
      *  Fetch the frame index for current turret facing.
@@ -171,7 +184,6 @@ DECLARE_PATCH(_UnitClass_Draw_Shape_Turret_Facing_Patch)
      * 
      *  @author: CCHyper
      */
-    unittypeext = UnitTypeClassExtensions.find(unittype);
     if (unittypeext && unittypeext->StartTurretFrame != -1) {
         frame_number = unittypeext->StartTurretFrame + (shape_number % turret_facings);
     } else {

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -25,11 +25,12 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#include "houseext_hooks.h"
+#include "unitext_hooks.h"
 #include "tibsun_inline.h"
 #include "vinifera_globals.h"
 #include "tibsun_globals.h"
 #include "tibsun_functions.h"
+#include "unittypeext.h"
 #include "technotype.h"
 #include "technotypeext.h"
 #include "unit.h"
@@ -134,10 +135,13 @@ DECLARE_PATCH(_UnitClass_Draw_Shape_Turret_Facing_Patch)
     GET_REGISTER_STATIC(UnitClass *, this_ptr, ebp);
     GET_REGISTER_STATIC(const void *, shape, edi);
     static const UnitTypeClass *unittype;
+    static const UnitTypeClassExtension *unittypeext;
     static int shape_number;
     static int frame_number;
     static int turret_facings;
     static int start_turret_frame;
+
+    frame_number = 0;
 
     unittype = reinterpret_cast<UnitTypeClass *>(this_ptr->Class_Of());
     
@@ -159,7 +163,20 @@ DECLARE_PATCH(_UnitClass_Draw_Shape_Turret_Facing_Patch)
     /**
      *  Now adjust the frame index based on the units walk frames.
      */
-    frame_number = shape_number + (start_turret_frame * unittype->WalkFrames);
+
+    /**
+     *  #issue-389
+     * 
+     *  Allow the starting turret frame index to be defined.
+     * 
+     *  @author: CCHyper
+     */
+    unittypeext = UnitTypeClassExtensions.find(unittype);
+    if (unittypeext && unittypeext->StartTurretFrame != -1) {
+        frame_number = unittypeext->StartTurretFrame + (shape_number % turret_facings);
+    } else {
+        frame_number = start_turret_frame + (shape_number % turret_facings);
+    }
 
     /**
      *  The location we jump back to pushes EAX into the stack for

--- a/src/extensions/unittype/unittypeext.cpp
+++ b/src/extensions/unittype/unittypeext.cpp
@@ -47,7 +47,8 @@ UnitTypeClassExtension::UnitTypeClassExtension(UnitTypeClass *this_ptr) :
     Extension(this_ptr),
 
     IsTotable(true),
-    StartTurretFrame(-1)
+    StartTurretFrame(-1),
+    TurretFacings(32)		// Must default to 32 as all Tiberian Sun units have 32 facings for turrets.
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("UnitTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -192,6 +193,13 @@ bool UnitTypeClassExtension::Read_INI(CCINIClass &ini)
      *  @note: This key is loaded from the ArtINI database.
      */
     StartTurretFrame = ArtINI.Get_Int(graphic_name, "StartTurretFrame", StartTurretFrame);
+
+    /**
+     *  Custom turret facings.
+     * 
+     *  @note: This key is loaded from the ArtINI database.
+     */
+    TurretFacings = ArtINI.Get_Int(graphic_name, "TurretFacings", TurretFacings);
     
     return true;
 }

--- a/src/extensions/unittype/unittypeext.cpp
+++ b/src/extensions/unittype/unittypeext.cpp
@@ -46,12 +46,8 @@ ExtensionMap<UnitTypeClass, UnitTypeClassExtension> UnitTypeClassExtensions;
 UnitTypeClassExtension::UnitTypeClassExtension(UnitTypeClass *this_ptr) :
     Extension(this_ptr),
 
-    /**
-     *  #issue-208
-     * 
-     *  Adds flag to prevent a vehicle from being picked up by a Carryall.
-     */
-    IsTotable(true)
+    IsTotable(true),
+    StartTurretFrame(-1)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("UnitTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -182,7 +178,20 @@ bool UnitTypeClassExtension::Read_INI(CCINIClass &ini)
         return false;
     }
 
+    const char *graphic_name = ThisPtr->Graphic_Name();
+    
+    //if (!ArtINI.Is_Present(graphic_name)) {
+    //    return false;
+    //}
+
     IsTotable = ini.Get_Bool(ini_name, "Totable", IsTotable);
+
+    /**
+     *  Custom turret starting frame.
+     * 
+     *  @note: This key is loaded from the ArtINI database.
+     */
+    StartTurretFrame = ArtINI.Get_Int(graphic_name, "StartTurretFrame", StartTurretFrame);
     
     return true;
 }

--- a/src/extensions/unittype/unittypeext.h
+++ b/src/extensions/unittype/unittypeext.h
@@ -56,6 +56,11 @@ class UnitTypeClassExtension final : public Extension<UnitTypeClass>
          *  Can this unit be picked up (toted) by the carryall aircraft?
          */
         bool IsTotable;
+
+        /**
+         *  The starting frame for the turret graphics in the units shape file.
+         */
+        int StartTurretFrame;
 };
 
 

--- a/src/extensions/unittype/unittypeext.h
+++ b/src/extensions/unittype/unittypeext.h
@@ -61,6 +61,11 @@ class UnitTypeClassExtension final : public Extension<UnitTypeClass>
          *  The starting frame for the turret graphics in the units shape file.
          */
         int StartTurretFrame;
+
+        /**
+         *  The facing count for the turret graphics in the units shape file.
+         */
+        int TurretFacings;
 };
 
 


### PR DESCRIPTION
This pull request adds more graphic facings for UnitTypes, as well as some associated items.

Closes #214, Closes #389, Closes #391, Closes #393

<ins>**Adds support for more graphic facings for UnitTypes**</ins>
With Vinifera, the engine now supports 16, 32 and 64 graphic facings for UnitTypes.

<ins>**Implements `StartTurretFrame` for UnitTypes**</ins>
It is now possible to define the starting turret frame index for UnitTypes, allowing them to be adjusted manually if required. `StartTurretFrame` defaults to `-1` _(not used)_.

<ins>**Implements `TurretFacings` for UnitTypes**</ins>
It is now possible to define the turret facing count for UnitTypes. `TurretFacings` defaults to `32`.

<ins>**Update the `Anim=` key for WeaponTypes to support the new facing options.**</ins>
The `Anim=` INI key for WeaponTypes will now read the number of entries that matches the firing objects `Facings=` entry.  

<ins>**Increases the buffer size from 128 to 2048 characters when loading `Anim=` for WeaponTypes**</ins>
Because of the new extended facing support, it was observed that the buffer size was too small and has now been increased to allow a larger entry to accommodate a larger facing count.