### PR TITLE
Fixes the bug where buildings randomly respawn in a "limbo" state when destroyed.

### DIFF
--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -165,6 +165,18 @@ DECLARE_PATCH(_BuildingClass_Explode_ShakeScreen_Division_BugFix_Patch)
      *  Continue execution of function.
      */
 continue_function:
+
+    /**
+     *  #issue-502
+     * 
+     *  Fixes the bug where buildings randomly respawn in a "limbo" state
+     *  when destroyed. The EDI register was used to set Strength to 0 further
+     *  down in the function after we return back.
+     * 
+     *  @author: CCHyper
+     */
+    _asm { xor edi, edi }
+
     JMP_REG(edx, 0x0042B27F);
 }
 


### PR DESCRIPTION
Closes #502 

This pull request fixes a bug introduced by Vinifera where buildings would randomly respawn in a "limbo" state when destroyed.

The cause of this issue was a side effect of the Shake Screen feature. Code to clear a register was missing that was later used to set the health of the building to zero.

Special thanks to @tomsons26 for investigating the cause of this issue.