### PR TITLE
 Adds command line options to skip to specific game modes and to skip startup movies.

### DIFF
--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -32,6 +32,7 @@
 /**
  *  Extended classes here.
  */
+#include "initext_hooks.h"
 #include "mainloopext_hooks.h"
 
 #include "tacticalext_hooks.h"
@@ -97,6 +98,7 @@ void Extension_Hooks()
     /**
      *  Various functions.
      */
+    GameInit_Hooks();
     MainLoop_Hooks();
 
     /**

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -34,6 +34,7 @@
  */
 #include "initext_hooks.h"
 #include "mainloopext_hooks.h"
+#include "newmenuext_hooks.h"
 
 #include "tacticalext_hooks.h"
 #include "scenarioext_hooks.h"
@@ -100,6 +101,7 @@ void Extension_Hooks()
      */
     GameInit_Hooks();
     MainLoop_Hooks();
+    NewMenuExtension_Hooks();
 
     /**
      *  All class extensions here.

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -74,9 +74,9 @@ DECLARE_PATCH(_Init_Game_Skip_Startup_Movies_Patch)
 
     if (!NewMenuClass::Get()) {
         if (CCFile_Is_Available("FS_TITLE.VQA")) {
-            Play_Movie("FS_TITLE.VQA", THEME_NONE, true, true, true);
+            Play_Movie("FS_TITLE.VQA", THEME_NONE, true, false, true);
         } else {
-            Play_Movie("STARTUP.VQA", THEME_NONE, true, true, true);
+            Play_Movie("STARTUP.VQA", THEME_NONE, true, false, true);
         }
     }
 

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -1,0 +1,98 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          INITEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains any hooks for the game init process.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "initext_hooks.h"
+#include "vinifera_globals.h"
+#include "tibsun_globals.h"
+#include "special.h"
+#include "playmovie.h"
+#include "ccfile.h"
+#include "newmenu.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+static bool CCFile_Is_Available(const char *filename)
+{
+    return CCFileClass(filename).Is_Available();
+}
+
+
+/**
+ *  #issue-478
+ * 
+ *  
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Init_Game_Skip_Startup_Movies_Patch)
+{
+    if (Vinifera_SkipStartupMovies) {
+        DEBUG_INFO("Skipping startup movies.\n");
+        goto skip_loading_screen;
+    }
+
+    if (Special.IsFromInstall) {
+        DEBUG_GAME("Playing first time intro sequence.\n");
+        Play_Movie("EVA.VQA", THEME_NONE, true, true, true);
+    }
+
+    if (!Vinifera_SkipWWLogoMovie) {
+        DEBUG_GAME("Playing startup movies.\n");
+        Play_Movie("WWLOGO.VQA", THEME_NONE, true, true, true);
+    } else {
+        DEBUG_INFO("Skipping startup movie.\n");
+    }
+
+    if (!NewMenuClass::Get()) {
+        if (CCFile_Is_Available("FS_TITLE.VQA")) {
+            Play_Movie("FS_TITLE.VQA", THEME_NONE, true, true, true);
+        } else {
+            Play_Movie("STARTUP.VQA", THEME_NONE, true, true, true);
+        }
+    }
+
+loading_screen:
+    _asm { or ebx, 0xFFFFFFFF }
+    JMP(0x004E0848);
+
+skip_loading_screen:
+    JMP(0x004E084D);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void GameInit_Hooks()
+{
+    Patch_Jump(0x004E0786, &_Init_Game_Skip_Startup_Movies_Patch);
+}

--- a/src/extensions/init/initext_hooks.h
+++ b/src/extensions/init/initext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          VINIFERA_GLOBALS.CPP
+ *  @file          INITEXT_HOOKS.H
  *
- *  @authors       CCHyper
+ *  @author        CCHyper
  *
- *  @brief         Vinifera global values.
+ *  @brief         Contains any hooks for the game init process.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,21 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "vinifera_globals.h"
 
-
-bool Vinifera_DeveloperMode = false;
-
-char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
-
-bool Vinifera_Developer_InstantBuild = false;
-bool Vinifera_Developer_AIInstantBuild = false;
-bool Vinifera_Developer_BuildCheat = false;
-bool Vinifera_Developer_Unshroud = false;
-bool Vinifera_Developer_ShowCursorPosition = false;
-bool Vinifera_Developer_FrameStep = false;
-int Vinifera_Developer_FrameStepCount = 0;
-bool Vinifera_Developer_AIControl = false;
-
-bool Vinifera_SkipWWLogoMovie = false;
-bool Vinifera_SkipStartupMovies = false;
+void GameInit_Hooks();

--- a/src/extensions/newmenu/newmenuext_hooks.cpp
+++ b/src/extensions/newmenu/newmenuext_hooks.cpp
@@ -1,0 +1,238 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          NEWMENUEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended NewMenuClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "initext_hooks.h"
+#include "vinifera_globals.h"
+#include "tibsun_functions.h"
+#include "tibsun_globals.h"
+#include "iomap.h"
+#include "newmenu.h"
+#include "session.h"
+#include "cd.h"
+#include "addon.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Have we performed the menu skip?
+ */
+static bool MenuSkipDone = false;
+
+
+/**
+ *  Force draw the title screen background.
+ * 
+ *  @author: CCHyper
+ */
+static void Draw_Title_Screen(bool firestorm)
+{
+    Load_Title_Screen(firestorm ? "FSTBACK.PCX" : "TSTBACK.PCX", (XSurface *)HiddenSurface, &OriginalPalette);
+    GScreenClass::Blit(false, (Surface *)HiddenSurface);
+}
+
+
+/**
+ *  Set the addon mode values. This will also set the Firestorm
+ *  disk if firestorm mode is requested.
+ * 
+ *  @author: CCHyper
+ */
+static void Set_Addon_Mode(bool firestorm)
+{
+    Addon_4071C0(-1);
+
+    if (firestorm) {
+         Addon_407190(1);
+    }
+
+    Set_Required_Addon(firestorm ? ADDON_FIRESTORM : ADDON_NONE);
+
+    if (firestorm) {
+        CD::Set_Required_CD(DISK_FIRESTORM);
+        CD().Is_Available(DISK_FIRESTORM);
+        Session.Read_Scenario_Descriptions();
+    }
+}
+
+
+/**
+ *  #issue-241
+ * 
+ *  Patch to allow skipping directly to game mode or dialogs.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_NewMenuClass_Process_SkipToMenus_Patch)
+{
+    GET_REGISTER_STATIC(NewMenuClass *, newmenu, ecx);
+    static int gamemode;
+    static int mode;
+
+    /**
+     *  -1 = Game Select
+     *   0 = Tiberian Sun
+     *   1 = Firestorm
+     */
+    gamemode = -1;           // Default to Game Select.
+
+    /**
+     *  0 = Exit
+     *  1 = Campaign
+     *  2 = Load
+     *  3 = Network
+     *  4 = Internet
+     *  5 = Modem
+     *  6 = Skirmish
+     *  7 = WDT
+     *  8 = Options
+     *  9 = Network Load
+     *  10 = Intro/Sneak Peak
+     *  11 = Version
+     *  12 = Credits
+     *  13 = Main Menu
+     */
+    mode = 0;               // Default to Exit.
+
+    if (Vinifera_SkipToTSMenu) {
+        DEBUG_INFO("Skipping to the Tiberian Sun menu.\n");
+        Vinifera_SkipToTSMenu = false;
+        Set_Addon_Mode(false);
+        gamemode = 0;
+    }
+
+    if (Vinifera_SkipToFSMenu) {
+        DEBUG_INFO("Skipping to the Firestorm menu.\n");
+        Vinifera_SkipToFSMenu = false;
+        Set_Addon_Mode(true);
+        gamemode = 1;
+    }
+
+    if (Vinifera_SkipToLAN) {
+        DEBUG_INFO("Skipping to the LAN dialog.\n");
+        mode = 3;
+        goto set_dialog_check_for_exit;
+    }
+
+    if (Vinifera_SkipToCampaign) {
+        DEBUG_INFO("Skipping to the Campaign dialog.\n");
+        mode = 1;
+        goto set_dialog_check_for_exit;
+    }
+
+    if (Vinifera_SkipToSkirmish) {
+        DEBUG_INFO("Skipping to the Skirmish dialog.\n");
+        mode = 6;
+        goto set_dialog_check_for_exit;
+    }
+
+    if (Vinifera_SkipToInternet) {
+        DEBUG_INFO("Skipping to the Internet dialog.\n");
+        mode = 4;
+        goto set_dialog_check_for_exit;
+    }
+
+    /**
+     *  Should we exit the game after we have returned from a
+     *  dialog that we skipped directly to?
+     */
+    if (MenuSkipDone && Vinifera_ExitAfterSkip) {
+        DEBUG_INFO("Forcing game exit.\n");
+        Vinifera_ExitAfterSkip = false;
+        mode = 0;
+        goto set_dialog;
+    }
+    
+    /**
+     *  Show the desired game menu.
+     */
+show_game_menu:
+    newmenu->GameMode = gamemode;
+    _asm { mov ecx, newmenu }
+    _asm { mov eax, 0x0057FD40 }
+    _asm { call eax }
+
+    JMP_REG(ecx, 0x004E883D);
+    
+    /**
+     *  Set the desired dialog, making sure Exit was not set.
+     */
+set_dialog_check_for_exit:
+
+    /**
+     *  Clear any globals.
+     */
+    Vinifera_SkipToLAN = false;
+    Vinifera_SkipToSkirmish = false;
+    Vinifera_SkipToCampaign = false;
+    Vinifera_SkipToInternet = false;
+
+    MenuSkipDone = true;
+
+    if (mode == 0) {
+        goto show_game_menu;
+    }
+
+    /**
+     *  The "new menu" system design is a little awkward, so we need to
+     *  force the PCX filename it updates the screen with behind dialogs.
+     */
+    if (gamemode == 1) {
+        std::strcpy((char *)newmenu->BackgroundImage, "FSTBACK.PCX");
+    } else {
+        std::strcpy((char *)newmenu->BackgroundImage, "TSTBACK.PCX");
+    }
+    
+    /**
+     *  Force the addon mode so Firestorm works correctly.
+     */
+    if (gamemode == 1) {
+        Set_Addon_Mode(true);
+    } else {
+        Set_Addon_Mode(false);
+    }
+
+    /**
+     *  Set the desired dialog, no checks.
+     */
+set_dialog:
+    _asm { mov eax, mode }
+    JMP_REG(ecx, 0x004E883D);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void NewMenuExtension_Hooks()
+{
+    Patch_Jump(0x004E8838, &_NewMenuClass_Process_SkipToMenus_Patch);
+}

--- a/src/extensions/newmenu/newmenuext_hooks.h
+++ b/src/extensions/newmenu/newmenuext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          VINIFERA_GLOBALS.H
+ *  @file          NEWMENUEXT_HOOKS.H
  *
- *  @authors       CCHyper
+ *  @author        CCHyper
  *
- *  @brief         Vinifera global values.
+ *  @brief         Contains the hooks for the extended NewMenuClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,41 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "always.h"
 
-
-extern bool Vinifera_DeveloperMode;
-
-extern char Vinifera_DebugDirectory[PATH_MAX];
-
-
-/**
- *  Developer mode globals.
- */
-extern bool Vinifera_Developer_InstantBuild;
-extern bool Vinifera_Developer_AIInstantBuild;
-extern bool Vinifera_Developer_BuildCheat;
-extern bool Vinifera_Developer_Unshroud;
-extern bool Vinifera_Developer_ShowCursorPosition;
-extern bool Vinifera_Developer_FrameStep;
-extern int Vinifera_Developer_FrameStepCount;
-extern bool Vinifera_Developer_AIControl;
-
-
-/**
- *  Various globals.
- */
-extern bool Vinifera_SkipWWLogoMovie;
-extern bool Vinifera_SkipStartupMovies;
-
-
-/**
- *  Skip to menus.
- */
-extern bool Vinifera_SkipToTSMenu;
-extern bool Vinifera_SkipToFSMenu;
-extern bool Vinifera_SkipToLAN;
-extern bool Vinifera_SkipToSkirmish;
-extern bool Vinifera_SkipToCampaign;
-extern bool Vinifera_SkipToInternet;
-extern bool Vinifera_ExitAfterSkip;
+void NewMenuExtension_Hooks();

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -46,6 +46,8 @@ bool Vinifera_Parse_Command_Line(int argc, char *argv[])
         DEBUG_INFO("Parsing command line arguments...\n");
     }
 
+    bool menu_skip = false;
+
     /**
      *  Iterate over all command line params.
      */
@@ -89,11 +91,92 @@ bool Vinifera_Parse_Command_Line(int argc, char *argv[])
             continue;
         }
 
+        /**
+         *  Skip directly to Tiberian Sun menu.
+         */
+        if (stricmp(string, "-SKIP_TO_TS_MENU") == 0) {
+            DEBUG_INFO("  - Skipping to Tiberian Sun menu.\n");
+            Vinifera_SkipToTSMenu = true;
+            menu_skip = true;
+            continue;
+        }
+
+        /**
+         *  Skip directly to Firestorm menu.
+         */
+        if (stricmp(string, "-SKIP_TO_FS_MENU") == 0) {
+            DEBUG_INFO("  - Skipping to Firestorm menu.\n");
+            Vinifera_SkipToFSMenu = true;
+            menu_skip = true;
+            continue;
+        }
+
+        /**
+         *  Skip directly to a specific game mode dialog.
+         */
+        if (stricmp(string, "-SKIP_TO_LAN") == 0) {
+            DEBUG_INFO("  - Skipping to LAN dialog.\n");
+            Vinifera_SkipToLAN = true;
+            menu_skip = true;
+            continue;
+        }
+
+        if (stricmp(string, "-SKIP_TO_CAMPAIGN") == 0) {
+            DEBUG_INFO("  - Skipping to campaign dialog.\n");
+            Vinifera_SkipToCampaign = true;
+            menu_skip = true;
+            continue;
+        }
+
+        if (stricmp(string, "-SKIP_TO_SKIRMISH") == 0) {
+            DEBUG_INFO("  - Skipping to skirmish dialog.\n");
+            Vinifera_SkipToSkirmish = true;
+            menu_skip = true;
+            continue;
+        }
+
+        if (stricmp(string, "-SKIP_TO_INTERNET") == 0) {
+            DEBUG_INFO("  - Skipping to internet dialog.\n");
+            Vinifera_SkipToInternet = true;
+            menu_skip = true;
+            continue;
+        }
+
+        /**
+         *  Exit the game after the dialog we skipped to has been canceled?
+         */
+        if (stricmp(string, "-EXIT_AFTER_SKIP") == 0) {
+            DEBUG_INFO("  - Skipping to Firestorm menu.\n");
+            Vinifera_ExitAfterSkip = true;
+            menu_skip = true;
+            continue;
+        }
+
     }
 
     if (argc > 1) {
         DEBUG_INFO("Finished parsing command line arguments.\n");
     }
+
+    /**
+     *  Firestorm has priority over Tiberian Sun.
+     */
+    if (Vinifera_SkipToTSMenu && Vinifera_SkipToFSMenu) {
+        Vinifera_SkipToTSMenu = false;
+    }
+
+    /**
+     *  If any of the menu skip commands have been set then
+     *  we also need to skip the startup movies.
+     */
+    if (menu_skip) {
+        Vinifera_SkipStartupMovies = true;
+    }
+
+
+
+    Vinifera_SkipToFSMenu = true;
+    Vinifera_SkipToSkirmish = true;
 
     return true;
 }

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -42,51 +42,60 @@
  */
 bool Vinifera_Parse_Command_Line(int argc, char *argv[])
 {
-	if (argc > 1) {
-		DEBUG_INFO("Parsing command line arguments...\n");
-	}
+    if (argc > 1) {
+        DEBUG_INFO("Parsing command line arguments...\n");
+    }
 
-	/**
-	 *  Iterate over all command line params.
-	 */
-	for (int index = 1; index < argc; index++) {
+    /**
+     *  Iterate over all command line params.
+     */
+    for (int index = 1; index < argc; index++) {
 
-		char arg_string[512];
+        char arg_string[512];
 
-		char *src = argv[index];
-		char *dest = arg_string; 
-		for (int i= 0; i < std::strlen(argv[index]); ++i) {
-			if (*src == '\"') {
-				src++;
-			} else {
-				*dest++ = *src++;
-			}
-		}
-		*dest++ = '\0';
+        char *src = argv[index];
+        char *dest = arg_string; 
+        for (int i= 0; i < std::strlen(argv[index]); ++i) {
+            if (*src == '\"') {
+                src++;
+            } else {
+                *dest++ = *src++;
+            }
+        }
+        *dest++ = '\0';
 
-		char *string = arg_string; // Pointer to current argument.
-		strupr(string);
+        char *string = arg_string; // Pointer to current argument.
+        strupr(string);
 
-		/**
-		 *  Add all new command line params here.
-		 */
+        /**
+         *  Add all new command line params here.
+         */
 
-		/**
-		 *  Mod developer mode.
-		 */
-		if (stricmp(string, "-DEVELOPER") == 0) {
-			DEBUG_INFO("  - Developer mode enabled.\n");
-			Vinifera_DeveloperMode = true;
-			continue;
-		}
+        /**
+         *  Mod developer mode.
+         */
+        if (stricmp(string, "-DEVELOPER") == 0) {
+            DEBUG_INFO("  - Developer mode enabled.\n");
+            Vinifera_DeveloperMode = true;
+            continue;
+        }
 
-	}
+        /**
+         *  Skip the startup videos.
+         */
+        if (stricmp(string, "-NO_STARTUP_VIDEO") == 0) {
+            DEBUG_INFO("  - Skipping startup videos.\n");
+            Vinifera_SkipStartupMovies = true;
+            continue;
+        }
 
-	if (argc > 1) {
-		DEBUG_INFO("Finished parsing command line arguments.\n");
-	}
+    }
 
-	return true;
+    if (argc > 1) {
+        DEBUG_INFO("Finished parsing command line arguments.\n");
+    }
+
+    return true;
 }
 
 
@@ -98,23 +107,23 @@ bool Vinifera_Parse_Command_Line(int argc, char *argv[])
  */
 bool Vinifera_Startup()
 {
-	/**
-	 *  Initialise the CnCNet4 system.
-	 */
-	if (!CnCNet4::Init()) {
-		CnCNet4::IsEnabled = false;
-		DEBUG_WARNING("Failed to initialise CnCNet4, continuing without CnCNet4 support!\n");
-	}
+    /**
+     *  Initialise the CnCNet4 system.
+     */
+    if (!CnCNet4::Init()) {
+        CnCNet4::IsEnabled = false;
+        DEBUG_WARNING("Failed to initialise CnCNet4, continuing without CnCNet4 support!\n");
+    }
 
-	/**
-	 *  Disable CnCNet4 if CnCNet5 is active, they can not co-exist.
-	 */
-	if (CnCNet4::IsEnabled && CnCNet5::IsActive) {
-		CnCNet4::Shutdown();
-		CnCNet4::IsEnabled = false;
-	}
+    /**
+     *  Disable CnCNet4 if CnCNet5 is active, they can not co-exist.
+     */
+    if (CnCNet4::IsEnabled && CnCNet5::IsActive) {
+        CnCNet4::Shutdown();
+        CnCNet4::IsEnabled = false;
+    }
 
-	return true;
+    return true;
 }
 
 
@@ -126,7 +135,7 @@ bool Vinifera_Startup()
  */
 bool Vinifera_Shutdown()
 {
-	DEV_DEBUG_INFO("Shutdown - New Count: %d, Delete Count: %d\n", Vinifera_New_Count, Vinifera_Delete_Count);
+    DEV_DEBUG_INFO("Shutdown - New Count: %d, Delete Count: %d\n", Vinifera_New_Count, Vinifera_Delete_Count);
 
-	return true;
+    return true;
 }

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -45,3 +45,11 @@ bool Vinifera_Developer_AIControl = false;
 
 bool Vinifera_SkipWWLogoMovie = false;
 bool Vinifera_SkipStartupMovies = false;
+
+bool Vinifera_SkipToTSMenu = false;
+bool Vinifera_SkipToFSMenu = false;
+bool Vinifera_SkipToLAN = false;
+bool Vinifera_SkipToSkirmish = false;
+bool Vinifera_SkipToCampaign = false;
+bool Vinifera_SkipToInternet = false;
+bool Vinifera_ExitAfterSkip = false;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -46,3 +46,10 @@ extern bool Vinifera_Developer_ShowCursorPosition;
 extern bool Vinifera_Developer_FrameStep;
 extern int Vinifera_Developer_FrameStepCount;
 extern bool Vinifera_Developer_AIControl;
+
+
+/**
+ *  Various globals.
+ */
+extern bool Vinifera_SkipWWLogoMovie;
+extern bool Vinifera_SkipStartupMovies;


### PR DESCRIPTION
Closes #241, Closes #478

This pull request adds a number of command-line arguments allowing the user to skip the startup movies, or skip directly to a specific game mode and/or dialog.

**-NO_STARTUP_VIDEO**
_Skips all startup movies._

**-SKIP_TO_TS_MENU**
_Loads the game directly into the Tiberian Sun main menu _(also skips startup movies)_._

**-SKIP_TO_FS_MENU**
_Loads the game directly into the Firestorm main menu _(also skips startup movies)_. This option has priority over the TS main menu argument._

The following options will be affected by the choice of menu you skip to, otherwise, they default to the Tiberian Sun game mode.

**-SKIP_TO_LAN**
_Loads the game directly into the LAN dialog._

**-SKIP_TO_CAMPAIGN**
_Loads the game directly into the Campaign dialog._

**-SKIP_TO_SKIRMISH**
_Loads the game directly into the Skirmish dialog._

**-SKIP_TO_INTERNET**
_Loads the game directly into the Internet dialog._

**- EXIT_AFTER_SKIP**
_This option tells the game to exit when you press **Cancel** or **Back** from the dialog you skipped to._
