### PR TITLE
Gate rising and lowering sound overrides for buildings.

### DIFF
--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -27,6 +27,7 @@
  ******************************************************************************/
 #include "buildingtypeext.h"
 #include "buildingtype.h"
+#include "tibsun_defines.h"
 #include "ccini.h"
 #include "asserthandler.h"
 #include "debughandler.h"
@@ -44,7 +45,10 @@ ExtensionMap<BuildingTypeClass, BuildingTypeClassExtension> BuildingTypeClassExt
  *  @author: CCHyper
  */
 BuildingTypeClassExtension::BuildingTypeClassExtension(BuildingTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    GateUpSound(VOC_NONE),
+    GateDownSound(VOC_NONE)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("BuildingTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -174,6 +178,14 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    /**
+     *  #issue-65
+     * 
+     *  Gate lowering and rising sound overrides for buildings.
+     */
+    GateUpSound = ini.Get_VocType(ini_name, "GateUpSound", GateUpSound);
+    GateDownSound = ini.Get_VocType(ini_name, "GateDownSound", GateDownSound);
     
     return true;
 }

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -52,7 +52,15 @@ class BuildingTypeClassExtension final : public Extension<BuildingTypeClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
+        /**
+         *  This is the sound effect to play when the animation of the gate is rising.
+         */
+        VocType GateUpSound;
 
+        /**
+         *  This is the sound effect to play when the animation of the gate is lowering.
+         */
+        VocType GateDownSound;
 };
 
 


### PR DESCRIPTION
Closes #65 

This pull request implements overrides for the gate rising and lowering sounds on BuildingTypes.

The following new INI keys have been added to BuildingTypes;
`GateUpSound=<VocType>` - Sound effect to play when the gate is rising.
`GateDownSound=<VocType>` - Sound effect to play when the gate is lowering.