### PR TITLE
Adds keyboard commands for playing previous and next music tracks in the jukebox.

### DIFF
--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -26,6 +26,7 @@
  *
  ******************************************************************************/
 #include "commandext.h"
+#include "commandext_functions.h"
 #include "tibsun_globals.h"
 #include "tibsun_util.h"
 #include "vinifera_globals.h"
@@ -275,6 +276,72 @@ bool ManualPlaceCommandClass::Process()
      *  Go into placement mode.
      */
     return PlayerPtr->Manual_Place(builder, pending_bptr);
+}
+
+
+/**
+ *  Skip to the previous playable music track.
+ * 
+ *  @author: CCHyper
+ */
+const char *PrevThemeCommandClass::Get_Name() const
+{
+    return "PrevTheme";
+}
+
+const char *PrevThemeCommandClass::Get_UI_Name() const
+{
+    return "Music: Previous Track";
+}
+
+const char *PrevThemeCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *PrevThemeCommandClass::Get_Description() const
+{
+    return "Play the previous music track in the jukebox.";
+}
+
+bool PrevThemeCommandClass::Process()
+{
+    Prev_Theme_Command();
+
+    return true;
+}
+
+
+/**
+ *  Skip to the next playable music track.
+ * 
+ *  @author: CCHyper
+ */
+const char *NextThemeCommandClass::Get_Name() const
+{
+    return "NextTheme";
+}
+
+const char *NextThemeCommandClass::Get_UI_Name() const
+{
+    return "Music: Next Track";
+}
+
+const char *NextThemeCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *NextThemeCommandClass::Get_Description() const
+{
+    return "Play the next music track in the jukebox.";
+}
+
+bool NextThemeCommandClass::Process()
+{
+    Next_Theme_Command();
+
+    return true;
 }
 
 

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -94,6 +94,44 @@ class ManualPlaceCommandClass : public ViniferaCommandClass
 
 
 /**
+ *  Skip to the previous playable music track.
+ */
+class PrevThemeCommandClass : public ViniferaCommandClass
+{
+    public:
+        PrevThemeCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~PrevThemeCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_LBRACKET); }
+};
+
+
+/**
+ *  Skip to the next playable music track.
+ */
+class NextThemeCommandClass : public ViniferaCommandClass
+{
+    public:
+        NextThemeCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~NextThemeCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_RBRACKET); }
+};
+
+
+/**
  *  Produces a memory dump on request.
  */
 class MemoryDumpCommandClass : public ViniferaCommandClass

--- a/src/extensions/command/commandext_functions.cpp
+++ b/src/extensions/command/commandext_functions.cpp
@@ -1,0 +1,156 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          COMMANDEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended command class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "commandext_functions.h"
+#include "tibsun_defines.h"
+#include "tibsun_globals.h"
+#include "theme.h"
+#include "rules.h"
+#include "tacticalext.h"
+#include "tactical.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+
+/**
+ *  Skips to the previous available music track allowed.
+ * 
+ *  @author: CCHyper
+ */
+bool Prev_Theme_Command()
+{
+    ThemeType theme = Theme.What_Is_Playing();
+
+    /**
+     *  Iterate backward from the current theme and find the next available
+     *  music track we can play.
+     */
+    while (theme >= THEME_FIRST) {
+
+        --theme;
+
+        if (theme < THEME_FIRST) {
+            theme = ThemeType(Theme.Max_Themes());
+        }
+
+        if (Theme.Is_Allowed(theme)) {
+            break;
+        }
+
+    }
+
+    /**
+     *  Queue the track for playback. We need to stop the track first
+     *  otherwise Queue_Song() will fade the track out.
+     */
+    Theme.Stop();
+    Theme.Queue_Song(theme);
+
+    /**
+     *  Print the chosen music track name on the screen.
+     */
+    if (TacticalExtension) {
+
+        TacticalExtension->InfoTextTimer.Stop();
+
+        char buffer[256];
+        std::snprintf(buffer, sizeof(buffer), "Now Playing: %s", Theme.ThemeClass::Full_Name(theme));
+
+        TacticalExtension->InfoTextBuffer = buffer;
+        TacticalExtension->IsInfoTextSet = true;
+
+        TacticalExtension->InfoTextPosition = InfoTextPosType::BOTTOM_LEFT;
+
+        //TacticalExtension->InfoTextNotifySound = Rule->OptionsChanged;
+        //TacticalExtension->InfoTextNotifySoundVolume = 0.5f;
+
+        TacticalExtension->InfoTextTimer = SECONDS_TO_MILLISECONDS(4);
+        TacticalExtension->InfoTextTimer.Start();
+    }
+
+    return true;
+}
+
+
+/**
+ *  Skips to the next available music track allowed.
+ * 
+ *  @author: CCHyper
+ */
+bool Next_Theme_Command()
+{
+    ThemeType theme = Theme.What_Is_Playing();
+
+    /**
+     *  Iterate forward from the current theme and find the next available
+     *  music track we can play.
+     */
+    while (theme < ThemeType(Theme.Max_Themes())) {
+
+        ++theme;
+
+        if (theme >= ThemeType(Theme.Max_Themes())) {
+            theme = ThemeType(THEME_FIRST);
+        }
+
+        if (Theme.Is_Allowed(theme)) {
+            break;
+        }
+
+    }
+
+    /**
+     *  Queue the track for playback. We need to stop the track first
+     *  otherwise Queue_Song() will fade the track out.
+     */
+    Theme.Stop();
+    Theme.Queue_Song(theme);
+
+    /**
+     *  Print the chosen music track name on the screen.
+     */
+    if (TacticalExtension) {
+
+        TacticalExtension->InfoTextTimer.Stop();
+
+        char buffer[256];
+        std::snprintf(buffer, sizeof(buffer), "Now Playing: %s", Theme.ThemeClass::Full_Name(theme));
+
+        TacticalExtension->InfoTextBuffer = buffer;
+        TacticalExtension->IsInfoTextSet = true;
+        
+        TacticalExtension->InfoTextPosition = InfoTextPosType::BOTTOM_LEFT;
+
+        //TacticalExtension->InfoTextNotifySound = Rule->OptionsChanged;
+        //TacticalExtension->InfoTextNotifySoundVolume = 0.5f;
+
+        TacticalExtension->InfoTextTimer = SECONDS_TO_MILLISECONDS(4);
+        TacticalExtension->InfoTextTimer.Start();
+    }
+
+    return true;
+}

--- a/src/extensions/command/commandext_functions.h
+++ b/src/extensions/command/commandext_functions.h
@@ -1,0 +1,32 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          COMMANDEXT_FUNCTIONS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended command class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+bool Prev_Theme_Command();
+bool Next_Theme_Command();

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -141,7 +141,13 @@ void Init_Vinifera_Commands()
 
     cmdptr = new ManualPlaceCommandClass;
     Commands.Add(cmdptr);
-    
+
+    cmdptr = new PrevThemeCommandClass;
+    Commands.Add(cmdptr);
+
+    cmdptr = new NextThemeCommandClass;
+    Commands.Add(cmdptr);
+
     /**
      *  Next, initialised any new commands here if the developer mode is enabled.
      */
@@ -291,6 +297,22 @@ static void Process_Vinifera_Hotkeys()
 
     if (!ini.Is_Present("Hotkey", "ManualPlace")) {
         cmdptr = CommandClass::From_Name("ManualPlace");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "PrevTheme")) {
+        cmdptr = CommandClass::From_Name("PrevTheme");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "NextTheme")) {
+        cmdptr = CommandClass::From_Name("NextTheme");
         if (cmdptr) {
             key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
             HotkeyIndex.Add_Index(key, cmdptr);

--- a/src/extensions/tactical/tacticalext.cpp
+++ b/src/extensions/tactical/tacticalext.cpp
@@ -41,7 +41,15 @@ TacticalMapExtension *TacticalExtension = nullptr;
  *  @author: CCHyper
  */
 TacticalMapExtension::TacticalMapExtension(Tactical *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    IsInfoTextSet(false),
+    InfoTextBuffer(),
+    InfoTextPosition(BOTTOM_LEFT),
+    InfoTextNotifySound(VOC_NONE),
+    InfoTextNotifySoundVolume(1.0f),
+    InfoTextStyle(TPF_6PT_GRAD|TPF_DROPSHADOW),
+    InfoTextTimer(0)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TacticalMapExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -57,7 +65,10 @@ TacticalMapExtension::TacticalMapExtension(Tactical *this_ptr) :
  *  @author: CCHyper
  */
 TacticalMapExtension::TacticalMapExtension(const NoInitClass &noinit) :
-    Extension(noinit)
+    Extension(noinit),
+
+    IsInfoTextSet(false),
+    InfoTextTimer(noinit)
 {
     IsInitialized = false;
 }

--- a/src/extensions/tactical/tacticalext.h
+++ b/src/extensions/tactical/tacticalext.h
@@ -28,10 +28,23 @@
 #pragma once
 
 #include "extension.h"
+#include "ttimer.h"
+#include "stimer.h"
+#include "wstring.h"
+#include "point.h"
+#include "textprint.h"
 
 
 class Tactical;
 class HouseClass;
+
+
+enum InfoTextPosType {
+    TOP_LEFT,
+    TOP_RIGHT,
+    BOTTOM_LEFT,
+    BOTTOM_RIGHT,
+};
 
 
 /**
@@ -52,6 +65,40 @@ class TacticalMapExtension final : public Extension<Tactical>
         virtual void Compute_CRC(WWCRCEngine &crc) const override;
 
     public:
+        /**
+         *  Has information text been set?
+         */
+        bool IsInfoTextSet;
+
+        /**
+         *  The information text to print on the screen.
+         */
+        Wstring InfoTextBuffer;
+
+        /**
+         *  Where on the screen shall the text be printed?
+         */
+        InfoTextPosType InfoTextPosition;
+
+        /**
+         *  Sound to play when this text is initially drawn.
+         */
+        VocType InfoTextNotifySound;
+
+        /**
+         *  Volume at which to play the initial sound.
+         */
+        float InfoTextNotifySoundVolume;
+
+        /**
+         *  The font style of the print text.
+         */
+        TextPrintType InfoTextStyle;
+
+        /**
+         *  The lifetime timer for the information text.
+         */
+        CDTimerClass<MSTimerClass> InfoTextTimer;
 };
 
 


### PR DESCRIPTION
This pull request implement a nice QoL feature which allows the user to play the previous or next music track in the games jukebox queue using the keyboard.

The game will also show a handy **_"Now Playing..."_** tooltip on the bottom left of the screen to indicate the title of the track the user has skipped to.

![image](https://user-images.githubusercontent.com/73803386/123566309-4ade4600-d7b7-11eb-9b77-5c9de7959822.png)

These keyboard commands default to the **"["** _(Previous)_ and **"]"** _(Next)_ keys.