### PR TITLE
Implements CloakSound and UncloakSound for TechnoTypes.

### DIFF
--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -67,6 +67,8 @@
 //#include "tagtypeext_hooks.h"
 //#include "triggertypeext_hooks.h"
 
+#include "technoext_hooks.h"
+#include "footext_hooks.h"
 #include "unitext_hooks.h"
 #include "aircraftext_hooks.h"
 #include "buildingext_hooks.h"
@@ -74,7 +76,6 @@
 #include "houseext_hooks.h"
 #include "teamext_hooks.h"
 #include "factoryext_hooks.h"
-#include "footext_hooks.h"
 
 #include "dropshipext_hooks.h"
 
@@ -135,6 +136,8 @@ void Extension_Hooks()
     //TagTypeClassExtension_Hooks();
     //TriggerTypeClassExtension_Hooks();
 
+    TechnoClassExtension_Hooks();
+    FootClassExtension_Hooks();
     UnitClassExtension_Hooks();
     AircraftClassExtension_Hooks();
     InfantryClassExtension_Hooks();
@@ -142,7 +145,6 @@ void Extension_Hooks()
     HouseClassExtension_Hooks();
     TeamClassExtension_Hooks();
     FactoryClassExtension_Hooks();
-    FootClassExtension_Hooks();
 
     DropshipExtension_Hooks();
 

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TECHNOEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended TechnoClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "technoext_hooks.h"
+#include "techno.h"
+#include "technotype.h"
+#include "technotypeext.h"
+#include "rules.h"
+#include "voc.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  #issue-356
+ * 
+ *  Custom cloaking sound for TechnoTypes.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Do_Cloak_Cloak_Sound_Patch)
+{
+    GET_REGISTER_STATIC(Coordinate *, coord, eax);
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    static TechnoTypeClass *technotype;
+    static TechnoTypeClassExtension *technotypeext;
+    static VocType voc;
+
+    technotype = this_ptr->Techno_Type_Class();
+
+    /**
+     *  Fetch the default cloaking sound.
+     */
+    voc = Rule->CloakSound;
+
+    /**
+     *  Fetch the class extension if it exists.
+     */
+    technotypeext = TechnoTypeClassExtensions.find(technotype);
+    if (technotypeext) {
+
+        /**
+         *  Does this object have a custom cloaking sound? If so, use it.
+         */
+        if (technotypeext->CloakSound != VOC_NONE) {
+            voc = technotypeext->CloakSound;
+        }
+    }
+
+    /**
+     *  Play the sound effect at the objects location.
+     */
+    Sound_Effect(voc, *coord);
+
+    JMP(0x00633C8B);
+}
+
+
+/**
+ *  #issue-356
+ * 
+ *  Custom uncloaking sound for TechnoTypes.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch)
+{
+    GET_REGISTER_STATIC(Coordinate *, coord, eax);
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    static TechnoTypeClass *technotype;
+    static TechnoTypeClassExtension *technotypeext;
+    static VocType voc;
+
+    technotype = this_ptr->Techno_Type_Class();
+
+    /**
+     *  Fetch the default cloaking sound.
+     */
+    voc = Rule->CloakSound;
+
+    /**
+     *  Fetch the class extension if it exists.
+     */
+    technotypeext = TechnoTypeClassExtensions.find(technotype);
+    if (technotypeext) {
+
+        /**
+         *  Does this object have a custom decloaking sound? If so, use it.
+         */
+        if (technotypeext->UncloakSound != VOC_NONE) {
+            voc = technotypeext->UncloakSound;
+        }
+    }
+
+    /**
+     *  Play the sound effect at the objects location.
+     */
+    Sound_Effect(voc, *coord);
+
+    JMP(0x00633BE7);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void TechnoClassExtension_Hooks()
+{
+    Patch_Jump(0x00633C78, &_TechnoClass_Do_Cloak_Cloak_Sound_Patch);
+    Patch_Jump(0x00633BD4, &_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch);
+}

--- a/src/extensions/techno/technoext_hooks.h
+++ b/src/extensions/techno/technoext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          TECHNOTYPEEXT.H
+ *  @file          TECHNOEXT_HOOKS.H
  *
  *  @author        CCHyper
  *
- *  @brief         Extended TechnoTypeClass class.
+ *  @brief         Contains the hooks for the extended TechnoClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,42 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "extension.h"
-#include "container.h"
-#include "tibsun_defines.h"
 
-
-class TechnoTypeClass;
-class CCINIClass;
-
-
-class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
-{
-    public:
-        TechnoTypeClassExtension(TechnoTypeClass *this_ptr);
-        TechnoTypeClassExtension(const NoInitClass &noinit);
-        ~TechnoTypeClassExtension();
-
-        virtual HRESULT Load(IStream *pStm) override;
-        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
-        virtual int Size_Of() const override;
-
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
-
-        bool Read_INI(CCINIClass &ini);
-
-    public:
-        /**
-         *  This is the sound effect to play when the unit is cloaking.
-         */
-        VocType CloakSound;
-
-        /**
-         *  This is the sound effect to play when the unit is decloaking.
-         */
-        VocType UncloakSound;
-};
-
-
-extern ExtensionMap<TechnoTypeClass, TechnoTypeClassExtension> TechnoTypeClassExtensions;
+void TechnoClassExtension_Hooks();

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -44,7 +44,10 @@ ExtensionMap<TechnoTypeClass, TechnoTypeClassExtension> TechnoTypeClassExtension
  *  @author: CCHyper
  */
 TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    CloakSound(VOC_NONE),
+    UncloakSound(VOC_NONE)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TechnoTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -175,5 +178,8 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
         return false;
     }
     
+    CloakSound = ini.Get_VocType(ini_name, "CloakSound", CloakSound);
+    UncloakSound = ini.Get_VocType(ini_name, "UncloakSound", UncloakSound);
+
     return true;
 }


### PR DESCRIPTION
Closes #356

This pull request implements Cloaking and Uncloaking sound overrides to TechnoTypes.

**`CloakSound=<Sound>`**
The sound effect to play when the object is cloaking. Defaults to `<none>` _(Uses the `CloakSound=` from `[AudioVisual]`)_.

**`UncloakSound=<Sound>`**
The sound effect to play when the object is decloaking. Defaults to `<none>` _(Uses the `CloakSound=` from `[AudioVisual]`)_.
