### PR TITLE
Fixes a bug where CloakStop had no effect on the cloaking behaviour.

### DIFF
--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -155,6 +155,7 @@ void Extension_Hooks()
     HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
     FactoryClassExtension_Hooks();
+    TechnoClassExtension_Hooks();
     FootClassExtension_Hooks();
     AnimClassExtension_Hooks();
 

--- a/src/extensions/foot/footext_hooks.cpp
+++ b/src/extensions/foot/footext_hooks.cpp
@@ -37,6 +37,52 @@
 
 
 /**
+ *  #issue-404
+ * 
+ *  A object with "CloakStop" set has no effect on the cloaking behavior.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_FootClass_Is_Allowed_To_Recloak_Cloak_Stop_BugFix_Patch)
+{
+    GET_REGISTER_STATIC(FootClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(TechnoTypeClass *, technotype, eax);
+    static ILocomotion *loco;
+
+    /**
+     *  Is this unit flagged to only re-cloak when not moving?
+     */
+    if (technotype->CloakStop) {
+
+        loco = this_ptr->Locomotor_Ptr();
+
+        /**
+         *  If the object is currently moving, then return false.
+         * 
+         *  The original code here called Is_Moving_Now, which returned
+         *  false when the locomotor was on a slope or rotating, which
+         *  breaks the CloakStop mechanic.
+         */
+        if (loco->Is_Moving()) {
+            goto return_false;
+        }
+    }
+
+    /**
+     *  The unit can re-cloak.
+     */
+return_true:
+    JMP_REG(ecx, 0x004A6897);
+
+    /**
+     *  The unit is not allowed to re-cloak.
+     */
+return_false:
+    JMP_REG(ecx, 0x004A689B);
+}
+
+
+/**
  *  #issue-192
  * 
  *  IsInsignificant is not checked on FootClass objects.
@@ -89,10 +135,6 @@ function_return:
  */
 void FootClassExtension_Hooks()
 {
-    /**
-     *  #issue-192
-     * 
-     *  IsInsignificant is not checked on FootClass objects.
-     */
     Patch_Jump(0x004A4D60, &_FootClass_Death_Announcement_IsInsignifcant_Patch);
+    Patch_Jump(0x004A6866, &_FootClass_Is_Allowed_To_Recloak_Cloak_Stop_BugFix_Patch);
 }

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -45,6 +45,41 @@
 
 
 /**
+ *  #issue-404
+ * 
+ *  A object with "CloakStop" set has no effect on the cloaking behavior.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Is_Ready_To_Uncloak_Cloak_Stop_BugFix_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(bool, cloaked_by_house, al);
+
+    /**
+     *  Is this object unable to recloak or is it disabled by an EMP?
+     */
+    //if (!this_ptr->Is_Allowed_To_Recloak() && !this_ptr->IsCloakable || this_ptr->entry_2A4()) { // Original code.
+    if (!this_ptr->Is_Allowed_To_Recloak() || !this_ptr->IsCloakable || this_ptr->entry_2A4()) {
+        goto continue_check;
+    }
+
+    /**
+     *  Object is not allowed to un-cloak at this time.
+     */
+return_false:
+    JMP_REG(ecx, 0x0062F746);
+
+    /**
+     *  Continue checks.
+     */
+continue_check:
+    _asm { mov bl, cloaked_by_house }
+    JMP_REG(ecx, 0x0062F6DD);
+}
+
+
+/**
  *  #issue-391
  * 
  *  Extends the firing animation effect to support more facings.
@@ -203,4 +238,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00633C78, &_TechnoClass_Do_Cloak_Cloak_Sound_Patch);
     Patch_Jump(0x00633BD4, &_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch);
     Patch_Jump(0x0063105C, &_TechnoClass_Fire_At_Weapon_Anim_Patch);
+    Patch_Jump(0x0062F6B7, &_TechnoClass_Is_Ready_To_Uncloak_Cloak_Stop_BugFix_Patch);
 }


### PR DESCRIPTION
Closes #404 

This pull request fixes a bug where `CloakStop` had no effect on the cloaking behaviour.

In addition to this, there was a residential bug where the Cloak Stop logic called the locomotor query `Is_Moving_Now()`, which returns false if the object was turning or currently on a slope. This has been changed to use `Is_Moving()`, which is the general movement query function.