### PR TITLE
Restores the screen shake when a strong unit or building is destroyed.

### DIFF
--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -36,6 +36,7 @@
 #include "drawshape.h"
 #include "rules.h"
 #include "voc.h"
+#include "iomap.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
@@ -148,7 +149,17 @@ static void BuildingClass_Shake_Screen(BuildingClass *building)
         int shakes = std::min(building->Class->Cost_Of() / Rule->ShakeScreen, 6);
         //int shakes = building->Class->Cost_Of() / Rule->ShakeScreen;
         if (shakes > 0) {
-            Shake_The_Screen(shakes);
+
+            /**
+             *  #issue-414
+             * 
+             *  Restores the vertical screen shake when a strong building is destroyed.
+             * 
+             *  @author: CCHyper
+             */
+            Map.ScreenY = shakes;
+
+            //Shake_The_Screen(shakes);
         }
 
     }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -31,6 +31,8 @@
 #include "building.h"
 #include "buildingtype.h"
 #include "buildingtypeext.h"
+#include "technotype.h"
+#include "technotypeext.h"
 #include "dsurface.h"
 #include "convert.h"
 #include "drawshape.h"
@@ -140,26 +142,46 @@ DECLARE_PATCH(_BuildingClass_Mission_Open_Gate_Close_Sound_Patch)
  */
 static void BuildingClass_Shake_Screen(BuildingClass *building)
 {
+    TechnoTypeClass *technotype;
+    TechnoTypeClassExtension *technotypeext;
+
     /**
-     *  Make sure both the screen shake factor and the buildings cost
-     *  are valid before performing the division.
+     *  Fetch the extended techno type instance if it exists.
      */
-    if (Rule->ShakeScreen > 0 && building->Class->Cost_Of() > 0) {
+    technotype = building->Techno_Type_Class();
+    technotypeext = TechnoTypeClassExtensions.find(technotype);
 
-        int shakes = std::min(building->Class->Cost_Of() / Rule->ShakeScreen, 6);
-        //int shakes = building->Class->Cost_Of() / Rule->ShakeScreen;
-        if (shakes > 0) {
+    /**
+     *  #issue-414
+     * 
+     *  Can this unit shake the screen when it is destroyed?
+     * 
+     *  @author: CCHyper
+     */
+    if (technotypeext && technotypeext->IsShakeScreen) {
 
-            /**
-             *  #issue-414
-             * 
-             *  Restores the vertical screen shake when a strong building is destroyed.
-             * 
-             *  @author: CCHyper
-             */
-            Map.ScreenY = shakes;
+        /**
+         *  Make sure both the screen shake factor and the buildings cost
+         *  are valid before performing the division.
+         */
+        if (Rule->ShakeScreen > 0 && building->Class->Cost_Of() > 0) {
 
-            //Shake_The_Screen(shakes);
+            int shakes = std::min(building->Class->Cost_Of() / Rule->ShakeScreen, 6);
+            //int shakes = building->Class->Cost_Of() / Rule->ShakeScreen;
+            if (shakes > 0) {
+
+                /**
+                 *  #issue-414
+                 * 
+                 *  Restores the vertical screen shake when a strong building is destroyed.
+                 * 
+                 *  @author: CCHyper
+                 */
+                Map.ScreenY = shakes;
+
+                //Shake_The_Screen(shakes);
+            }
+
         }
 
     }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -161,25 +161,43 @@ static void BuildingClass_Shake_Screen(BuildingClass *building)
     if (technotypeext && technotypeext->IsShakeScreen) {
 
         /**
-         *  Make sure both the screen shake factor and the buildings cost
-         *  are valid before performing the division.
+         *  If this building has screen shake values defined, then set the blitter
+         *  offset values. GScreenClass::Blit will handle the rest for us.
          */
-        if (Rule->ShakeScreen > 0 && building->Class->Cost_Of() > 0) {
+        if ((technotypeext->ShakePixelXLo > 0 || technotypeext->ShakePixelXHi > 0)
+         || (technotypeext->ShakePixelYLo > 0 || technotypeext->ShakePixelYHi > 0)) {
 
-            int shakes = std::min(building->Class->Cost_Of() / Rule->ShakeScreen, 6);
-            //int shakes = building->Class->Cost_Of() / Rule->ShakeScreen;
-            if (shakes > 0) {
+            if (technotypeext->ShakePixelXLo > 0 || technotypeext->ShakePixelXHi > 0) {
+                Map.ScreenX = Sim_Random_Pick(technotypeext->ShakePixelXLo, technotypeext->ShakePixelXHi);
+            }
+            if (technotypeext->ShakePixelYLo > 0 || technotypeext->ShakePixelYHi > 0) {
+                Map.ScreenY = Sim_Random_Pick(technotypeext->ShakePixelYLo, technotypeext->ShakePixelYHi);
+            }
 
-                /**
-                 *  #issue-414
-                 * 
-                 *  Restores the vertical screen shake when a strong building is destroyed.
-                 * 
-                 *  @author: CCHyper
-                 */
-                Map.ScreenY = shakes;
+        } else {
 
-                //Shake_The_Screen(shakes);
+            /**
+             *  Make sure both the screen shake factor and the buildings cost
+             *  are valid before performing the division.
+             */
+            if (Rule->ShakeScreen > 0 && building->Class->Cost_Of() > 0) {
+
+                int shakes = std::min(building->Class->Cost_Of() / Rule->ShakeScreen, 6);
+                //int shakes = building->Class->Cost_Of() / Rule->ShakeScreen;
+                if (shakes > 0) {
+
+                    /**
+                     *  #issue-414
+                     * 
+                     *  Restores the vertical screen shake when a strong building is destroyed.
+                     * 
+                     *  @author: CCHyper
+                     */
+                    Map.ScreenY = shakes;
+
+                    //Shake_The_Screen(shakes);
+                }
+
             }
 
         }

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -70,7 +70,6 @@
 #include "technoext_hooks.h"
 #include "footext_hooks.h"
 #include "unitext_hooks.h"
-#include "aircraftext_hooks.h"
 #include "buildingext_hooks.h"
 #include "aircraftext_hooks.h"
 #include "infantryext_hooks.h"
@@ -138,15 +137,14 @@ void Extension_Hooks()
     //TriggerTypeClassExtension_Hooks();
 
     TechnoClassExtension_Hooks();
-    FootClassExtension_Hooks();
     UnitClassExtension_Hooks();
     AircraftClassExtension_Hooks();
     InfantryClassExtension_Hooks();
     BuildingClassExtension_Hooks();
-    AircraftClassExtension_Hooks();
     HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
     FactoryClassExtension_Hooks();
+    FootClassExtension_Hooks();
 
     DropshipExtension_Hooks();
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -47,7 +47,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     Extension(this_ptr),
 
     CloakSound(VOC_NONE),
-    UncloakSound(VOC_NONE)
+    UncloakSound(VOC_NONE),
+    IsShakeScreen(false)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TechnoTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -158,6 +159,8 @@ void TechnoTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TechnoTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    crc(IsShakeScreen);
 }
 
 
@@ -180,6 +183,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     
     CloakSound = ini.Get_VocType(ini_name, "CloakSound", CloakSound);
     UncloakSound = ini.Get_VocType(ini_name, "UncloakSound", UncloakSound);
+    IsShakeScreen = ini.Get_Bool(ini_name, "CanShakeScreen", IsShakeScreen);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -48,7 +48,11 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
 
     CloakSound(VOC_NONE),
     UncloakSound(VOC_NONE),
-    IsShakeScreen(false)
+    IsShakeScreen(false),
+    ShakePixelYHi(0),
+    ShakePixelYLo(0),
+    ShakePixelXHi(0),
+    ShakePixelXLo(0)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TechnoTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -161,6 +165,10 @@ void TechnoTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     //DEV_DEBUG_TRACE("TechnoTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
 
     crc(IsShakeScreen);
+    crc(ShakePixelYHi);
+    crc(ShakePixelYLo);
+    crc(ShakePixelXHi);
+    crc(ShakePixelXLo);
 }
 
 
@@ -184,6 +192,10 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     CloakSound = ini.Get_VocType(ini_name, "CloakSound", CloakSound);
     UncloakSound = ini.Get_VocType(ini_name, "UncloakSound", UncloakSound);
     IsShakeScreen = ini.Get_Bool(ini_name, "CanShakeScreen", IsShakeScreen);
+    ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
+    ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
+    ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);
+    ShakePixelXLo = ini.Get_Int(ini_name, "ShakeXlo", ShakePixelXLo);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -62,6 +62,12 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
          *  This is the sound effect to play when the unit is decloaking.
          */
         VocType UncloakSound;
+
+        /**
+         *  Can this object shake the screen when it is destroyed?
+         *  (Must meet the rules as specified by Rule->ShakeScreen.
+         */
+        bool IsShakeScreen;
 };
 
 

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -68,6 +68,14 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
          *  (Must meet the rules as specified by Rule->ShakeScreen.
          */
         bool IsShakeScreen;
+
+        /**
+         *  These values are used to shake the screen when the object is destroyed.
+         */
+        unsigned int ShakePixelYHi;
+        unsigned int ShakePixelYLo;
+        unsigned int ShakePixelXHi;
+        unsigned int ShakePixelXLo;
 };
 
 

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -33,6 +33,7 @@
 #include "unittype.h"
 #include "target.h"
 #include "rules.h"
+#include "iomap.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -64,7 +65,17 @@ static void UnitClass_Shake_Screen(UnitClass *unit)
         if (Rule->ShakeScreen > 0 && unit->Class->MaxStrength > 0) {
 
             int shakes = std::min<int>(unit->Class->MaxStrength / (Rule->ShakeScreen/2), 6);
-            Shake_The_Screen(shakes);
+
+            /**
+             *  #issue-414
+             * 
+             *  Restores the vertical screen shake when a strong unit is destroyed.
+             * 
+             *  @author: CCHyper
+             */
+            Map.ScreenY = shakes;
+
+            //Shake_The_Screen(shakes);
         }
     }
 }

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -29,6 +29,8 @@
 #include "vinifera_globals.h"
 #include "tibsun_globals.h"
 #include "tibsun_functions.h"
+#include "technotype.h"
+#include "technotypeext.h"
 #include "unit.h"
 #include "unittype.h"
 #include "target.h"
@@ -52,31 +54,51 @@
  */
 static void UnitClass_Shake_Screen(UnitClass *unit)
 {
+    TechnoTypeClass *technotype;
+    TechnoTypeClassExtension *technotypeext;
+
     /**
-     *  Very strong units that have an explosion will also rock the
-     *  screen when they are destroyed.
+     *  Fetch the extended techno type instance if it exists.
      */
-    if (unit->Class->MaxStrength > Rule->ShakeScreen) {
+    technotype = unit->Techno_Type_Class();
+    technotypeext = TechnoTypeClassExtensions.find(technotype);
+
+    /**
+     *  #issue-414
+     * 
+     *  Can this unit shake the screen when it is destroyed?
+     * 
+     *  @author: CCHyper
+     */
+    if (technotypeext && technotypeext->IsShakeScreen) {
 
         /**
-         *  Make sure both the screen shake factor and the units strength
-         *  are valid before performing the division.
+         *  Very strong units that have an explosion will also rock the
+         *  screen when they are destroyed.
          */
-        if (Rule->ShakeScreen > 0 && unit->Class->MaxStrength > 0) {
-
-            int shakes = std::min<int>(unit->Class->MaxStrength / (Rule->ShakeScreen/2), 6);
+        if (unit->Class->MaxStrength > Rule->ShakeScreen) {
 
             /**
-             *  #issue-414
-             * 
-             *  Restores the vertical screen shake when a strong unit is destroyed.
-             * 
-             *  @author: CCHyper
+             *  Make sure both the screen shake factor and the units strength
+             *  are valid before performing the division.
              */
-            Map.ScreenY = shakes;
+            if (Rule->ShakeScreen > 0 && unit->Class->MaxStrength > 0) {
 
-            //Shake_The_Screen(shakes);
+                int shakes = std::min<int>(unit->Class->MaxStrength / (Rule->ShakeScreen/2), 6);
+
+                /**
+                 *  #issue-414
+                 * 
+                 *  Restores the vertical screen shake when a strong unit is destroyed.
+                 * 
+                 *  @author: CCHyper
+                 */
+                Map.ScreenY = shakes;
+
+                //Shake_The_Screen(shakes);
+            }
         }
+
     }
 }
 

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -73,30 +73,49 @@ static void UnitClass_Shake_Screen(UnitClass *unit)
     if (technotypeext && technotypeext->IsShakeScreen) {
 
         /**
-         *  Very strong units that have an explosion will also rock the
-         *  screen when they are destroyed.
+         *  If this unit has screen shake values defined, then set the blitter
+         *  offset values. GScreenClass::Blit will handle the rest for us.
          */
-        if (unit->Class->MaxStrength > Rule->ShakeScreen) {
+        if ((technotypeext->ShakePixelXLo > 0 || technotypeext->ShakePixelXHi > 0)
+         || (technotypeext->ShakePixelYLo > 0 || technotypeext->ShakePixelYHi > 0)) {
+
+            if (technotypeext->ShakePixelXLo > 0 || technotypeext->ShakePixelXHi > 0) {
+                Map.ScreenX = Sim_Random_Pick(technotypeext->ShakePixelXLo, technotypeext->ShakePixelXHi);
+            }
+            if (technotypeext->ShakePixelYLo > 0 || technotypeext->ShakePixelYHi > 0) {
+                Map.ScreenY = Sim_Random_Pick(technotypeext->ShakePixelYLo, technotypeext->ShakePixelYHi);
+            }
+
+        } else {
 
             /**
-             *  Make sure both the screen shake factor and the units strength
-             *  are valid before performing the division.
+             *  Very strong units that have an explosion will also rock the
+             *  screen when they are destroyed.
              */
-            if (Rule->ShakeScreen > 0 && unit->Class->MaxStrength > 0) {
-
-                int shakes = std::min<int>(unit->Class->MaxStrength / (Rule->ShakeScreen/2), 6);
+            if (unit->Class->MaxStrength > Rule->ShakeScreen) {
 
                 /**
-                 *  #issue-414
-                 * 
-                 *  Restores the vertical screen shake when a strong unit is destroyed.
-                 * 
-                 *  @author: CCHyper
+                 *  Make sure both the screen shake factor and the units strength
+                 *  are valid before performing the division.
                  */
-                Map.ScreenY = shakes;
+                if (Rule->ShakeScreen > 0 && unit->Class->MaxStrength > 0) {
 
-                //Shake_The_Screen(shakes);
+                    int shakes = std::min<int>(unit->Class->MaxStrength / (Rule->ShakeScreen/2), 6);
+
+                    /**
+                     *  #issue-414
+                     * 
+                     *  Restores the vertical screen shake when a strong unit is destroyed.
+                     * 
+                     *  @author: CCHyper
+                     */
+                    Map.ScreenY = shakes;
+
+                    //Shake_The_Screen(shakes);
+                }
+
             }
+
         }
 
     }


### PR DESCRIPTION
Closes #414

This pull request restores the screen shake when a strong unit or building is destroyed. In addition to this, it also implements new options to control the amount the screen moves.

**`CanShakeScreen=<boolean>`**
Can this unit or building cause the screen to shake the screen when it dies? Defaults to `no`.
**NOTE:** _Object must meet the rules as specified by `ShakeScreen=` in `[AudioVisual]`._

**Shake Screen Controls**
These values are used to shake the screen when the unit or building is destroyed. All of these values default to `0` and do not support negative values.
`ShakeYhi=<integer>` - The maximum pixel Y value.
`ShakeYlo=<integer>` - The minimum pixel Y value.
`ShakeXhi=<integer>` - The maximum pixel X value.
`ShakeXlo=<integer>` - The minimum pixel X value.
