### PR TITLE
Implements light sources for TerrainTypes.

### DIFF
--- a/src/extensions/container.h
+++ b/src/extensions/container.h
@@ -231,6 +231,15 @@ class ExtensionMap final
             delete Map.remove(key);
         }
 
+        
+        /**
+         *  Returns the number of elements in the map.
+         */
+        size_t size() const
+        {
+            return Map.size();
+        }
+
         /**
          *  Checks whether the container is empty.
          */

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -81,6 +81,7 @@
 #include "teamext_hooks.h"
 #include "factoryext_hooks.h"
 #include "animext_hooks.h"
+#include "terrainext_hooks.h"
 
 #include "dropshipext_hooks.h"
 
@@ -158,6 +159,7 @@ void Extension_Hooks()
     TechnoClassExtension_Hooks();
     FootClassExtension_Hooks();
     AnimClassExtension_Hooks();
+    TerrainClassExtension_Hooks();
 
     DropshipExtension_Hooks();
 

--- a/src/extensions/saveload/saveload.cpp
+++ b/src/extensions/saveload/saveload.cpp
@@ -65,6 +65,7 @@
 //#include "triggertypeext.h"
 
 #include "technoext.h"
+#include "terrainext.h"
 
 
 /**
@@ -111,6 +112,7 @@ unsigned ViniferaSaveGameVersion =
             //+ sizeof(TagTypeClassExtension)
             //+ sizeof(TriggerTypeClassExtension)
             + sizeof(TechnoClassExtension)
+            + sizeof(TerrainClassExtension)
 ;
 
 
@@ -307,6 +309,7 @@ DEFINE_EXTENSION_SAVE(TiberiumClassExtension, TiberiumClassExtensions);
 //DEFINE_EXTENSION_SAVE(TriggerTypeClassExtension, TriggerTypeClassExtensions);
 
 DEFINE_EXTENSION_SAVE(TechnoClassExtension, TechnoClassExtensions);
+DEFINE_EXTENSION_SAVE(TerrainClassExtension, TerrainClassExtensions);
 
 DEFINE_EXTENSION_LOAD(ObjectTypeClassExtension, ObjectTypeClassExtensions);
 DEFINE_EXTENSION_LOAD(TechnoTypeClassExtension, TechnoTypeClassExtensions);
@@ -337,6 +340,7 @@ DEFINE_EXTENSION_LOAD(TiberiumClassExtension, TiberiumClassExtensions);
 //DEFINE_EXTENSION_LOAD(TriggerTypeClassExtension, TriggerTypeClassExtensions);
 
 DEFINE_EXTENSION_LOAD(TechnoClassExtension, TechnoClassExtensions);
+DEFINE_EXTENSION_LOAD(TerrainClassExtension, TerrainClassExtensions);
 
 
 /**
@@ -540,6 +544,12 @@ bool Vinifera_Put_All(IStream *pStm)
 
     DEBUG_INFO("Saving TechnoClassExtension\n");
     if (!Vinifera_Save_TechnoClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
+
+    DEBUG_INFO("Saving TerrainClassExtension\n");
+    if (!Vinifera_Save_TerrainClassExtension(pStm)) {
         DEBUG_INFO("\t***** FAILED!\n");
         return false;
     }
@@ -776,6 +786,12 @@ bool Vinifera_Load_All(IStream *pStm)
 
     DEBUG_INFO("Loading TechnoClassExtension\n");
     if (!Vinifera_Load_TechnoClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
+
+    DEBUG_INFO("Loading TerrainClassExtension\n");
+    if (!Vinifera_Load_TerrainClassExtension(pStm)) {
         DEBUG_INFO("\t***** FAILED!\n");
         return false;
     }

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TERRAINEXT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended TerrainClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "terrainext.h"
+#include "terrain.h"
+#include "wwcrc.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+
+/**
+ *  Provides the map for all TerrainClass extension instances.
+ */
+ExtensionMap<TerrainClass, TerrainClassExtension> TerrainClassExtensions;
+
+
+/**
+ *  Class constructor.
+ *  
+ *  @author: CCHyper
+ */
+TerrainClassExtension::TerrainClassExtension(TerrainClass *this_ptr) :
+    Extension(this_ptr)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TerrainClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("TerrainClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = true;
+}
+
+
+/**
+ *  Class no-init constructor.
+ *  
+ *  @author: CCHyper
+ */
+TerrainClassExtension::TerrainClassExtension(const NoInitClass &noinit) :
+    Extension(noinit)
+{
+    IsInitialized = false;
+}
+
+
+/**
+ *  Class deconstructor.
+ *  
+ *  @author: CCHyper
+ */
+TerrainClassExtension::~TerrainClassExtension()
+{
+    //EXT_DEBUG_TRACE("TerrainClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("TerrainClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = false;
+}
+
+
+/**
+ *  Initializes an object from the stream where it was saved previously.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT TerrainClassExtension::Load(IStream *pStm)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TerrainClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Load(pStm);
+    if (FAILED(hr)) {
+        return E_FAIL;
+    }
+
+    new (this) TerrainClassExtension(NoInitClass());
+    
+    return hr;
+}
+
+
+/**
+ *  Saves an object to the specified stream.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT TerrainClassExtension::Save(IStream *pStm, BOOL fClearDirty)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TerrainClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Save(pStm, fClearDirty);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Return the raw size of class data for save/load purposes.
+ *  
+ *  @author: CCHyper
+ */
+int TerrainClassExtension::Size_Of() const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TerrainClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    return sizeof(*this);
+}
+
+
+/**
+ *  Removes the specified target from any targeting and reference trackers.
+ *  
+ *  @author: CCHyper
+ */
+void TerrainClassExtension::Detach(TARGET target, bool all)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TerrainClassExtension::Detach - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}
+
+
+/**
+ *  Compute a unique crc value for this instance.
+ *  
+ *  @author: CCHyper
+ */
+void TerrainClassExtension::Compute_CRC(WWCRCEngine &crc) const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TerrainClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -28,6 +28,7 @@
 #include "terrainext.h"
 #include "terrain.h"
 #include "wwcrc.h"
+#include "lightsource.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -44,7 +45,9 @@ ExtensionMap<TerrainClass, TerrainClassExtension> TerrainClassExtensions;
  *  @author: CCHyper
  */
 TerrainClassExtension::TerrainClassExtension(TerrainClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    LightSource(nullptr)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("TerrainClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -76,6 +79,12 @@ TerrainClassExtension::~TerrainClassExtension()
     //EXT_DEBUG_TRACE("TerrainClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
     //EXT_DEBUG_WARNING("TerrainClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
 
+    if (LightSource) {
+        LightSource->Disable();
+        delete LightSource;
+        LightSource = nullptr;
+    }
+
     IsInitialized = false;
 }
 
@@ -96,6 +105,8 @@ HRESULT TerrainClassExtension::Load(IStream *pStm)
     }
 
     new (this) TerrainClassExtension(NoInitClass());
+
+    LightSource = nullptr;
     
     return hr;
 }

--- a/src/extensions/terrain/terrainext.h
+++ b/src/extensions/terrain/terrainext.h
@@ -1,0 +1,53 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TERRAINEXT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended TerrainClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "extension.h"
+#include "container.h"
+#include "terrain.h"
+
+
+class TerrainClassExtension final : public Extension<TerrainClass>
+{
+    public:
+        TerrainClassExtension(TerrainClass *this_ptr);
+        TerrainClassExtension(const NoInitClass &noinit);
+        ~TerrainClassExtension();
+
+        virtual HRESULT Load(IStream *pStm) override;
+        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
+        virtual int Size_Of() const override;
+
+        virtual void Detach(TARGET target, bool all = true) override;
+        virtual void Compute_CRC(WWCRCEngine &crc) const override;
+
+    public:
+};
+
+
+extern ExtensionMap<TerrainClass, TerrainClassExtension> TerrainClassExtensions;

--- a/src/extensions/terrain/terrainext.h
+++ b/src/extensions/terrain/terrainext.h
@@ -32,6 +32,9 @@
 #include "terrain.h"
 
 
+class LightSourceClass;
+
+
 class TerrainClassExtension final : public Extension<TerrainClass>
 {
     public:
@@ -47,6 +50,10 @@ class TerrainClassExtension final : public Extension<TerrainClass>
         virtual void Compute_CRC(WWCRCEngine &crc) const override;
 
     public:
+        /**
+         *  The light source instance for this terrain object.
+         */
+        LightSourceClass *LightSource;
 };
 
 

--- a/src/extensions/terrain/terrainext_hooks.cpp
+++ b/src/extensions/terrain/terrainext_hooks.cpp
@@ -28,10 +28,153 @@
 #include "terrainext_hooks.h"
 #include "terrainext_init.h"
 #include "terrainext.h"
+#include "terraintypeext.h"
+#include "terrain.h"
+#include "terraintype.h"
+#include "lightsource.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 #include "vinifera_util.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Create a light source instances for terrain object.
+ * 
+ *  @author: CCHyper
+ */
+static LightSourceClass *Terrain_New_LightSource(TerrainClass *this_ptr)
+{
+    if (!this_ptr) {
+        return nullptr;
+    }
+    
+    TerrainClassExtension *terrainext;
+    TerrainTypeClassExtension *terraintypeext;
+    LightSourceClass *light;
+
+    /**
+     *  Fetch the extended class instances if they exist.
+     */
+    terrainext = TerrainClassExtensions.find(this_ptr);
+    terraintypeext = TerrainTypeClassExtensions.find(this_ptr->Class);
+
+    /**
+     *  Create the light source object at the terrain coord.
+     */
+    light = new LightSourceClass(
+                    this_ptr->Center_Coord(),
+                    terraintypeext->LightVisibility,
+                    terraintypeext->LightIntensity,
+                    terraintypeext->LightRedTint,
+                    terraintypeext->LightGreenTint,
+                    terraintypeext->LightBlueTint
+                );
+    ASSERT(light != nullptr);
+
+    return light;
+}
+
+
+/**
+ *  #issue-452
+ * 
+ *  Create the light source object when the terrain is placed
+ *  into the game world.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Unlimbo_LightSource_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, edi);
+    static TerrainClassExtension *terrainext;
+    static TerrainTypeClassExtension *terraintypeext;
+    static TerrainTypeClass *terraintype;
+    static LightSourceClass *light;
+
+    terraintype = this_ptr->Class;
+
+    /**
+     *  Fetch the extended class instances if they exist.
+     */
+    terrainext = TerrainClassExtensions.find(this_ptr);
+    terraintypeext = TerrainTypeClassExtensions.find(terraintype);
+
+    if (terraintypeext && terraintypeext->LightIntensity > 0) {
+
+        if (terrainext && !terrainext->LightSource) {
+
+            /**
+             *  Create the light source object.
+             */
+            light = Terrain_New_LightSource(this_ptr);
+
+            if (light) {
+                terrainext->LightSource = light;
+
+                /**
+                 *  Enable the light source.
+                 */
+                terrainext->LightSource->Enable();
+            }
+
+        }
+
+    }
+
+    /**
+     *  Function return.
+     */
+function_return:
+    _asm { mov al, 1 }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { add esp, 0x10 }
+    _asm { ret 0x8 }
+}
+
+
+/**
+ *  #issue-452
+ * 
+ *  Disable the light source object when the terrain object is destroyed.
+ * 
+ *  #NOTE: This patch is within and at the end of the RESULT_DESTROYED (4) branch
+ *         returned from ObjectClass::Take_Damage().
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Take_Damage_LightSource_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, esi);
+    static TerrainClassExtension *terrainext;
+
+    /**
+     *  Fetch the extended class instance if it exists.
+     */
+    terrainext = TerrainClassExtensions.find(this_ptr);
+    if (terrainext && terrainext->LightSource) {
+
+        /**
+         *  This terrain object was destroyed, disable the attached lighting.
+         */
+        terrainext->LightSource->Disable();
+    }
+
+    /**
+     *  Stolen bytes/code
+     */
+    this_ptr->Detach_All(true);
+    this_ptr->entry_E4();
+
+    /**
+     *  Function return.
+     */
+    JMP(0x0063F4EF);
+}
 
 
 /**
@@ -43,4 +186,7 @@ void TerrainClassExtension_Hooks()
      *  Initialises the extended class.
      */
     TerrainClassExtension_Init();
+
+    Patch_Jump(0x006409C3, &_TerrainClass_Unlimbo_LightSource_Patch);
+    Patch_Jump(0x0063F4D9, &_TerrainClass_Take_Damage_LightSource_Patch);
 }

--- a/src/extensions/terrain/terrainext_hooks.cpp
+++ b/src/extensions/terrain/terrainext_hooks.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TERRAINEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended TerrainClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "terrainext_hooks.h"
+#include "terrainext_init.h"
+#include "terrainext.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+#include "vinifera_util.h"
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void TerrainClassExtension_Hooks()
+{
+    /**
+     *  Initialises the extended class.
+     */
+    TerrainClassExtension_Init();
+}

--- a/src/extensions/terrain/terrainext_hooks.h
+++ b/src/extensions/terrain/terrainext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TERRAINEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended TerrainClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void TerrainClassExtension_Hooks();

--- a/src/extensions/terrain/terrainext_init.cpp
+++ b/src/extensions/terrain/terrainext_init.cpp
@@ -1,0 +1,262 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TERRAINEXT_INIT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended TerrainClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "terrainext.h"
+#include "terrain.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+#include "vinifera_util.h"
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Default_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, esi); // Current "this" pointer.
+    GET_STACK_STATIC(const TerrainTypeClass *, classof, esp, 0x20);
+    GET_STACK_STATIC(const Cell *, cell, esp, 0x24);
+    static TerrainClassExtension *ext_ptr;
+
+    /**
+     *  Find existing or create an extended class instance.
+     */
+    ext_ptr = TerrainClassExtensions.find_or_create(this_ptr);
+    if (!ext_ptr) {
+        DEBUG_ERROR("Failed to create TerrainClassExtension instance for 0x%08X!\n", (uintptr_t)this_ptr);
+        ShowCursor(TRUE);
+        MessageBoxA(MainWindow, "Failed to create TerrainClassExtensions instance!\n", "Vinifera", MB_OK|MB_ICONEXCLAMATION);
+        Vinifera_Generate_Mini_Dump();
+        Fatal("Failed to create TerrainClassExtensions instance!\n");
+        goto original_code; // Keep this for clean code analysis.
+    }
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { add esp, 0x8 }
+    _asm { ret }
+}
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, esi); // Current "this" pointer.
+    static TerrainClassExtension *ext_ptr;
+
+    /**
+     *  Find existing or create an extended class instance.
+     */
+    ext_ptr = TerrainClassExtensions.find_or_create(this_ptr);
+    if (!ext_ptr) {
+        DEBUG_ERROR("Failed to create TerrainClassExtension instance for 0x%08X!\n", (uintptr_t)this_ptr);
+        ShowCursor(TRUE);
+        MessageBoxA(MainWindow, "Failed to create TerrainClassExtensions instance!\n", "Vinifera", MB_OK|MB_ICONEXCLAMATION);
+        Vinifera_Generate_Mini_Dump();
+        Fatal("Failed to create TerrainClassExtensions instance!\n");
+        goto original_code; // Keep this for clean code analysis.
+    }
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { add esp, 0x0C }
+    _asm { ret 8 }
+}
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  We need do this before the unlimbo otherwise finding extension data
+ *  will fail if you patch Unlimbo.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Constructor_Before_Unlimbo_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, esi); // Current "this" pointer.
+    GET_STACK_STATIC(Cell *, cell, esp, 0x24);
+    static TerrainClassExtension *ext_ptr;
+
+    /**
+     *  Find existing or create an extended class instance.
+     */
+    ext_ptr = TerrainClassExtensions.find_or_create(this_ptr);
+    if (!ext_ptr) {
+        DEBUG_ERROR("Failed to create TerrainClassExtension instance for 0x%08X!\n", (uintptr_t)this_ptr);
+        ShowCursor(TRUE);
+        MessageBoxA(MainWindow, "Failed to create TerrainClassExtensions instance!\n", "Vinifera", MB_OK|MB_ICONEXCLAMATION);
+        Vinifera_Generate_Mini_Dump();
+        Fatal("Failed to create TerrainClassExtensions instance!\n");
+        goto original_code; // Keep this for clean code analysis.
+    }
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov esi, this_ptr }
+    _asm { mov edx, [esi+0x64] } // this->Class
+    _asm { mov ecx, cell }
+
+    JMP(0x0063F55D);
+}
+
+
+/**
+ *  Patch for including the extended class members in the destruction process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Deconstructor_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, esi);
+
+    /**
+     *  Remove the extended class from the global index.
+     */
+    TerrainClassExtensions.remove(this_ptr);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { add esp, 0x8 }
+    _asm { ret }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class detach process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Detach_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, esi);
+    GET_STACK_STATIC(TARGET, target, esp, 0x10);
+    GET_STACK_STATIC8(bool, all, esp, 0x8);
+    static TerrainClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = TerrainClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Detach(target, all);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 8 }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class crc calculation.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TerrainClass_Compute_CRC_Patch)
+{
+    GET_REGISTER_STATIC(TerrainClass *, this_ptr, esi);
+    GET_STACK_STATIC(WWCRCEngine *, crc, esp, 0xC);
+    static TerrainClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = TerrainClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Compute_CRC(*crc);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void TerrainClassExtension_Init()
+{
+    Patch_Jump(0x0063F88C, _TerrainClass_Default_Constructor_Patch);
+    //Patch_Jump(0x0063F701, _TerrainClass_Constructor_Patch);
+    Patch_Jump(0x0063F556, _TerrainClass_Constructor_Before_Unlimbo_Patch);
+    Patch_Jump(0x0063F2BC, _TerrainClass_Deconstructor_Patch);
+    Patch_Jump(0x0064089F, _TerrainClass_Detach_Patch);
+    Patch_Jump(0x0064086E, _TerrainClass_Compute_CRC_Patch);
+}

--- a/src/extensions/terrain/terrainext_init.h
+++ b/src/extensions/terrain/terrainext_init.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TECHNOEXT_INIT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended TerrainClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void TerrainClassExtension_Init();

--- a/src/extensions/terraintype/terraintypeext.cpp
+++ b/src/extensions/terraintype/terraintypeext.cpp
@@ -44,7 +44,13 @@ ExtensionMap<TerrainTypeClass, TerrainTypeClassExtension> TerrainTypeClassExtens
  *  @author: CCHyper
  */
 TerrainTypeClassExtension::TerrainTypeClassExtension(TerrainTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    LightVisibility(5000),
+    LightIntensity(0),
+    LightRedTint(1000000),
+    LightGreenTint(1000000),
+    LightBlueTint(1000000)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TerrainTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -174,6 +180,12 @@ bool TerrainTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    LightVisibility = ini.Get_Int(ini_name, "LightVisibility", LightVisibility);
+    LightIntensity = ini.Get_Double(ini_name, "LightIntensity", (LightIntensity / 1000)) * 1000.0 + 0.1;
+    LightRedTint = ini.Get_Double(ini_name, "LightRedTint", (LightRedTint / 1000)) * 1000.0 + 0.1;
+    LightGreenTint = ini.Get_Double(ini_name, "LightGreenTint", (LightGreenTint / 1000)) * 1000.0 + 0.1;
+    LightBlueTint = ini.Get_Double(ini_name, "LightBlueTint", (LightBlueTint / 1000)) * 1000.0 + 0.1;
     
     return true;
 }

--- a/src/extensions/terraintype/terraintypeext.h
+++ b/src/extensions/terraintype/terraintypeext.h
@@ -52,7 +52,30 @@ class TerrainTypeClassExtension final : public Extension<TerrainTypeClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
+        /**
+         *  This terrain object radiates this amount of light.
+         */
+        int LightVisibility;
 
+        /**
+         *  The distance (in leptons) that this light is visible from.
+         */
+        int LightIntensity;
+
+        /**
+         *  The red tint of this terrain objects light.
+         */
+        int LightRedTint;
+
+        /**
+         *  The green tint of this terrain objects light.
+         */
+        int LightGreenTint;
+
+        /**
+         *  The blue tint of this terrain objects light.
+         */
+        int LightBlueTint;
 };
 
 

--- a/src/extensions/terraintype/terraintypeext_init.cpp
+++ b/src/extensions/terraintype/terraintypeext_init.cpp
@@ -48,8 +48,6 @@ DECLARE_PATCH(_TerrainTypeClass_Constructor_Patch)
     GET_STACK_STATIC(const char *, ini_name, esp, 0xC); // ini name.
     static TerrainTypeClassExtension *exttype_ptr;
 
-    //DEV_DEBUG_WARNING("Creating TerrainTypeClassExtension instance for \"%s\".\n", ini_name);
-
     /**
      *  Find existing or create an extended class instance.
      */


### PR DESCRIPTION
Closes #452 

This pull request implements light sources for TerrainTypes.

**`LightVisibility=<integer>`**
This terrain object radiates this amount of light _(default `5000`)_.

**`LightIntensity=<float>`**
The distance that this light is visible from _(default `0`)_.

**`LightRedTint=<float>`**
The red tint of this terrain objects light _(default `1.0`)_.

**`LightGreenTint=<float>`**
The green tint of this terrain objects light _(default `1.0`)_.

**`LightBlueTint=<float>`**
The blue tint of this terrain objects light _(default `1.0`)_.
