### PR TITLE
Adds UnitType flag to prevent a vehicle from being picked up by a Carryall.

### DIFF
--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -72,6 +72,7 @@
 #include "unitext_hooks.h"
 #include "aircraftext_hooks.h"
 #include "buildingext_hooks.h"
+#include "aircraftext_hooks.h"
 #include "infantryext_hooks.h"
 #include "houseext_hooks.h"
 #include "teamext_hooks.h"
@@ -142,6 +143,7 @@ void Extension_Hooks()
     AircraftClassExtension_Hooks();
     InfantryClassExtension_Hooks();
     BuildingClassExtension_Hooks();
+    AircraftClassExtension_Hooks();
     HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
     FactoryClassExtension_Hooks();

--- a/src/extensions/unittype/unittypeext.cpp
+++ b/src/extensions/unittype/unittypeext.cpp
@@ -44,7 +44,14 @@ ExtensionMap<UnitTypeClass, UnitTypeClassExtension> UnitTypeClassExtensions;
  *  @author: CCHyper
  */
 UnitTypeClassExtension::UnitTypeClassExtension(UnitTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    /**
+     *  #issue-208
+     * 
+     *  Adds flag to prevent a vehicle from being picked up by a Carryall.
+     */
+    IsTotable(true)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("UnitTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -174,6 +181,8 @@ bool UnitTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    IsTotable = ini.Get_Bool(ini_name, "Totable", IsTotable);
     
     return true;
 }

--- a/src/extensions/unittype/unittypeext.h
+++ b/src/extensions/unittype/unittypeext.h
@@ -52,7 +52,10 @@ class UnitTypeClassExtension final : public Extension<UnitTypeClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
-
+        /**
+         *  Can this unit be picked up (toted) by the carryall aircraft?
+         */
+        bool IsTotable;
 };
 
 


### PR DESCRIPTION
Closes #208 

This pull request adds a new flag, `Totable=<boolean>`, to UnitType's which can prevent them from being picked up by a Carryall.