### PR TITLE
Implements various Red Alert 2 WarheadType features.

### DIFF
--- a/src/extensions/bullet/bulletext_hooks.cpp
+++ b/src/extensions/bullet/bulletext_hooks.cpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BULLETEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended BulletClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "bulletext_hooks.h"
+#include "bullet.h"
+#include "warheadtype.h"
+#include "warheadtypeext.h"
+#include "iomap.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  #issue-415
+ * 
+ *  Implements screen shake values for WarheadTypes.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BulletClass_Logic_ShakeScreen_Patch)
+{
+    GET_REGISTER_STATIC(BulletClass *, this_ptr, ebx);
+    GET_REGISTER_STATIC(WarheadTypeClass *, warhead, eax);
+    GET_STACK_STATIC(Coordinate *, coord, esp, 0x0A8);
+    static WarheadTypeClassExtension *warheadext;
+
+    /**
+     *  Fetch the extended warhead type instance if it exists.
+     */
+    warheadext = WarheadTypeClassExtensions.find(warhead);
+    if (warheadext) {
+
+        /**
+         *  If this warhead has screen shake values defined, then set the blitter
+         *  offset values. GScreenClass::Blit will handle the rest for us.
+         */
+        if (warheadext->ShakePixelXLo > 0 || warheadext->ShakePixelXHi > 0) {
+            Map.ScreenX = Sim_Random_Pick(warheadext->ShakePixelXLo, warheadext->ShakePixelXHi);
+        }
+        if (warheadext->ShakePixelYLo > 0 || warheadext->ShakePixelYHi > 0) {
+            Map.ScreenY = Sim_Random_Pick(warheadext->ShakePixelYLo, warheadext->ShakePixelYHi);
+        }
+    }
+
+    /**
+     *  Restore some registers.
+     */
+    _asm { mov eax, warhead }
+    _asm { mov edi, coord /*[esp+0x0A8]*/ } // coord
+
+    /**
+     *  Jumps back to IsEMEffect check.
+     */
+    JMP_REG(edx, 0x00446659);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void BulletClassExtension_Hooks()
+{
+    Patch_Jump(0x00446652, &_BulletClass_Logic_ShakeScreen_Patch);
+}

--- a/src/extensions/bullet/bulletext_hooks.h
+++ b/src/extensions/bullet/bulletext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BULLETEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended BulletClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void BulletClassExtension_Hooks();

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -1,0 +1,90 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          COMBATEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended combat functions.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "buildingext_hooks.h"
+#include "combat.h"
+#include "cell.h"
+#include "overlaytype.h"
+#include "warheadtype.h"
+#include "warheadtypeext.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  #issue-410
+ * 
+ *  Implements IsWallAbsoluteDestroyer for WarheadTypes.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Explosion_Damage_IsWallAbsoluteDestroyer_Patch)
+{
+    GET_REGISTER_STATIC(OverlayTypeClass *, overlay, esi);
+    GET_REGISTER_STATIC(const WarheadTypeClass *, warhead, ebx);
+    GET_REGISTER_STATIC(CellClass *, cellptr, edi);
+    GET_STACK_STATIC(int, strength, esp, 0x54);
+    static const WarheadTypeClassExtension *warheadtypeext;
+
+    /**
+     *  Check to make sure that the warhead is of the kind that can destroy walls.
+     */
+    if (overlay->IsWall) {
+
+        /**
+         *  Is this warhead capable of instantly destroying the wall regardless
+         *  of damage? If so, then pass -1 into Reduce_Wall to remove the wall
+         *  section from the cell.
+         */
+        warheadtypeext = WarheadTypeClassExtensions.find(warhead);
+        if (warheadtypeext && warheadtypeext->IsWallAbsoluteDestroyer) {
+            cellptr->Reduce_Wall(-1);
+
+        /**
+         *  Original check.
+         */
+        } else if (warhead->IsWallDestroyer || warhead->IsWoodDestroyer || overlay->Armor == ARMOR_WOOD) {
+            cellptr->Reduce_Wall(strength);
+        }
+
+    }
+
+    JMP_REG(ecx, 0x0045FAD0);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void CombatExtension_Hooks()
+{
+    Patch_Jump(0x0045FAA0, &_Explosion_Damage_IsWallAbsoluteDestroyer_Patch);
+}

--- a/src/extensions/combat/combatext_hooks.h
+++ b/src/extensions/combat/combatext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          WEAPONTYPEEXT.H
+ *  @file          COMBATEXT_HOOKS.H
  *
  *  @author        CCHyper
  *
- *  @brief         Extended WeaponTypeClass class.
+ *  @brief         Contains the hooks for the extended Combat functions.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,32 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "extension.h"
-#include "container.h"
 
-
-class WeaponTypeClass;
-class CCINIClass;
-
-
-class WeaponTypeClassExtension final : public Extension<WeaponTypeClass>
-{
-    public:
-        WeaponTypeClassExtension(WeaponTypeClass *this_ptr);
-        WeaponTypeClassExtension(const NoInitClass &noinit);
-        ~WeaponTypeClassExtension();
-
-        virtual HRESULT Load(IStream *pStm) override;
-        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
-        virtual int Size_Of() const override;
-
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
-
-        bool Read_INI(CCINIClass &ini);
-
-    public:
-};
-
-
-extern ExtensionMap<WeaponTypeClass, WeaponTypeClassExtension> WeaponTypeClassExtensions;
+void CombatExtension_Hooks();

--- a/src/extensions/combat/combatext_hooks.h
+++ b/src/extensions/combat/combatext_hooks.h
@@ -27,5 +27,7 @@
  ******************************************************************************/
 #pragma once
 
+#include "always.h"
+
 
 void CombatExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -72,6 +72,7 @@
 
 #include "technoext_hooks.h"
 #include "footext_hooks.h"
+
 #include "unitext_hooks.h"
 #include "buildingext_hooks.h"
 #include "aircraftext_hooks.h"

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -82,6 +82,7 @@
 #include "teamext_hooks.h"
 #include "factoryext_hooks.h"
 #include "animext_hooks.h"
+#include "bulletext_hooks.h"
 #include "terrainext_hooks.h"
 
 #include "combatext_hooks.h"
@@ -162,6 +163,7 @@ void Extension_Hooks()
     TechnoClassExtension_Hooks();
     FootClassExtension_Hooks();
     AnimClassExtension_Hooks();
+    BulletClassExtension_Hooks();
     TerrainClassExtension_Hooks();
 
     CombatExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -83,6 +83,8 @@
 #include "animext_hooks.h"
 #include "terrainext_hooks.h"
 
+#include "combatext_hooks.h"
+
 #include "dropshipext_hooks.h"
 
 #include "cciniext_hooks.h"
@@ -160,6 +162,8 @@ void Extension_Hooks()
     FootClassExtension_Hooks();
     AnimClassExtension_Hooks();
     TerrainClassExtension_Hooks();
+
+    CombatExtension_Hooks();
 
     DropshipExtension_Hooks();
 

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -47,7 +47,8 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(WarheadTypeClass *this_ptr)
     Extension(this_ptr),
 
     IsWallAbsoluteDestroyer(false),
-    IsAffectsAllies(true)
+    IsAffectsAllies(true),
+    CombatLightSize(0.0f)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("WarheadTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -161,6 +162,7 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
 
     crc(IsWallAbsoluteDestroyer);
     crc(IsAffectsAllies);
+    crc(CombatLightSize);
 }
 
 
@@ -183,6 +185,7 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
 
     IsWallAbsoluteDestroyer = ini.Get_Bool(ini_name, "WallAbsoluteDestroyer", IsWallAbsoluteDestroyer);
     IsAffectsAllies = ini.Get_Bool(ini_name, "AffectsAllies", IsAffectsAllies);
+    CombatLightSize = ini.Get_Float_Clamp(ini_name, "CombatLightSize", 0.0f, 1.0f, CombatLightSize);
     
     return true;
 }

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -48,7 +48,11 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(WarheadTypeClass *this_ptr)
 
     IsWallAbsoluteDestroyer(false),
     IsAffectsAllies(true),
-    CombatLightSize(0.0f)
+    CombatLightSize(0.0f),
+    ShakePixelYHi(0),
+    ShakePixelYLo(0),
+    ShakePixelXHi(0),
+    ShakePixelXLo(0)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("WarheadTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -163,6 +167,10 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(IsWallAbsoluteDestroyer);
     crc(IsAffectsAllies);
     crc(CombatLightSize);
+    crc(ShakePixelYHi);
+    crc(ShakePixelYLo);
+    crc(ShakePixelXHi);
+    crc(ShakePixelXLo);
 }
 
 
@@ -186,6 +194,10 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     IsWallAbsoluteDestroyer = ini.Get_Bool(ini_name, "WallAbsoluteDestroyer", IsWallAbsoluteDestroyer);
     IsAffectsAllies = ini.Get_Bool(ini_name, "AffectsAllies", IsAffectsAllies);
     CombatLightSize = ini.Get_Float_Clamp(ini_name, "CombatLightSize", 0.0f, 1.0f, CombatLightSize);
-    
+    ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
+    ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
+    ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);
+    ShakePixelXLo = ini.Get_Int(ini_name, "ShakeXlo", ShakePixelXLo);
+
     return true;
 }

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -44,7 +44,9 @@ ExtensionMap<WarheadTypeClass, WarheadTypeClassExtension> WarheadTypeClassExtens
  *  @author: CCHyper
  */
 WarheadTypeClassExtension::WarheadTypeClassExtension(WarheadTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    IsWallAbsoluteDestroyer(false)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("WarheadTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -155,6 +157,8 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("WarheadTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    crc(IsWallAbsoluteDestroyer);
 }
 
 
@@ -174,6 +178,8 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    IsWallAbsoluteDestroyer = ini.Get_Bool(ini_name, "WallAbsoluteDestroyer", IsWallAbsoluteDestroyer);
     
     return true;
 }

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -46,7 +46,8 @@ ExtensionMap<WarheadTypeClass, WarheadTypeClassExtension> WarheadTypeClassExtens
 WarheadTypeClassExtension::WarheadTypeClassExtension(WarheadTypeClass *this_ptr) :
     Extension(this_ptr),
 
-    IsWallAbsoluteDestroyer(false)
+    IsWallAbsoluteDestroyer(false),
+    IsAffectsAllies(true)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("WarheadTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -159,6 +160,7 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     //DEV_DEBUG_TRACE("WarheadTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
 
     crc(IsWallAbsoluteDestroyer);
+    crc(IsAffectsAllies);
 }
 
 
@@ -180,6 +182,7 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     IsWallAbsoluteDestroyer = ini.Get_Bool(ini_name, "WallAbsoluteDestroyer", IsWallAbsoluteDestroyer);
+    IsAffectsAllies = ini.Get_Bool(ini_name, "AffectsAllies", IsAffectsAllies);
     
     return true;
 }

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -52,7 +52,10 @@ class WarheadTypeClassExtension final : public Extension<WarheadTypeClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
-
+        /**
+         *  Does this warhead instantly destroy walls regardless of the warhead damage value?
+         */
+        bool IsWallAbsoluteDestroyer;
 };
 
 

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -56,6 +56,11 @@ class WarheadTypeClassExtension final : public Extension<WarheadTypeClass>
          *  Does this warhead instantly destroy walls regardless of the warhead damage value?
          */
         bool IsWallAbsoluteDestroyer;
+
+        /**
+         *  Can this warhead damage friendly units?
+         */
+        bool IsAffectsAllies;
 };
 
 

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -61,6 +61,11 @@ class WarheadTypeClassExtension final : public Extension<WarheadTypeClass>
          *  Can this warhead damage friendly units?
          */
         bool IsAffectsAllies;
+
+        /**
+         *  This is used to override the size of the combat light flash at the point of impact.
+         */
+        float CombatLightSize;
 };
 
 

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -66,6 +66,14 @@ class WarheadTypeClassExtension final : public Extension<WarheadTypeClass>
          *  This is used to override the size of the combat light flash at the point of impact.
          */
         float CombatLightSize;
+
+        /**
+         *  These values are used to shake the screen when the projectile impacts.
+         */
+        unsigned int ShakePixelYHi;
+        unsigned int ShakePixelYLo;
+        unsigned int ShakePixelXHi;
+        unsigned int ShakePixelXLo;
 };
 
 


### PR DESCRIPTION
Closes #410, Closes #411, Closes #412, Closes #415

This pull request implements various WarheadType keys from Red Alert 2;

**`WallAbsoluteDestroyer=<boolean>`**
Does this warhead instantly destroy walls regardless of the warhead damage value? Defaults to `no`.

**`AffectsAllies=<boolean>`**
Can this warhead damage friendly units? Defaults to `yes`.

**`CombatLightSize=<boolean>`**
This is used to override the size of the combat light flash at the point of impact for Warheads with `Bright=yes` set _(`Bright=yes` must also be set on the Weapon using this warhead)_. Defaults to `0.0`. Ranges between `0.0` _(uses the default behaviour seen with `Bright=yes`)_ and `1.0` _(full size)_.

**Shake Screen Controls**
These values are used to shake the screen when the projectile impacts. All of these values default to `0` and do not support negative values.

`ShakeXhi<unsigned integer>` - Maxiumum Y pixel movement.
`ShakeXlo<unsigned integer>` - Minimum Y pixel movement.
`ShakeXhi<unsigned integer>` - Maxiumum X pixel movement.
`ShakeXlo<unsigned integer>` - Minimum X pixel movement.