### PR TITLE
Adds warning notification if a NULL house instance is detected during the game loading screen.

### DIFF
--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -33,6 +33,8 @@
 #include "technotypeext.h"
 #include "tibsun_inline.h"
 #include "weapontype.h"
+#include "house.h"
+#include "housetype.h"
 #include "rules.h"
 #include "voc.h"
 #include "fatal.h"
@@ -226,6 +228,35 @@ DECLARE_PATCH(_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch)
 
 
 /**
+ *  A patch that adds debug logging on null house pointers in TechnoClass::Owner().
+ * 
+ *  This is a common crash observed by mod developers and map creators, and
+ *  aims to assist tracking down the offending object.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Null_House_Warning_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, ecx);
+    static HouseClass *house;
+    static int id;
+    
+    house = this_ptr->House;
+    if (!house) {
+        DEBUG_WARNING("Techno \"%s\" has an invalid house!", this_ptr->Name());
+        Vinifera_DeveloperMode_Warning_WWMessageBox("Techno \"%s\" has an invalid house!", this_ptr->Name());
+        Fatal("Null house pointer in TechnoClass::Owner!\n");
+
+    } else {
+        id = house->ID;
+    }
+    
+    _asm { mov eax, id }
+    _asm { ret }
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void TechnoClassExtension_Hooks()
@@ -239,4 +270,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00633BD4, &_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch);
     Patch_Jump(0x0063105C, &_TechnoClass_Fire_At_Weapon_Anim_Patch);
     Patch_Jump(0x0062F6B7, &_TechnoClass_Is_Ready_To_Uncloak_Cloak_Stop_BugFix_Patch);
+    Patch_Jump(0x0062E6F0, &_TechnoClass_Null_House_Warning_Patch);
 }

--- a/src/vinifera_util.cpp
+++ b/src/vinifera_util.cpp
@@ -253,3 +253,30 @@ int Vinifera_Do_WWMessageBox(const char *msg, const char *btn1, const char *btn2
 {
     return WWMessageBox().Process(msg, 0, btn1, btn2, btn3);
 }
+
+
+/**
+ *  Shows a in-game warning message box only if developer mode is active.
+ * 
+ *  This has been made its own function because we can not allocate on the stack with
+ *  our patches, so this handles all that within this function scope.
+ * 
+ *  @author: CCHyper
+ */
+void Vinifera_DeveloperMode_Warning_WWMessageBox(const char *msg, ...)
+{
+    if (Vinifera_DeveloperMode) {
+
+        char msg_buff[512];
+        std:snprintf(msg_buff, sizeof(msg_buff), "WARNING!\n%s", msg);
+        
+        char buffer[512];	    // Working staging buffer.
+        va_list	arg;		    // Argument list var.
+
+        va_start(arg, msg);
+        vsnprintf(buffer, sizeof(buffer), msg_buff, arg);
+        va_end(arg);
+
+        WWMessageBox().Process(buffer, 0, "OK");
+    }
+}

--- a/src/vinifera_util.h
+++ b/src/vinifera_util.h
@@ -39,3 +39,4 @@ void Vinifera_Draw_Version_Text(XSurface *surface, bool pre_init = false);
 bool Vinifera_Generate_Mini_Dump();
 
 int Vinifera_Do_WWMessageBox(const char *msg, const char *btn1, const char *btn2 = nullptr, const char *btn3 = nullptr);
+void Vinifera_DeveloperMode_Warning_WWMessageBox(const char *msg, ...);


### PR DESCRIPTION
This pull request adds a warning to the debug log output when a null house pointer is detected during the game loading screen.

Also, if the user has Developer Mode enabled, then a dialog will be shown to notify the user of the offending objects name.

Example message box that will be shown;
![image](https://user-images.githubusercontent.com/73803386/129727642-8e929cc7-1b1c-4231-be44-abe4312ea265.png)
