### PR TITLE
Implements DirectShow video support for full-screen MP4, WMV, MPG and AVI videos.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,7 +96,7 @@ jobs:
           cp ./build/LaunchVinifera.exe ./artifact/LaunchVinifera.exe
           cp ./build/_deps/tspp-src/pdb/Game.pdb ./artifact/Game.pdb
           cp ./build/_deps/tspp-src/edb/Game.edb ./artifact/Game.edb
-          cp ./vinifera-files/files/VINIFERA.VQA ./artifact/Movies/VINIFERA.VQA
+          cp ./vinifera-files/files/VINIFERA.WMV ./artifact/Movies/Vinifera.wmv
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
@@ -189,7 +189,7 @@ jobs:
           cp ./build/LaunchVinifera.exe ./artifact/LaunchVinifera.dat
           cp ./build/_deps/tspp-src/pdb/Game.pdb ./artifact/Game.pdb
           cp ./build/_deps/tspp-src/edb/Game.edb ./artifact/Game.edb
-          cp ./vinifera-files/files/VINIFERA.VQA ./artifact/Movies/VINIFERA.VQA
+          cp ./vinifera-files/files/VINIFERA.WMV ./artifact/Movies/Vinifera.wmv
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,7 +58,7 @@ jobs:
           cp ./build/LaunchVinifera.exe ./artifact/LaunchVinifera.exe
           cp ./build/_deps/tspp-src/pdb/Game.pdb ./artifact/Game.pdb
           cp ./build/_deps/tspp-src/edb/Game.edb ./artifact/Game.edb
-          cp ./vinifera-files/files/VINIFERA.VQA ./artifact/Movies/VINIFERA.VQA
+          cp ./vinifera-files/files/VINIFERA.WMV ./artifact/Movies/Vinifera.wmv
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
@@ -116,7 +116,7 @@ jobs:
           cp ./build/LaunchVinifera.exe ./artifact/LaunchVinifera.dat
           cp ./build/_deps/tspp-src/pdb/Game.pdb ./artifact/Game.pdb
           cp ./build/_deps/tspp-src/edb/Game.edb ./artifact/Game.edb
-          cp ./vinifera-files/files/VINIFERA.WMV ./artifact/Movies/VINIFERA.VQA
+          cp ./vinifera-files/files/VINIFERA.WMV ./artifact/Movies/Vinifera.wmv
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,7 +615,7 @@ add_dependencies(${PROJECT_NAME} TSpp)
 # Ensure the launcher is built with the main project.
 add_dependencies(${PROJECT_NAME} Launch${PROJECT_NAME})
 
-set(REQUIRED_LIBRARIES ws2_32 dbghelp shlwapi version comctl32)
+set(REQUIRED_LIBRARIES ws2_32 dbghelp shlwapi version comctl32 strmiids)
 
 # Link to any required libraries.
 target_link_libraries(${PROJECT_NAME} ${REQUIRED_LIBRARIES})

--- a/src/dshowvideo/dshowrenderer.cpp
+++ b/src/dshowvideo/dshowrenderer.cpp
@@ -1,0 +1,540 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DSHOWRENDERER.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         DirectShow video renderers.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "dshowrenderer.h"
+#include "dshowutil.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+#include <Mfidl.h>
+
+
+/**
+ *  Initialize the VMR-7 for windowless mode. 
+ */
+HRESULT InitWindowlessVMR( 
+    IBaseFilter *pVMR,              // Pointer to the VMR
+    HWND hWnd,                      // Clipping window
+    IVMRWindowlessControl **ppWC    // Receives a pointer to the VMR.
+    ) 
+{ 
+
+    IVMRFilterConfig* pConfig = nullptr; 
+    IVMRWindowlessControl *pWC = nullptr;
+
+    /**
+     *  Set the rendering mode.  
+     */
+    HRESULT hr = pVMR->QueryInterface(IID_PPV_ARGS(&pConfig)); 
+    if (FAILED(hr))
+    {
+        goto done;
+    }
+
+    hr = pConfig->SetRenderingMode(VMRMode_Windowless); 
+    if (FAILED(hr))
+    {
+        goto done;
+    }
+    
+    /**
+     *  Query for the windowless control interface.
+     */
+    hr = pVMR->QueryInterface(IID_PPV_ARGS(&pWC));
+    if (FAILED(hr))
+    {
+        goto done;
+    }
+    
+    /**
+     *  Set the clipping window.
+     */
+    hr = pWC->SetVideoClippingWindow(hWnd);
+    if (FAILED(hr))
+    {
+        goto done;
+    }
+    
+    /**
+     *  Preserve aspect ratio by letter-boxing.
+     */
+    hr = pWC->SetAspectRatioMode(VMR_ARMODE_LETTER_BOX);
+    if (FAILED(hr))
+    {
+        goto done;
+    }
+
+    /**
+     *  Return the IVMRWindowlessControl pointer to the caller.
+     */
+    *ppWC = pWC;
+    (*ppWC)->AddRef();
+
+done:
+    SafeRelease(&pConfig);
+    SafeRelease(&pWC);
+    return hr; 
+} 
+
+
+
+// Initialize the VMR-9 for windowless mode. 
+/**
+ *  
+ */
+HRESULT InitWindowlessVMR9( 
+    IBaseFilter *pVMR,              // Pointer to the VMR
+    HWND hWnd,                      // Clipping window
+    IVMRWindowlessControl9 **ppWC   // Receives a pointer to the VMR.
+    ) 
+{ 
+
+    IVMRFilterConfig9 * pConfig = nullptr; 
+    IVMRWindowlessControl9 *pWC = nullptr;
+
+    /**
+     *  Set the rendering mode. 
+     */ 
+    HRESULT hr = pVMR->QueryInterface(IID_PPV_ARGS(&pConfig)); 
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    hr = pConfig->SetRenderingMode(VMR9Mode_Windowless); 
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Query for the windowless control interface.
+     */
+    hr = pVMR->QueryInterface(IID_PPV_ARGS(&pWC));
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Set the clipping window.
+     */
+    hr = pWC->SetVideoClippingWindow(hWnd);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Preserve aspect ratio by letter-boxing.
+     */
+    hr = pWC->SetAspectRatioMode(VMR9ARMode_LetterBox);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Return the IVMRWindowlessControl pointer to the caller.
+     */
+    *ppWC = pWC;
+    (*ppWC)->AddRef();
+
+done:
+    SafeRelease(&pConfig);
+    SafeRelease(&pWC);
+    return hr; 
+} 
+
+
+/**
+ *  Initialize the EVR filter.
+ */
+HRESULT InitializeEVR( 
+    IBaseFilter *pEVR,              // Pointer to the EVR
+    HWND hWnd,                      // Clipping window
+    IMFVideoDisplayControl **ppDisplayControl
+    ) 
+{ 
+    IMFGetService *pGS = nullptr;
+    IMFVideoDisplayControl *pDisplay = nullptr;
+
+    HRESULT hr = pEVR->QueryInterface(IID_PPV_ARGS(&pGS)); 
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    hr = pGS->GetService(MR_VIDEO_RENDER_SERVICE, IID_PPV_ARGS(&pDisplay));
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Set the clipping window.
+     */
+    hr = pDisplay->SetVideoWindow(hWnd);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Preserve aspect ratio by letter-boxing.
+     */
+    hr = pDisplay->SetAspectRatioMode(MFVideoARMode_PreservePicture);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Return the IMFVideoDisplayControl pointer to the caller.
+     */
+    *ppDisplayControl = pDisplay;
+    (*ppDisplayControl)->AddRef();
+
+done:
+    SafeRelease(&pGS);
+    SafeRelease(&pDisplay);
+    return hr; 
+} 
+
+
+/**
+ *  VMR-7 Wrapper
+ */
+VMR7::VMR7() :
+    m_pWindowless(nullptr)
+{
+
+}
+
+
+VMR7::~VMR7()
+{
+    SafeRelease(&m_pWindowless);
+}
+
+
+BOOL VMR7::HasVideo() const 
+{ 
+    return (m_pWindowless != nullptr); 
+}
+
+
+HRESULT VMR7::AddToGraph(IGraphBuilder *pGraph, HWND hWnd)
+{
+    IBaseFilter *pVMR = nullptr;
+
+    HRESULT hr = AddFilterByCLSID(pGraph, CLSID_VideoMixingRenderer, 
+        &pVMR, L"VMR-7");
+
+    if (SUCCEEDED(hr)) {
+        /**
+         *  Set windowless mode on the VMR. This must be done before the VMR
+         *  is connected.
+         */
+        hr = InitWindowlessVMR(pVMR, hWnd, &m_pWindowless);
+    }
+    SafeRelease(&pVMR);
+    return hr;
+}
+
+HRESULT VMR7::FinalizeGraph(IGraphBuilder *pGraph)
+{
+    if (m_pWindowless == nullptr) {
+        return S_OK;
+    }
+
+    IBaseFilter *pFilter = nullptr;
+
+    HRESULT hr = m_pWindowless->QueryInterface(IID_PPV_ARGS(&pFilter));
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    BOOL bRemoved;
+    hr = RemoveUnconnectedRenderer(pGraph, pFilter, &bRemoved);
+
+    /**
+     *  If we removed the VMR, then we also need to release our 
+     *  pointer to the VMR's windowless control interface.
+     */
+    if (bRemoved) {
+        SafeRelease(&m_pWindowless);
+    }
+
+done:
+    SafeRelease(&pFilter);
+    return hr;
+}
+
+
+HRESULT VMR7::UpdateVideoWindow(HWND hWnd, const LPRECT prc)
+{
+    if (m_pWindowless == nullptr) {
+        return S_OK; // no-op
+    }
+
+    if (prc) {
+        return m_pWindowless->SetVideoPosition(nullptr, prc);
+    } else {
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+        return m_pWindowless->SetVideoPosition(nullptr, &rc);
+    }
+}
+
+
+HRESULT VMR7::Repaint(HWND hWnd, HDC hdc)
+{
+    if (m_pWindowless)
+    {
+        return m_pWindowless->RepaintVideo(hWnd, hdc);
+    } else {
+        return S_OK;
+    }
+}
+
+
+HRESULT VMR7::DisplayModeChanged()
+{
+    if (m_pWindowless) {
+        return m_pWindowless->DisplayModeChanged();
+    } else {
+        return S_OK;
+    }
+}
+
+
+/**
+ *  VMR-9 Wrapper
+ */
+VMR9::VMR9() : 
+    m_pWindowless(nullptr)
+{
+
+}
+
+
+BOOL VMR9::HasVideo() const 
+{ 
+    return (m_pWindowless != nullptr); 
+}
+
+
+VMR9::~VMR9()
+{
+    SafeRelease(&m_pWindowless);
+}
+
+
+HRESULT VMR9::AddToGraph(IGraphBuilder *pGraph, HWND hWnd)
+{
+    IBaseFilter *pVMR = nullptr;
+
+    HRESULT hr = AddFilterByCLSID(pGraph, CLSID_VideoMixingRenderer9, 
+        &pVMR, L"VMR-9");
+    if (SUCCEEDED(hr)) {
+
+        /**
+         *  Set windowless mode on the VMR. This must be done before the VMR 
+         *  is connected.
+         */
+        hr = InitWindowlessVMR9(pVMR, hWnd, &m_pWindowless);
+    }
+    SafeRelease(&pVMR);
+    return hr;
+}
+
+
+HRESULT VMR9::FinalizeGraph(IGraphBuilder *pGraph)
+{
+    if (m_pWindowless == nullptr) {
+        return S_OK;
+    }
+
+    IBaseFilter *pFilter = nullptr;
+
+    HRESULT hr = m_pWindowless->QueryInterface(IID_PPV_ARGS(&pFilter));
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    BOOL bRemoved;
+    hr = RemoveUnconnectedRenderer(pGraph, pFilter, &bRemoved);
+
+    /**
+     *  If we removed the VMR, then we also need to release our 
+     *  pointer to the VMR's windowless control interface.
+     */
+    if (bRemoved)
+    {
+        SafeRelease(&m_pWindowless);
+    }
+
+done:
+    SafeRelease(&pFilter);
+    return hr;
+}
+
+
+HRESULT VMR9::UpdateVideoWindow(HWND hWnd, const LPRECT prc)
+{
+    if (m_pWindowless == nullptr) {
+        return S_OK; // no-op
+    }
+
+    if (prc) {
+        return m_pWindowless->SetVideoPosition(nullptr, prc);
+    } else {
+
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+        return m_pWindowless->SetVideoPosition(nullptr, &rc);
+    }
+}
+
+
+HRESULT VMR9::Repaint(HWND hWnd, HDC hdc)
+{
+    if (m_pWindowless) {
+        return m_pWindowless->RepaintVideo(hWnd, hdc);
+    } else {
+        return S_OK;
+    }
+}
+
+
+HRESULT VMR9::DisplayModeChanged()
+{
+    if (m_pWindowless) {
+        return m_pWindowless->DisplayModeChanged();
+    } else {
+        return S_OK;
+    }
+}
+
+
+/**
+ *  EVR Wrapper
+ */
+EVR::EVR() :
+    m_pEVR(nullptr),
+    VideoDisplay(nullptr)
+{
+
+}
+
+
+EVR::~EVR()
+{
+    SafeRelease(&m_pEVR);
+    SafeRelease(&VideoDisplay);
+}
+
+
+BOOL EVR::HasVideo() const 
+{ 
+    return (VideoDisplay != nullptr); 
+}
+
+
+HRESULT EVR::AddToGraph(IGraphBuilder *pGraph, HWND hWnd)
+{
+    IBaseFilter *pEVR = nullptr;
+
+    HRESULT hr = AddFilterByCLSID(pGraph, CLSID_EnhancedVideoRenderer, 
+        &pEVR, L"EVR");
+
+    if (FAILED(hr)) {
+        DEBUG_ERROR("DirectShow(EVR): AddFilterByCLSID failed!\n");
+        goto done;
+    }
+
+    hr = InitializeEVR(pEVR, hWnd, &VideoDisplay);
+    if (FAILED(hr)) {
+        DEBUG_ERROR("DirectShow(EVR): InitializeEVR failed!\n");
+        goto done;
+    }
+
+    /**
+     *  NOTE: Because IMFVideoDisplayControl is a service interface,
+     *  you cannot QI the pointer to get back the IBaseFilter pointer.
+     *  Therefore, we need to cache the IBaseFilter pointer.
+     */
+    m_pEVR = pEVR;
+    m_pEVR->AddRef();
+
+done:
+    SafeRelease(&pEVR);
+    return hr;
+}
+
+
+HRESULT EVR::FinalizeGraph(IGraphBuilder *pGraph)
+{
+    if (m_pEVR == nullptr) {
+        return S_OK;
+    }
+
+    BOOL bRemoved;
+    HRESULT hr = RemoveUnconnectedRenderer(pGraph, m_pEVR, &bRemoved);
+    if (bRemoved) {
+        SafeRelease(&m_pEVR);
+        SafeRelease(&VideoDisplay);
+    }
+    return hr;
+}
+
+
+HRESULT EVR::UpdateVideoWindow(HWND hWnd, const LPRECT prc)
+{
+    if (VideoDisplay == nullptr) {
+        return S_OK; // no-op
+    }
+
+    if (prc) {
+        return VideoDisplay->SetVideoPosition(nullptr, prc);
+    } else {
+
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+        return VideoDisplay->SetVideoPosition(nullptr, &rc);
+    }
+}
+
+
+HRESULT EVR::Repaint(HWND hWnd, HDC hdc)
+{
+    if (VideoDisplay) {
+        return VideoDisplay->RepaintVideo();
+    } else {
+        return S_OK;
+    }
+}
+
+
+HRESULT EVR::DisplayModeChanged()
+{
+    /**
+     *  The EVR does not require any action in response to WM_DISPLAYCHANGE.
+     */
+    return S_OK;
+}

--- a/src/dshowvideo/dshowrenderer.h
+++ b/src/dshowvideo/dshowrenderer.h
@@ -1,0 +1,129 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DSHOWRENDERER.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         DirectShow video renderers.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "always.h"
+#include <dshow.h>
+#include <d3d9.h>
+#include <Vmr9.h>
+#include <Evr.h>
+
+
+/**
+ * 
+ *  Heavily based on Windows SDK sample code.
+ * 
+ */
+
+
+/**
+ *  Abstract class to manage the video renderer filter.
+ *  Specific implementations handle the VMR-7, VMR-9, or EVR filter.
+ */
+class BaseVideoRenderer
+{
+    public:
+        BaseVideoRenderer() {}
+        virtual ~BaseVideoRenderer() {}
+
+        virtual BOOL HasVideo() const = 0;
+        virtual HRESULT AddToGraph(IGraphBuilder *pGraph, HWND hwnd) = 0;
+        virtual HRESULT FinalizeGraph(IGraphBuilder *pGraph) = 0;
+        virtual HRESULT UpdateVideoWindow(HWND hwnd, const LPRECT prc) = 0;
+        virtual HRESULT Repaint(HWND hwnd, HDC hdc) = 0;
+        virtual HRESULT DisplayModeChanged() = 0;
+};
+
+
+/**
+ *  Manages the VMR-7 (Video Mixing Renderer Filter 7) video renderer filter.
+ */
+class VMR7 : public BaseVideoRenderer
+{
+    public:
+        VMR7();
+        ~VMR7();
+
+        BOOL HasVideo() const;
+        HRESULT AddToGraph(IGraphBuilder *pGraph, HWND hwnd);
+        HRESULT FinalizeGraph(IGraphBuilder *pGraph);
+        HRESULT UpdateVideoWindow(HWND hwnd, const LPRECT prc);
+        HRESULT Repaint(HWND hwnd, HDC hdc);
+        HRESULT DisplayModeChanged();
+        
+    public:
+        IVMRWindowlessControl *m_pWindowless;
+};
+
+
+/**
+ *  Manages the VMR-9 (Video Mixing Renderer Filter 9) video renderer filter.
+ */
+class VMR9 : public BaseVideoRenderer
+{
+    public:
+        VMR9();
+        ~VMR9();
+
+        BOOL HasVideo() const;
+        HRESULT AddToGraph(IGraphBuilder *pGraph, HWND hwnd);
+        HRESULT FinalizeGraph(IGraphBuilder *pGraph);
+        HRESULT UpdateVideoWindow(HWND hwnd, const LPRECT prc);
+        HRESULT Repaint(HWND hwnd, HDC hdc);
+        HRESULT DisplayModeChanged();
+
+    public:
+        IVMRWindowlessControl9 *m_pWindowless;
+};
+
+
+/**
+ *  Manages the EVR (Enhanced) video renderer filter.
+ */
+class EVR : public BaseVideoRenderer
+{
+    public:
+        EVR();
+        ~EVR();
+
+        BOOL HasVideo() const;
+        HRESULT AddToGraph(IGraphBuilder *pGraph, HWND hwnd);
+        HRESULT FinalizeGraph(IGraphBuilder *pGraph);
+        HRESULT UpdateVideoWindow(HWND hwnd, const LPRECT prc);
+        HRESULT Repaint(HWND hwnd, HDC hdc);
+        HRESULT DisplayModeChanged();
+
+    public:
+        IBaseFilter *m_pEVR;
+        IMFVideoDisplayControl *VideoDisplay;
+};
+
+
+HRESULT InitializeEVR(IBaseFilter *pEVR, HWND hwnd, IMFVideoDisplayControl ** ppWc); 
+HRESULT InitWindowlessVMR9(IBaseFilter *pVMR, HWND hwnd, IVMRWindowlessControl9 ** ppWc); 
+HRESULT InitWindowlessVMR(IBaseFilter *pVMR, HWND hwnd, IVMRWindowlessControl** ppWc); 

--- a/src/dshowvideo/dshowutil.cpp
+++ b/src/dshowvideo/dshowutil.cpp
@@ -1,0 +1,157 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DSHOWUTIL.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         DirectShow utility functions.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "dshowutil.h"
+
+
+HRESULT RemoveUnconnectedRenderer(IGraphBuilder *pGraph, IBaseFilter *pRenderer, BOOL *pbRemoved)
+{
+    IPin *pPin = nullptr;
+
+    *pbRemoved = false;
+
+    /**
+     *  Look for a connected input pin on the renderer.
+     */
+    HRESULT hr = FindConnectedPin(pRenderer, PINDIR_INPUT, &pPin);
+    SafeRelease(&pPin);
+
+    /**
+     *  If this function succeeds, the renderer is connected, so we don't remove it.
+     *  If it fails, it means the renderer is not connected to anything, so
+     *  we remove it.
+     */
+    if (FAILED(hr)) {
+        hr = pGraph->RemoveFilter(pRenderer);
+        *pbRemoved = true;
+    }
+
+    return hr;
+}
+
+
+HRESULT IsPinConnected(IPin *pPin, BOOL *pResult)
+{
+    IPin *pTmp = nullptr;
+
+    HRESULT hr = pPin->ConnectedTo(&pTmp);
+    if (SUCCEEDED(hr)) {
+        *pResult = true;
+
+    } else if (hr == VFW_E_NOT_CONNECTED) {
+
+        /**
+         *  The pin is not connected. This is not an error for our purposes.
+         */
+        *pResult = false;
+        hr = S_OK;
+    }
+
+    SafeRelease(&pTmp);
+    return hr;
+}
+
+
+HRESULT IsPinDirection(IPin *pPin, PIN_DIRECTION dir, BOOL *pResult)
+{
+    PIN_DIRECTION pinDir;
+    HRESULT hr = pPin->QueryDirection(&pinDir);
+    if (SUCCEEDED(hr)) {
+        *pResult = (pinDir == dir);
+    }
+    return hr;
+}
+
+
+HRESULT FindConnectedPin(IBaseFilter *pFilter, PIN_DIRECTION PinDir, 
+    IPin **ppPin)
+{
+    IEnumPins *pEnum = nullptr;
+    IPin *pPin = nullptr;
+
+    *ppPin = nullptr;
+
+    HRESULT hr = pFilter->EnumPins(&pEnum);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    BOOL bFound = false;
+    while (S_OK == pEnum->Next(1, &pPin, nullptr)) {
+
+        BOOL bIsConnected;
+        hr = IsPinConnected(pPin, &bIsConnected);
+        if (SUCCEEDED(hr)) {
+            if (bIsConnected) {
+                hr = IsPinDirection(pPin, PinDir, &bFound);
+            }
+        }
+
+        if (FAILED(hr)) {
+            pPin->Release();
+            break;
+        }
+        if (bFound) {
+            *ppPin = pPin;
+            break;
+        }
+        pPin->Release();
+    }
+
+    pEnum->Release();
+
+    if (!bFound)
+    {
+        hr = VFW_E_NOT_FOUND;
+    }
+    return hr;
+}
+
+
+HRESULT AddFilterByCLSID(IGraphBuilder *pGraph, REFGUID clsid, 
+    IBaseFilter **ppF, LPCWSTR wszName)
+{
+    *ppF = nullptr;
+    IBaseFilter *pFilter = nullptr;
+    
+    HRESULT hr = CoCreateInstance(clsid, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pFilter));
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    hr = pGraph->AddFilter(pFilter, wszName);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    *ppF = pFilter;
+    (*ppF)->AddRef();
+
+done:
+    SafeRelease(&pFilter);
+    return hr;
+}

--- a/src/dshowvideo/dshowutil.h
+++ b/src/dshowvideo/dshowutil.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          SETUP_HOOKS.CPP
+ *  @file          DSHOWUTIL.H
  *
  *  @author        CCHyper
  *
- *  @brief         Contains the main function that sets up all hooks.
+ *  @brief         DirectShow utility functions.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -25,34 +25,26 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#include "setup_hooks.h"
+#pragma once
 
-/**
- *  Include the hook headers here.
- */
-#include "vinifera_newdel.h"
-#include "crt_hooks.h"
-#include "debug_hooks.h"
-#include "vinifera_hooks.h"
-#include "newswizzle_hooks.h"
-#include "extension_hooks.h"
-#include "cncnet4_hooks.h"
-#include "cncnet5_hooks.h"
-#include "dshowvideo_hooks.h"
+#include <windows.h>
+#include <dshow.h>
 
 
-void Setup_Hooks()
-{
-    Vinifera_Memory_Hooks();
+template <class T> void SafeRelease(T **ppT) { if (*ppT) { (*ppT)->Release(); *ppT = nullptr; } }
 
-    CRT_Hooks();
-    Debug_Hooks();
-    Vinifera_Hooks();
-    NewSwizzle_Hooks();
-    Extension_Hooks();
 
-    CnCNet4_Hooks();
-    CnCNet5_Hooks();
+#ifndef SAFE_ARRAY_DELETE
+#define SAFE_ARRAY_DELETE(x) { if(x) { delete[] x; x = nullptr; } }
+#endif
 
-    DirectShowVideo_Hooks();
-}
+#ifndef SAFE_DELETE
+#define SAFE_DELETE(x) { delete x; x = nullptr; }
+#endif
+
+
+HRESULT RemoveUnconnectedRenderer(IGraphBuilder *pGraph, IBaseFilter *pRenderer, BOOL *pbRemoved);
+HRESULT IsPinConnected(IPin *pPin, BOOL *pResult);
+HRESULT IsPinDirection(IPin *pPin, PIN_DIRECTION dir, BOOL *pResult);
+HRESULT FindConnectedPin(IBaseFilter *pFilter, PIN_DIRECTION PinDir, IPin **ppPin);
+HRESULT AddFilterByCLSID(IGraphBuilder *pGraph, REFGUID clsid, IBaseFilter **ppF, LPCWSTR wszName);

--- a/src/dshowvideo/dshowvideo.cpp
+++ b/src/dshowvideo/dshowvideo.cpp
@@ -1,0 +1,1535 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DSHOWVIDEO.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         DirectShow video player interface.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "dshowvideo.h"
+#include "dshowrenderer.h"
+#include "dshowutil.h"
+#include "tibsun_globals.h"
+#include "tibsun_functions.h"
+#include "vinifera_util.h"
+#include "options.h"
+#include "ccfile.h"
+#include "ini.h"
+#include "winutil.h"
+#include "wwkeyboard.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+#include <string>
+#include <new>
+
+
+/**
+ *  Default constructor.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+DirectShowVideoPlayer::DirectShowVideoPlayer() :
+    hWnd(nullptr),
+    State(STATE_NO_GRAPH),
+    Format(FORMAT_NONE),
+    SeekCaps(0),
+    IsAudioStream(false),
+    CurrentVolume(MAX_VOLUME),
+    IsMuted(false),
+    PlaybackRate(1.0),
+    IsBreakoutAllowed(false),
+    IsScalingAllowed(false),
+    Filename(nullptr),
+    FilenameNoExt(nullptr),
+    VideoWidth(NORMAL_VIDEO_WIDTH),
+    VideoHeight(NORMAL_VIDEO_HEIGHT),
+    Graph(nullptr),
+    Video(nullptr),
+    Control(nullptr),
+    Event(nullptr),
+    Seek(nullptr),
+    Position(nullptr),
+    Audio(nullptr),
+    FrameStep(nullptr),
+    VideoRenderer(nullptr)
+{
+}
+
+
+/**
+ *  Constructor that takes window handle and filename.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+DirectShowVideoPlayer::DirectShowVideoPlayer(HWND hWnd, const char *pszFileName) :
+    hWnd(nullptr),
+    State(STATE_NO_GRAPH),
+    Format(FORMAT_NONE),
+    SeekCaps(0),
+    IsAudioStream(false),
+    CurrentVolume(MAX_VOLUME),
+    IsMuted(false),
+    PlaybackRate(1.0),
+    IsBreakoutAllowed(false),
+    IsScalingAllowed(false),
+    Filename(nullptr),
+    FilenameNoExt(nullptr),
+    VideoWidth(NORMAL_VIDEO_WIDTH),
+    VideoHeight(NORMAL_VIDEO_HEIGHT),
+    Graph(nullptr),
+    Video(nullptr),
+    Control(nullptr),
+    Event(nullptr),
+    Seek(nullptr),
+    Position(nullptr),
+    Audio(nullptr),
+    FrameStep(nullptr),
+    VideoRenderer(nullptr)
+{
+    Open_File(pszFileName);
+}
+
+
+/**
+ *  
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+DirectShowVideoPlayer::~DirectShowVideoPlayer()
+{
+    Reset();
+}
+
+
+/**
+ *  Reset the video player instance. 
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+void DirectShowVideoPlayer::Reset()
+{
+    Tear_Down_Graph();
+
+    hWnd = nullptr;
+    State = STATE_NO_GRAPH;
+    Format = FORMAT_NONE;
+    SeekCaps = 0;
+    IsAudioStream = false;
+    CurrentVolume = MAX_VOLUME;
+    IsMuted = false;
+    PlaybackRate = 1.0;
+    IsBreakoutAllowed = false;
+    IsScalingAllowed = false;
+    Filename = nullptr;
+    FilenameNoExt = nullptr;
+    VideoWidth = NORMAL_VIDEO_WIDTH;
+    VideoHeight = NORMAL_VIDEO_HEIGHT;
+    Graph = nullptr;
+    Video = nullptr;
+    Control = nullptr;
+    Event = nullptr;
+    Seek = nullptr;
+    Position = nullptr;
+    Audio = nullptr;
+    FrameStep = nullptr;
+    VideoRenderer = nullptr;
+}
+
+
+/**
+ *  Open a media file ready for playback.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Open_File(const char *pszFileName)
+{
+    IBaseFilter *pSource = nullptr;
+    std::string dest_filename;
+    HRESULT hr;
+
+    /**
+     *  Create a new filter graph (This also closes the old one).
+     */
+    hr = Initialize_Graph();
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    WCHAR wFileName[MAX_PATH];
+
+    /**
+     *  Check to see if the file exists.
+     */
+    if (!Is_File_Available(pszFileName, &dest_filename)) {
+        goto done;
+    }
+
+    MultiByteToWideChar(CP_ACP, 0, dest_filename.c_str(), -1, wFileName, MAX_PATH);
+    
+    /**
+     *  Add the source filter to the graph.
+     */
+    hr = Graph->AddSourceFilter(wFileName, nullptr, &pSource);
+
+    /**
+     *  If the media file was not found, inform the user.
+     */
+    if (hr == VFW_E_NOT_FOUND) {
+        DEBUG_ERROR("DirectShow: Media file not found! Error code: 0x%08x.\n", hr);
+        goto done;
+    }
+
+    if (FAILED(hr)) {
+        DEBUG_ERROR("DirectShow: Could not add source filter to graph! Error code: 0x%08x.\n", hr);
+        goto done;
+    }
+
+    /**
+     *  Store the filename.
+     */
+    Filename = dest_filename.c_str();
+    FilenameNoExt = pszFileName;
+
+    /**
+     *  Try to render the streams.
+     */
+    hr = Render_Streams(pSource);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Get the seeking capabilities.
+     */
+    hr = Seek->GetCapabilities(&SeekCaps);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Set the volume.
+     */
+    hr = Update_Volume();
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Update our state.
+     */
+    State = STATE_STOPPED;
+
+done:
+    //if (FAILED(hr)) {
+    //    Tear_Down_Graph();
+    //}
+
+    SafeRelease(&pSource);
+
+    return hr;
+}
+
+
+/**
+ *  Respond to a graph event.
+ * 
+ *  The owning window should call this method when it receives the window
+ *  message that the application specified when it called SetEventWindow.
+ * 
+ *  pfnOnGraphEvent:
+ *      Pointer to the GraphEventCallback callback, implemented by 
+ *      the application. This callback is invoked once for each event
+ *      in the queue.
+ * 
+ *  @warning: Do not tear down the graph from inside the callback.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Handle_Graph_Event(GraphEventCallback *pfnOnGraphEvent)
+{
+    if (!pfnOnGraphEvent) {
+        return E_UNEXPECTED;
+    }
+
+    if (!Event) {
+        return E_UNEXPECTED;
+    }
+
+    long evCode = 0;
+    LONG_PTR param1 = 0;
+    LONG_PTR param2 = 0;
+
+    HRESULT hr = S_OK;
+    
+    /**
+     *  Get the events from the queue.
+     */
+    while (SUCCEEDED(Event->GetEvent(&evCode, &param1, &param2, 0))) {
+
+        /**
+         *  Invoke the callback.
+         */
+        pfnOnGraphEvent->OnGraphEvent(evCode, param1, param2);
+        
+        /**
+         *  Free the event data.
+         */
+        hr = Event->FreeEventParams(evCode, param1, param2);
+        if (FAILED(hr)) {
+            break;
+        }
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Start playing the video.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Play()
+{
+    if (State != STATE_PAUSED && State != STATE_STOPPED) {
+        return VFW_E_WRONG_STATE;
+    }
+
+    ASSERT(Graph); // If state is correct, the graph should exist.
+
+    /**
+     *  Run the graph to play the media file.
+     */
+    HRESULT hr = Control->Run();
+    if (SUCCEEDED(hr)) {
+        State = STATE_RUNNING;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Play_Callback()
+{
+    Play();
+
+    WWKeyboard->Clear();
+
+    /*if (IsScalingAllowed) {
+        InvalidateRect(hWnd, nullptr, false);
+    }*/
+
+    PAINTSTRUCT ps;
+    HDC hdc;
+
+    //hdc = BeginPaint(hWnd, &ps);
+
+    bool process = true;
+
+    while (process) {
+
+        /**
+         *  Are there any Windows messages to handle?
+         */
+        if (!VQA_Movie_Message_Loop()) {
+            break;
+        }
+
+        /**
+         *  Handle window focus loss and restore.
+         */
+        if (!GameInFocus && State == STATE_PAUSED) {
+            DEBUG_INFO("DirectShow: Focus Restore.\n");
+            Play();
+
+        } else if (!GameInFocus && State == STATE_RUNNING) {
+            DEBUG_INFO("DirectShow: Focus Loss.\n");
+            Pause();
+        }
+
+        /**
+         *  Has the video finished? If so, stop it.
+         */
+        if (Is_Finished()) {
+            DEV_DEBUG_INFO("DirectShow: Video finished.\n");
+            State = STATE_STOPPED;
+            //break;
+        }
+    
+        /**
+         *  HAve we lost the video?
+         */
+        if (!Has_Video()) {
+            DEV_DEBUG_INFO("DirectShow: Video lost, ending playback.\n");
+            break;
+        }
+    
+        /**
+         *  If we have been flagged as finished, we are done.
+         */
+        if (State == STATE_STOPPED) {
+            DEV_DEBUG_INFO("DirectShow: Video stopped, ending playback.\n");
+            Stop_Events();
+            break;
+        }
+
+        /**
+         *  Are we still playing? Draw the next frame.
+         */
+        if (State == STATE_RUNNING) {
+
+            /**
+             *  The player has video, so ask the player to repaint.
+             */
+            //Repaint(hdc);
+
+        } else {
+
+            /**
+             *  We are paused. we don't need to redraw every tick, so add a little wait to take
+             *  the stress away from the CPU, because you know, it has a hard life...
+             */
+            //Repaint(hdc);
+            Sleep(33); // Sleep for 33 msec.
+        }
+
+        /**
+         *  Check for any keyboard input.
+         */
+        if (WWKeyboard->Check()) {
+
+            switch (WWKeyboard->Get()) {
+
+                /**
+                 *  Debug only: Space bar toggles pause.
+                 */
+                case (KN_RLSE_BIT|KN_SPACE):
+                    if (Vinifera_DeveloperMode) {
+                        if (State == STATE_PAUSED) {
+                            DEV_DEBUG_INFO("DirectShow: RESUME\n");
+                            Play();
+                        } else {
+                            DEV_DEBUG_INFO("DirectShow: PAUSE\n");
+                            Pause();
+                        }
+                    }
+                    break;
+
+                /**
+                 *  Debug only: Display the debug overlay.
+                 */
+                case (KN_RLSE_BIT|KN_D):
+                    if (Vinifera_DeveloperMode) {
+                    }
+                    break;
+
+                /**
+                 *  Debug only: Restart playback.
+                 */
+                case (KN_RLSE_BIT|KN_R):
+                    if (Vinifera_DeveloperMode && Can_Seek()) {
+                        DEV_DEBUG_INFO("DirectShow: Restarting playback.\n");
+                        Set_Position(0);
+                    }
+                    break;
+
+                /**
+                 *  Debug only: Mute volume.
+                 */
+                case (KN_RLSE_BIT|KN_M):
+                    if (Vinifera_DeveloperMode) {
+                        if (Is_Muted()) {
+                            DEV_DEBUG_INFO("DirectShow: Mute.\n");
+                            Mute(false);
+                        } else {
+                            DEV_DEBUG_INFO("DirectShow: Unmute.\n");
+                            Mute(true);
+                        }
+                    }
+                    break;
+
+                /**
+                 *  Debug only: Adjust playback rate.
+                 */
+                case (KN_RLSE_BIT|KN_MINUS):
+                    if (Vinifera_DeveloperMode) {
+                        DEV_DEBUG_INFO("DirectShow: Rate down.\n");
+                        Set_Rate(PlaybackRate-0.10f);
+                    }
+                    break;
+                case (KN_RLSE_BIT|KN_EQUAL):
+                    if (Vinifera_DeveloperMode) {
+                        DEV_DEBUG_INFO("DirectShow: Rate up.\n");
+                        Set_Rate(PlaybackRate+0.10f);
+                    }
+                    break;
+
+                /**
+                 *  Debug only: Adjust volume.
+                 */
+                case (KN_RLSE_BIT|KN_KEYPAD_MINUS):
+                    if (Vinifera_DeveloperMode) {
+                        DEV_DEBUG_INFO("DirectShow: Volume down.\n");
+                        Set_Volume(CurrentVolume-0.10f);
+                    }
+                    break;
+                case (KN_RLSE_BIT|KN_KEYPAD_PLUS):
+                    if (Vinifera_DeveloperMode) {
+                        DEV_DEBUG_INFO("DirectShow: Volume up.\n");
+                        Set_Volume(CurrentVolume+0.10f);
+                    }
+                    break;
+
+                /**
+                 *  Debug only: Frame step.
+                 */
+                case (KN_RLSE_BIT|KN_F1):
+                {
+                    if (Vinifera_DeveloperMode && Can_Seek()) {
+                        DEV_DEBUG_INFO("DirectShow: Frame step.\n");
+                        Step_One_Frame();
+                    }
+                    break;
+                }
+
+                /**
+                 *  Debug only: Previous and next frame. The payback must be
+                 *              paused for these keys to work.
+                 */
+                case (KN_RLSE_BIT|KN_COMMA):
+                {
+                    if (Vinifera_DeveloperMode && Can_Seek()) {
+                        DEV_DEBUG_INFO("DirectShow: Seek back .5 second.\n");
+                        LONGLONG current;
+                        Get_Current_Position(&current);
+                        Set_Position(current - HALF_SEC);
+                    }
+                    break;
+                }
+                case (KN_RLSE_BIT|KN_PERIOD):
+                    if (Vinifera_DeveloperMode && Can_Seek()) {
+                        DEV_DEBUG_INFO("DirectShow: Seek forward .5 second.\n");
+                        LONGLONG current;
+                        Get_Current_Position(&current);
+                        Set_Position(current + HALF_SEC);
+                    }
+                    break;
+
+                /**
+                 *  Check if the ESC key has been pressed. If so, break out
+                 *  and stop all frame updates.
+                 */
+                case (KN_RLSE_BIT|KN_ESC):
+                    if (IsBreakoutAllowed) {
+                        DEBUG_INFO("DirectShow: Breakout.\n");
+                        Stop();
+                        UpdateWindow(hWnd);
+                        //State = STATE_STOPPED;
+                        //process = false;
+                    }
+                    break;
+            };
+
+        }
+    
+    }
+
+    //EndPaint(hWnd, &ps);
+
+    /*if (IsScalingAllowed) {
+        InvalidateRect(hWnd, nullptr, false);
+    }*/
+
+    /**
+     *  Clear the keyboard buffers.
+     */
+    WWKeyboard->Clear();
+
+    return S_OK;
+}
+
+
+/**
+ *  
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Pause()
+{
+    if (State != STATE_RUNNING) {
+        return VFW_E_WRONG_STATE;
+    }
+
+    ASSERT(Graph); // If state is correct, the graph should exist.
+
+    HRESULT hr = Control->Pause();
+    if (SUCCEEDED(hr)) {
+        State = STATE_PAUSED;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Stop()
+{
+    if (State != STATE_RUNNING && State != STATE_PAUSED) {
+        return VFW_E_WRONG_STATE;
+    }
+
+    ASSERT(Graph); // If state is correct, the graph should exist.
+
+    HRESULT hr = Control->Stop();
+    if (SUCCEEDED(hr)) {
+        State = STATE_STOPPED;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+BOOL DirectShowVideoPlayer::Is_File_Available(const char *pszFileName, std::string *dest)
+{
+    for (int format = 0; format < FORMAT_COUNT; ++format) {
+        
+        std::string filename;
+        std::string tmp;
+
+        /**
+         *  Reset filename.
+         */
+        filename = pszFileName;
+
+        switch (format) {
+            case FORMAT_MP4:
+                filename += ".MP4";
+                break;
+            case FORMAT_WMV:
+                filename += ".WMV";
+                break;
+            case FORMAT_MPG:
+                filename += ".MPG";
+                break;
+            default:
+            case FORMAT_AVI:
+                filename += ".AVI";
+                break;
+        };
+
+        /**
+         *  Load from the file system. We use CDFileClass so local files
+         *  have priority over any video files in the mix files.
+         */
+        CDFileClass localfile(filename.c_str());
+        if (localfile.Is_Available()) {
+            if (dest) *dest = localfile.File_Name();
+            DEBUG_INFO("DirectShow: Found \"%s\".\n", localfile.File_Name());
+            return true;
+        }
+
+        /**
+         *  #TODO: Mix file support.
+         */
+#if 0
+        /**
+         *  Lastly check in the games mix files.
+         */
+        DEBUG_INFO("DirectShow: Search for \"%s\" in mix files.\n", filename.c_str());
+        if (CCFileClass(filename.c_str()).Is_Available()) {
+            if (dest) *dest = filename;
+            DEBUG_INFO("DirectShow: Found \"%s\".\n", filename.c_str());
+            return true;
+        }
+#endif
+
+    }
+
+    return false;
+}
+
+
+/**
+ *  Has the video player lost the renderer or ran out of frames to play?
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+BOOL DirectShowVideoPlayer::Has_Video() const 
+{
+#if 0
+    if (!VideoRenderer) {
+        DEBUG_ERROR("DirectShow: VideoRenderer is null!\n");
+        return false;
+    }
+    if (!VideoRenderer->HasVideo()) {
+        DEBUG_ERROR("DirectShow: HasVideo returned false!\n");
+        return false;
+    }
+#endif
+    return VideoRenderer && VideoRenderer->HasVideo(); 
+}
+
+
+/**
+ *  Sets the destination rectangle for the video.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+BOOL DirectShowVideoPlayer::Update_Video_Window(const LPRECT prc)
+{
+    if (!VideoRenderer) {
+        DEBUG_WARNING("DirectShow: Unable to update window, VideoRenderer is null!\n");
+        return S_OK;
+    }
+
+    bool fixup_default_scale = false;
+
+    /**
+     *  Get the size of the current window.
+     */
+    RECT rect;
+
+    /**
+     *  This is a workaround to make sure that we stretch the video to the size set by
+     *  a custom DDRAW dll, even if the size is larger than the game resolution.
+     */
+    if (RawFileClass("DDRAW.DLL").Is_Available()) {
+        RawFileClass ddrawfile("DDRAW.INI");
+        INIClass ddrawini;
+
+        ddrawini.Load(ddrawfile);
+
+        GetClientRect(hWnd, &rect);
+
+        int ddraw_width = ddrawini.Get_Int("ddraw", "width", rect.right);
+        int ddraw_height = ddrawini.Get_Int("ddraw", "height", rect.bottom);
+
+        if ((ddraw_width > 0 && ddraw_height > 0)
+          && (Options.ScreenWidth != ddraw_width || Options.ScreenHeight != ddraw_height)) {
+            fixup_default_scale = true;
+            rect.right = ddraw_width;
+            rect.bottom = ddraw_height;
+            DEV_DEBUG_WARNING("DirectShow: Possible resolution mismatch in ddraw.ini!\n");
+        }
+    }
+
+    /**
+     *  We detected a possible resolution mis-match, attempt to fix it.
+     */
+    if (fixup_default_scale) {
+
+        /**
+         *  #TODO:
+         *  For now we have to assume that the user set the resolution
+         *  in DDRAW.INI to x2 of the game resolution.
+         */
+        rect.left = prc->left*2;
+        rect.top = prc->top*2;
+        rect.right = prc->right*2;
+        rect.bottom = prc->bottom*2;
+
+    } else {
+        rect.left = prc->left;
+        rect.top = prc->top;
+        rect.right = prc->right;
+        rect.bottom = prc->bottom;
+    }
+
+    if (VideoRenderer) {
+        return VideoRenderer->UpdateVideoWindow(hWnd, &rect) == S_OK;
+    }
+
+    return false;
+}
+
+
+/**
+ *  Set the desired video window handle.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Set_Video_Window(HWND new_hWnd)
+{
+    if (!VideoRenderer) {
+        DEBUG_WARNING("DirectShow: Unable to set window, VideoRenderer is null!\n");
+        return S_OK;
+    }
+
+    /*if (!Video) {
+        DEBUG_WARNING("DirectShow: Unable to set window, Video is null!\n");
+        return S_OK;
+    }*/
+
+    bool fixup_default_scale = false;
+
+    /**
+     *  Get the size of the current window.
+     */
+    RECT rect;
+    GetClientRect(new_hWnd, &rect);
+
+    /**
+     *  This is a workaround to make sure that we stretch the video to the size set by
+     *  a custom DDRAW dll, even if the size is larger than the game resolution.
+     */
+    if (RawFileClass("DDRAW.DLL").Is_Available()) {
+        RawFileClass ddrawfile("DDRAW.INI");
+        INIClass ddrawini;
+
+        ddrawini.Load(ddrawfile);
+
+        int ddraw_width = ddrawini.Get_Int("ddraw", "width", rect.right);
+        int ddraw_height = ddrawini.Get_Int("ddraw", "height", rect.bottom);
+
+        if ((ddraw_width > 0 && ddraw_height > 0)
+          && (Options.ScreenWidth != ddraw_width || Options.ScreenHeight != ddraw_height)) {
+            fixup_default_scale = true;
+            rect.right = ddraw_width;
+            rect.bottom = ddraw_height;
+            DEV_DEBUG_WARNING("DirectShow: Possible resolution mismatch in ddraw.ini!\n");
+        }
+    }
+
+    /**
+     *  Store the screen surface size.
+     */
+    int surface_width = rect.right;
+    int surface_height = rect.bottom;
+
+    /**
+     *  Stretch (while maintaining aspect ratio) the movie to the window size.
+     */
+    Options.StretchMovies = true;
+    if (IsScalingAllowed && Options.StretchMovies) {
+
+        /**
+         *  Fetch the video dimensions.
+         */
+        /*if (Video) {
+            HRESULT hr = Video->GetVideoSize(&VideoWidth, &VideoHeight);
+            if (FAILED(hr)) {
+                return hr;
+            }
+        }*/
+
+        /**
+         *  Set the full window size, DirectShow will do the scaling for us.
+         */
+        rect.left = 0;
+        rect.top = 0;
+        rect.right = surface_width;
+        rect.bottom = surface_height;
+
+    /**
+     *  We detected a possible resolution mis-match, attempt to fix it.
+     */
+    } else if (fixup_default_scale) {
+    
+        /**
+         *  #TODO:
+         *  For now we have to assume that the user set the resolution
+         *  in DDRAW.INI to x2 of the game resolution.
+         */
+        rect.left = (surface_width-(NORMAL_VIDEO_WIDTH*2))/2;
+        rect.top = (surface_height-(NORMAL_VIDEO_HEIGHT*2))/2;
+        rect.right = (rect.left+(NORMAL_VIDEO_WIDTH*2));
+        rect.bottom = (rect.top+(NORMAL_VIDEO_HEIGHT*2));
+
+    } else {
+
+        /**
+         *  Even if the video is larger than 640x400, we still
+         *  retain the original expectations of the video playback
+         *  and tell DirectShow to scale the video down.
+         */
+        rect.left = (surface_width-(NORMAL_VIDEO_WIDTH))/2;
+        rect.top = (surface_height-(NORMAL_VIDEO_HEIGHT))/2;
+        rect.right = (rect.left+(NORMAL_VIDEO_WIDTH));
+        rect.bottom = (rect.top+(NORMAL_VIDEO_HEIGHT));
+    }
+
+    DEBUG_INFO("DirectShow: %d,%d,%d,%d\n", rect.left, rect.top, rect.right, rect.bottom);
+
+    return VideoRenderer->UpdateVideoWindow(new_hWnd, &rect);
+}
+
+
+/**
+ *  Repaints the video. Call this method when the application receives WM_PAINT.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Repaint(HDC hdc)
+{
+    if (VideoRenderer) {
+        return VideoRenderer->Repaint(hWnd, hdc);
+    }
+
+    return S_OK;
+}
+
+
+/**
+ *  Notifies the video renderer that the display mode changed.
+ *  Call this method when the application receives WM_DISPLAYCHANGE.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Display_Mode_Changed()
+{
+    if (VideoRenderer) {
+        return VideoRenderer->DisplayModeChanged();
+    }
+
+    return S_OK;
+}
+
+
+/**
+ *  Returns TRUE if the current file is seekable.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+BOOL DirectShowVideoPlayer::Can_Seek() const
+{
+    const DWORD caps = AM_SEEKING_CanSeekAbsolute | AM_SEEKING_CanGetDuration;
+    return ((SeekCaps & caps) == caps);
+}
+
+
+/**
+ *  Seeks to a new position.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Set_Position(REFERENCE_TIME pos)
+{
+    if (Control == nullptr || Seek == nullptr) {
+        return E_UNEXPECTED;
+    }
+
+    HRESULT hr = S_OK;
+
+    hr = Seek->SetPositions(&pos, AM_SEEKING_AbsolutePositioning,
+        nullptr, AM_SEEKING_NoPositioning);
+
+    if (SUCCEEDED(hr)) {
+
+        /**
+         *  If playback is stopped, we need to put the graph into the paused
+         *  state to update the video renderer with the new frame, and then stop 
+         *  the graph again. The IMediaControl::StopWhenReady does this.
+         */
+        if (State == STATE_STOPPED) {
+            hr = Control->StopWhenReady();
+        }
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Gets the duration of the current file.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Get_Duration(LONGLONG *pDuration)
+{
+    if (Seek == nullptr) {
+        return E_UNEXPECTED;
+    }
+
+    return Seek->GetDuration(pDuration);
+}
+
+
+/**
+ *  Gets the current playback position.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Get_Current_Position(LONGLONG *pTimeNow)
+{
+    if (Seek == nullptr) {
+        return E_UNEXPECTED;
+    }
+
+    return Seek->GetCurrentPosition(pTimeNow);
+}
+
+
+/**
+ *  Has the video finished playing?
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+BOOL DirectShowVideoPlayer::Is_Finished()
+{
+    HRESULT hr = S_OK;
+
+    LONGLONG current = 0;
+    LONGLONG duration = 0;
+
+    hr = Get_Current_Position(&current);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    hr = Get_Duration(&duration);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    return current >= duration;
+}
+
+
+/**
+ *  Mutes or unmutes the audio.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT	DirectShowVideoPlayer::Mute(BOOL bMute)
+{
+    IsMuted = bMute;
+    return Update_Volume();
+}
+
+
+/**
+ *  Sets the media volume.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT	DirectShowVideoPlayer::Set_Volume(float lVolume)
+{
+    if (lVolume < 0.0 ) lVolume = 0.0;
+    if (lVolume > 1.0 ) lVolume = 1.0; 
+    // Volume has to be log corrected/converted.
+    CurrentVolume = log10(lVolume) * 4000.0;
+    return Update_Volume();
+}
+
+
+/**
+ *  Update the volume after a call to Mute() or SetVolume().
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Update_Volume()
+{
+    HRESULT hr = S_OK;
+
+    if (IsAudioStream && Audio) {
+
+        /**
+         *  If the audio is muted, set the minimum volume.
+         */ 
+        if (IsMuted) {
+            hr = Audio->put_Volume(MIN_VOLUME);
+
+        } else {
+
+            /**
+             *  Restore previous volume setting.
+             */
+            hr = Audio->put_Volume(CurrentVolume);
+        }
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Stop the window from receiving any render events.
+ * 
+ *  @author: CCHyper
+ */
+void DirectShowVideoPlayer::Stop_Events()
+{
+    /**
+     *  Clear open dialog remnants before calling RenderFile().
+     */
+    UpdateWindow(hWnd);
+
+    /**
+     *  Stop sending event messages.
+     */
+    if (Event) {
+        Event->SetNotifyWindow((OAHWND)nullptr, 0, 0);
+    }
+}
+
+
+/**
+ *  Create a new filter graph. (Tears down the old graph.) 
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Initialize_Graph()
+{
+    Tear_Down_Graph();
+
+    /**
+     *  QueryInterface for DirectShow interfaces
+     */
+
+    /**
+     *  Create the Filter Graph Manager.
+     */
+    HRESULT hr = CoCreateInstance(CLSID_FilterGraph, nullptr, 
+        CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&Graph));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Query for graph interfaces.
+     */
+
+    hr = Graph->QueryInterface(IID_PPV_ARGS(&Control));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    hr = Graph->QueryInterface(IID_PPV_ARGS(&Event));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    hr = Graph->QueryInterface(IID_PPV_ARGS(&Seek));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    hr = Graph->QueryInterface(IID_PPV_ARGS(&Audio));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    hr = Graph->QueryInterface(IID_PPV_ARGS(&Video));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    hr = Graph->QueryInterface(IID_PPV_ARGS(&Position));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Get the frame step interface, if supported.
+     */
+    IVideoFrameStep *pFSTest = nullptr;
+    hr = Graph->QueryInterface(IID_PPV_ARGS(&pFSTest));
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Check if this decoder can step.
+     */
+    hr = pFSTest->CanStep(false, nullptr);
+    if (hr == S_OK) {
+        FrameStep = pFSTest;
+
+    } else {
+        pFSTest->Release();
+    }
+
+    /**
+     *  Set up event notification.
+     *  Have the graph signal event via window callbacks for performance.
+     */
+    hr = Event->SetNotifyWindow((OAHWND)hWnd, WM_GRAPH_EVENT, 0);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    State = STATE_STOPPED;
+
+    return hr;
+}
+
+
+/**
+ *  Tear down the filter graph and release resources.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+void DirectShowVideoPlayer::Tear_Down_Graph()
+{
+    /**
+     *  Clear open dialog remnants before calling RenderFile().
+     */
+    UpdateWindow(hWnd);
+
+    /**
+     *  Stop sending event messages.
+     */
+    if (Event) {
+        Event->SetNotifyWindow((OAHWND)nullptr, 0, 0);
+    }
+
+    SafeRelease(&Graph);
+    SafeRelease(&Control);
+    SafeRelease(&Event);
+    SafeRelease(&Seek);
+    SafeRelease(&Audio);
+    SafeRelease(&Video);
+
+    SAFE_DELETE(VideoRenderer);
+
+    State = STATE_NO_GRAPH;
+    SeekCaps = 0;
+
+    IsAudioStream = false;
+}
+
+
+/**
+ *  Create the DirectShow renderer.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Create_Video_Renderer()
+{
+    HRESULT hr = E_FAIL;
+
+    enum { Try_EVR, Try_VMR9, Try_VMR7 };
+
+    for (DWORD i = Try_EVR; i <= Try_VMR7; i++) {
+
+        switch (i) {
+            case Try_EVR:
+                DEBUG_INFO("DirectShow: Using EVR.\n");
+                VideoRenderer = new (std::nothrow) EVR();
+                break;
+
+            case Try_VMR9:
+                DEBUG_INFO("DirectShow: Using VMR9.\n");
+                VideoRenderer = new (std::nothrow) VMR9();
+                break;
+
+            case Try_VMR7:
+                DEBUG_INFO("DirectShow: Using VMR7.\n");
+                VideoRenderer = new (std::nothrow) VMR7();
+                break;
+        };
+
+        if (VideoRenderer == nullptr) {
+            hr = E_OUTOFMEMORY;
+            break;
+        }
+
+        hr = VideoRenderer->AddToGraph(Graph, hWnd);
+        if (SUCCEEDED(hr)) {
+            DEV_DEBUG_INFO("DirectShow: VideoRenderer->AddToGraph passed.\n");
+            break;
+        }
+        
+        DEBUG_ERROR("DirectShow: AddToGraph failed!\n");
+
+        SAFE_DELETE(VideoRenderer);
+
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Render the streams from a source filter.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Render_Streams(IBaseFilter *pSource)
+{
+    BOOL bRenderedAnyPin = FALSE;
+
+    IFilterGraph2 *pGraph2 = nullptr;
+    IEnumPins *pEnum = nullptr;
+    IBaseFilter *pAudioRenderer = nullptr;
+
+    HRESULT hr = Graph->QueryInterface(IID_PPV_ARGS(&pGraph2));
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Add the video renderer to the graph.
+     */
+    hr = Create_Video_Renderer();
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Add the DSound Renderer to the graph.
+     */
+    hr = AddFilterByCLSID(Graph, CLSID_DSoundRender, 
+        &pAudioRenderer, L"Audio Renderer");
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Enumerate the pins on the source filter.
+     */
+    hr = pSource->EnumPins(&pEnum);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Loop through all the pins.
+     */
+    IPin *pPin;
+    while (S_OK == pEnum->Next(1, &pPin, nullptr)) {
+
+        /**
+         *  Try to render this pin.
+         *  It's OK if we fail some pins, if at least one pin renders.
+         */
+        HRESULT hr2 = pGraph2->RenderEx(pPin, AM_RENDEREX_RENDERTOEXISTINGRENDERERS, nullptr);
+
+        pPin->Release();
+        if (SUCCEEDED(hr2)) {
+            bRenderedAnyPin = TRUE;
+        }
+    }
+
+    /**
+     *  Remove un-used renderers.
+     */
+
+    /**
+     *  Try to remove the VMR.
+     */
+    hr = VideoRenderer->FinalizeGraph(Graph);
+    if (FAILED(hr)) {
+        goto done;
+    }
+
+    /**
+     *  Try to remove the audio renderer.
+     */
+    BOOL bRemoved = FALSE;
+    hr = RemoveUnconnectedRenderer(Graph, pAudioRenderer, &bRemoved);
+    if (bRemoved) {
+        IsAudioStream = FALSE;
+    } else {
+        IsAudioStream = TRUE;
+    }
+
+done:
+    SafeRelease(&pEnum);
+    //SafeRelease(pVMR);
+    SafeRelease(&pAudioRenderer);
+    SafeRelease(&Audio);
+    SafeRelease(&Video);
+    SafeRelease(&pGraph2);
+
+    /**
+     *  If we succeeded to this point, make sure we rendered at least one
+     *  stream.
+     */
+    if (SUCCEEDED(hr)) {
+        if (!bRenderedAnyPin) {
+            hr = VFW_E_CANNOT_RENDER;
+        }
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Step a single frame forward.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Step_One_Frame()
+{
+    HRESULT hr = S_OK;
+
+    /**
+     *  If the Frame Stepping interface exists, use it to step one frame.
+     */
+    if (FrameStep) {
+
+        /**
+         *  The graph must be paused for frame stepping to work.
+         */
+        if (State != STATE_PAUSED) {
+            Pause();
+        }
+
+        /**
+         *  Step the requested number of frames, if supported.
+         */
+        hr = FrameStep->Step(1, nullptr);
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Skip 'n' frames forward.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Step_Frames(int nFramesToStep)
+{
+    HRESULT hr = S_OK;
+
+    /**
+     *  If the Frame Stepping interface exists, use it to step frames.
+     */
+    if (FrameStep) {
+
+        /**
+         *  The renderer may not support frame stepping for more than one
+         *  frame at a time, so check for support. S_OK indicates that the
+         *  renderer can step nFramesToStep successfully.
+         */
+        if ((hr = FrameStep->CanStep(nFramesToStep, nullptr)) == S_OK) {
+
+            /**
+             *  The graph must be paused for frame stepping to work.
+             */
+            if (State != STATE_PAUSED) {
+                Pause();
+            }
+
+            /**
+             *  Step the requested number of frames, if supported.
+             */
+            hr = FrameStep->Step(nFramesToStep, nullptr);
+        }
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Modify the current playback rate by this delta.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Modify_Rate(double dRateAdjust)
+{
+    HRESULT hr = S_OK;
+    double dRate;
+
+    /**
+     *  If the IMediaPosition interface exists, use it to set rate.
+     */
+    if ((Position) && (dRateAdjust != 0)) {
+        if ((hr = Position->get_Rate(&dRate)) == S_OK) {
+
+            /**
+             *  Add current rate to adjustment value.
+             */
+            double dNewRate = dRate + dRateAdjust;
+            hr = Position->put_Rate(dNewRate);
+
+            /**
+             *  Save new rate.
+             */
+            if (SUCCEEDED(hr)) {
+                PlaybackRate = dNewRate;
+            }
+        }
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Set the desired playback rate.
+ * 
+ *  @author: CCHyper (based on Windows SDK sample code)
+ */
+HRESULT DirectShowVideoPlayer::Set_Rate(double dRate)
+{
+    HRESULT hr = S_OK;
+
+    /**
+     *  If the IMediaPosition interface exists, use it to set rate.
+     */
+    if (Position) {
+        hr = Position->put_Rate(dRate);
+
+        /**
+         *  Save new rate
+         */
+        if (SUCCEEDED(hr)) {
+            PlaybackRate = dRate;
+        }
+    }
+
+    return hr;
+}
+
+#if 0
+double getDurationInSeconds(){
+    if( isLoaded() ){
+        long long lDurationInNanoSecs = 0;
+        m_pSeek->GetDuration(&lDurationInNanoSecs);
+        double timeInSeconds = (double)lDurationInNanoSecs/10000000.0;
+
+        return timeInSeconds;
+    }
+    return 0.0;
+}
+
+double getCurrentTimeInSeconds(){
+    if( isLoaded() ){
+        long long lCurrentTimeInNanoSecs = 0;
+        m_pSeek->GetCurrentPosition(&lCurrentTimeInNanoSecs);
+        double timeInSeconds = (double)lCurrentTimeInNanoSecs/10000000.0;
+
+        return timeInSeconds;
+    }
+    return 0.0;
+}
+#endif

--- a/src/dshowvideo/dshowvideo.h
+++ b/src/dshowvideo/dshowvideo.h
@@ -1,0 +1,201 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DSHOWVIDEO.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         DirectShow video player interface.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "always.h"
+#include <windows.h>
+#include <dshow.h>
+#include <d3d9.h>
+#include <control.h>
+#include <string>
+
+
+/**
+ * 
+ *  Direct show video player heavily based on Windows SDK sample code.
+ * 
+ */
+
+
+class BaseVideoRenderer;
+
+
+enum PlaybackState
+{
+    STATE_NO_GRAPH,
+    STATE_RUNNING,
+    STATE_PAUSED,
+    STATE_STOPPED,
+};
+
+
+/**
+ *  Supported video format types.
+ */
+enum FormatType
+{
+    FORMAT_MP4,
+    FORMAT_WMV,
+    FORMAT_MPG,
+    FORMAT_AVI,
+    FORMAT_COUNT,
+
+    FORMAT_NONE = -1
+};
+
+
+/**
+ *  Un-stretched video size.
+ */
+#define NORMAL_VIDEO_WIDTH 720
+#define NORMAL_VIDEO_HEIGHT 400
+
+const long MIN_VOLUME = -10000;
+const long MAX_VOLUME = 0;
+
+const LONG ONE_MSEC = 10000;                // The number of 100-ns in 1 msec.
+const LONG HALF_SEC = (ONE_MSEC*1000)/2;
+const LONG ONE_SEC = (ONE_MSEC*1000);
+
+const UINT WM_GRAPH_EVENT = WM_APP + 1;
+
+
+struct GraphEventCallback
+{
+	virtual void OnGraphEvent(long eventCode, LONG_PTR param1, LONG_PTR param2) = 0;
+};
+
+
+class DirectShowVideoPlayer
+{
+    public:
+        DirectShowVideoPlayer();
+        DirectShowVideoPlayer(HWND hWnd, const char *pszFileName);
+        ~DirectShowVideoPlayer();
+
+        HRESULT Open_File(const char *pszFileName);
+        void Reset();
+
+        static BOOL Is_File_Available(const char *pszFileName, std::string *dest = nullptr);
+
+        /**
+         *  VMR functionality
+         */
+        BOOL Has_Video() const;
+        BOOL Update_Video_Window(const LPRECT prc);
+        HRESULT Set_Video_Window(HWND hWnd);
+        HRESULT Repaint(HDC hdc);
+        HRESULT Display_Mode_Changed();
+
+        /**
+         *  Events
+         */
+        HRESULT Handle_Graph_Event(GraphEventCallback  *pfnOnGraphEvent);
+
+        /**
+         *  Streaming
+         */
+        HRESULT Play();
+        HRESULT Play_Callback();
+        HRESULT Pause();
+        HRESULT Stop();
+
+        /**
+         *  Seeking
+         */
+        BOOL Can_Seek() const;
+        HRESULT Set_Position(REFERENCE_TIME pos);
+        HRESULT Get_Duration(LONGLONG *pDuration);
+        HRESULT Get_Current_Position(LONGLONG *pTimeNow);
+
+        /**
+         *  Audio
+         */
+        HRESULT Mute(BOOL bMute);
+        BOOL Is_Muted() const { return IsMuted; }
+        HRESULT Set_Volume(float lVolume);
+        float Get_Volume() const { return powf(10, (float)CurrentVolume/4000.0); }
+
+        /**
+         *  Frame stepping
+         */
+        HRESULT Step_One_Frame();
+        HRESULT Step_Frames(int nFramesToStep);
+
+        /**
+         *  Playback
+         */
+        BOOL Is_Finished();
+
+        HRESULT Modify_Rate(double dRateAdjust);
+        HRESULT Set_Rate(double dRate);
+
+        void Set_Breakout(bool breakout) { IsBreakoutAllowed = breakout; }
+        void Set_Stretch(bool stretch) { IsScalingAllowed = stretch; }
+
+        void Set_HWND(HWND new_hWnd) { hWnd = new_hWnd; }
+
+        PlaybackState Get_State() const { return State; }
+        FormatType Get_Format() const { return Format; }
+
+        const char *Get_Filename() const { return Filename; }
+        const char *Get_Filename_NoExt() const { return FilenameNoExt; }
+
+    protected:
+        HRESULT Initialize_Graph();
+        void Tear_Down_Graph();
+        HRESULT Create_Video_Renderer();
+        HRESULT Render_Streams(IBaseFilter *pSource);
+        HRESULT Update_Volume();
+        void Stop_Events();
+
+    private:
+        HWND hWnd;              // Video window. This window also receives graph events.
+        PlaybackState State;
+        FormatType Format;
+        DWORD SeekCaps;         // Caps bits for IMediaSeeking
+        BOOL IsAudioStream;     // Is there an audio stream?
+        long CurrentVolume;     // Current volume (unless muted)
+        BOOL IsMuted;           // Is the volume muted?
+        double PlaybackRate;
+        BOOL IsBreakoutAllowed;
+        BOOL IsScalingAllowed;
+        const char *Filename;
+        const char *FilenameNoExt;
+        LONG VideoWidth;
+        LONG VideoHeight;
+        IGraphBuilder *Graph;
+        IBasicVideo *Video;
+        IMediaControl *Control;
+        IMediaEventEx *Event;
+        IMediaSeeking *Seek;
+        IMediaPosition *Position;
+        IBasicAudio *Audio;
+        IVideoFrameStep *FrameStep;
+        BaseVideoRenderer *VideoRenderer;
+};

--- a/src/dshowvideo/dshowvideo_hooks.cpp
+++ b/src/dshowvideo/dshowvideo_hooks.cpp
@@ -1,0 +1,251 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DSHOWVIDEO_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the DirectShow video player.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "dshowvideo_hooks.h"
+#include "dshowvideo.h"
+#include "tibsun_globals.h"
+#include "dsurface.h"
+#include "iomap.h"
+#include "session.h"
+#include "playmovie.h"
+#include "vox.h"
+#include "wstring.h"
+#include "dsaudio.h"
+#include "wwmouse.h"
+#include "wwkeyboard.h"
+#include "fatal.h"
+#include "winutil.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+#include <string>
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Global instance of the DirectShow video player.
+ */
+static DirectShowVideoPlayer VideoPlayer;
+
+
+/**
+ *  Play a DirectShow video.
+ * 
+ *  @author: CCHyper
+ */
+static bool Play_Movie_DirectShow(const char *name, ThemeType theme, bool clear_before = true, bool stretch_allowed = true, bool clear_after = true)
+{
+    WWKeyboard->Clear();
+    WWMouse->Hide_Mouse();
+
+    /**
+     *  Only play fullscreen videos in campaign/single-player!
+     */
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    if (clear_before) {
+        HiddenSurface->Clear();
+        GScreenClass::Blit(true, HiddenSurface);
+        InvalidateRect(MainWindow, nullptr, false);
+    }
+
+    /**
+     *  Open the new video using the DirectShow player.
+     */
+    VideoPlayer.Set_HWND(MainWindow);
+    VideoPlayer.Open_File(name);
+
+    if (!VideoPlayer.Has_Video()) {
+        DEBUG_ERROR("Failed to create DirectShow instance for \"%s\"!\n", VideoPlayer.Get_Filename() ? VideoPlayer.Get_Filename() : name);
+        return false;
+    }
+
+    DEBUG_INFO("Play_Movie \"%s\" with DirectShow!\n", VideoPlayer.Get_Filename());
+
+    /**
+     *  Full-screen videos can be skipped and scaled.
+     */
+    VideoPlayer.Set_Breakout(true);
+    VideoPlayer.Set_Stretch(stretch_allowed);
+
+    /**
+     *  Setup the drawing window.
+     */
+    VideoPlayer.Set_Video_Window(MainWindow);
+
+    /**
+     *  Play the movie!
+     */
+    VideoPlayer.Play_Callback();
+
+    if (clear_after) {
+        HiddenSurface->Clear();
+        GScreenClass::Blit(true, HiddenSurface);
+        InvalidateRect(MainWindow, nullptr, false);
+    }
+    
+    WWMouse->Show_Mouse();
+    WWKeyboard->Clear();
+
+    /**
+     *  Reset the video player to prepare for next video playback.
+     */
+    VideoPlayer.Reset();
+
+    Map.Flag_To_Redraw(2);
+    
+    return true;
+}
+
+
+/**
+ *  Utility function for checking if a movie exists in any of the known locations.
+ * 
+ *  @author: CCHyper
+ */
+bool Vinifera_Is_Movie_Available(const char *name)
+{
+    static char filename_buffer[32];
+    std::strncpy(filename_buffer, name, sizeof(filename_buffer));
+    
+    /**
+     *  Find the location of the file extension separator.
+     */
+    char *movie_name = std::strchr((char *)filename_buffer, '.');
+    
+    /**
+     *  Unexpected filename format passed in?
+     */
+    if (!movie_name) {
+        return false;
+    }
+
+    /**
+     *  Insert a null-char where the "." was. This will give us the actual
+     *  movie name without the extension, allowing us to rebuild them.
+     */
+    *movie_name = '\0';
+
+    const char *upper_filename = strupr((char *)filename_buffer);
+
+    /**
+     *  Was a DirectShow video found?
+     */
+    if (DirectShowVideoPlayer::Is_File_Available(upper_filename)) {
+        return true;
+    }
+
+    /**
+     *  Finally check if the VQA is available.
+     */
+    return CCFileClass(name).Is_Available();
+}
+
+
+/**
+ *  Intercept to the games Play_Movie which checks if the DirectShow video
+ *  file is available, falling back to VQA if not.
+ * 
+ *  @author: CCHyper
+ */
+void Vinifera_Play_Movie(const char *name, ThemeType theme, bool clear_before, bool stretch_allowed, bool clear_after)
+{
+    static char filename_buffer[32];
+    std::strncpy(filename_buffer, name, sizeof(filename_buffer));
+    
+    /**
+     *  Find the location of the file extension separator.
+     */
+    char *movie_name = std::strchr((char *)filename_buffer, '.');
+    
+    /**
+     *  Unexpected filename format passed in?
+     */
+    if (!movie_name) {
+        DEBUG_ERROR("Invalid movie filename \"%s\"!\n", filename_buffer);
+        return;
+    }
+
+    /**
+     *  Insert a null-char where the "." was. This will give us the actual
+     *  movie name without the extension, allowing us to rebuild them.
+     */
+    *movie_name = '\0';
+
+    const char *upper_filename = strupr((char *)filename_buffer);
+
+    /**
+     *  Attempt to play the video using the DirectShow player.
+     */
+    if (Play_Movie_DirectShow(upper_filename, theme, clear_before, stretch_allowed, clear_after)) {
+        return;
+    } else {
+        DEV_DEBUG_WARNING("Failed to play \"%s\" using DirectShow!\n", upper_filename);
+    }
+
+    char vqa_buffer[32-4];
+    std::snprintf(vqa_buffer, sizeof(vqa_buffer), "%s.VQA", upper_filename);
+
+    /**
+     *  The movie did not exist as a DirectShow or failed to play, attempt to play the .VQA.
+     */
+    if (CCFileClass(vqa_buffer).Is_Available()) {
+        DEBUG_INFO("Play_Movie \"%s\" as VQA!\n", upper_filename);
+
+        /**
+         *  Call the games VQA Play_Movie.
+         */
+        Play_Movie(vqa_buffer, theme, clear_before, stretch_allowed, clear_after);
+        
+    } else {
+        DEBUG_ERROR("Failed to play movie \"%s\" as VQA!\n", upper_filename);
+    }
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void DirectShowVideo_Hooks()
+{
+    /**
+     *  Patch in the main Play_Movie interceptor.
+     */
+    Patch_Call(0x004E07AD, &Vinifera_Play_Movie);
+    Patch_Call(0x004E07CC, &Vinifera_Play_Movie);
+    Patch_Call(0x004E0840, &Vinifera_Play_Movie);
+    Patch_Call(0x004E2865, &Vinifera_Play_Movie);
+    Patch_Call(0x004E287F, &Vinifera_Play_Movie);
+    Patch_Call(0x00563A1C, &Vinifera_Play_Movie);
+    Patch_Call(0x0057FEDA, &Vinifera_Play_Movie);
+    Patch_Call(0x0057FF3F, &Vinifera_Play_Movie);
+    Patch_Call(0x005DB314, &Vinifera_Play_Movie);
+    Patch_Call(0x005E35C8, &Vinifera_Play_Movie);
+}

--- a/src/dshowvideo/dshowvideo_hooks.h
+++ b/src/dshowvideo/dshowvideo_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          SETUP_HOOKS.CPP
+ *  @file          DSHOWVIDEO_HOOKS.H
  *
  *  @author        CCHyper
  *
- *  @brief         Contains the main function that sets up all hooks.
+ *  @brief         Contains the hooks for the DirectShow video player.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -25,34 +25,7 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#include "setup_hooks.h"
-
-/**
- *  Include the hook headers here.
- */
-#include "vinifera_newdel.h"
-#include "crt_hooks.h"
-#include "debug_hooks.h"
-#include "vinifera_hooks.h"
-#include "newswizzle_hooks.h"
-#include "extension_hooks.h"
-#include "cncnet4_hooks.h"
-#include "cncnet5_hooks.h"
-#include "dshowvideo_hooks.h"
+#pragma once
 
 
-void Setup_Hooks()
-{
-    Vinifera_Memory_Hooks();
-
-    CRT_Hooks();
-    Debug_Hooks();
-    Vinifera_Hooks();
-    NewSwizzle_Hooks();
-    Extension_Hooks();
-
-    CnCNet4_Hooks();
-    CnCNet5_Hooks();
-
-    DirectShowVideo_Hooks();
-}
+void DirectShowVideo_Hooks();

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -186,23 +186,14 @@ static bool Vinifera_Play_Startup_Movies()
     static const int WWLOGO_VQA_SIZE = 2415362;
 
     if (Special.IsFromInstall) {
-        DEBUG_INFO("Playing first time intro sequence.\n");
-        Play_Movie("EVA.VQA");
+        DEBUG_GAME("Playing first time intro sequence.\n");
+        Vinifera_Play_Movie("EVA.VQA", THEME_NONE, true, true, true);
     }
 
     if (!Vinifera_SkipLogoMovies) {
-        DEBUG_INFO("Playing logo movies.\n");
-        if (!CCFile_Validate_Is_Available("VINIFERA.VQA", VINIFERA_VQA_SIZE)) {
-            DEBUG_INFO("Failed to find VINIFERA.VQA!\n");
-        } else {
-            Play_Movie("VINIFERA.VQA");
-        }
-        
-        if (!CCFile_Validate_Is_Available("WWLOGO.VQA", WWLOGO_VQA_SIZE)) {
-            DEBUG_INFO("Failed to find WWLOGO.VQA!\n");
-        } else {
-            Play_Movie("WWLOGO.VQA");
-        }
+        DEBUG_GAME("Playing startup movies.\n");
+        Vinifera_Play_Movie("VINIFERA.VQA", THEME_NONE, true, true, true);
+        Vinifera_Play_Movie("WWLOGO.VQA", THEME_NONE, true, true, true);
     } else {
         DEBUG_INFO("Skipping logo movies.\n");
     }
@@ -210,9 +201,9 @@ static bool Vinifera_Play_Startup_Movies()
     if (!NewMenuClass::Get()) {
         DEBUG_INFO("Playing title movie.\n");
         if (CCFile_Is_Available("FS_TITLE.VQA")) {
-            Play_Movie("FS_TITLE.VQA", THEME_NONE, true, false, true);
+            Vinifera_Play_Movie("FS_TITLE.VQA", THEME_NONE, false, false, false);
         } else {
-            Play_Movie("STARTUP.VQA", THEME_NONE, true, false, true);
+            Vinifera_Play_Movie("STARTUP.VQA", THEME_NONE, true, false, false);
         }
     }
 

--- a/src/extensions/newmenu/newmenuext_hooks.cpp
+++ b/src/extensions/newmenu/newmenuext_hooks.cpp
@@ -68,10 +68,10 @@ static void Draw_Title_Screen(bool firestorm)
  */
 static void Set_Addon_Mode(bool firestorm)
 {
-    Addon_4071C0(ADDON_ANY);
+    Addon_Enabled(ADDON_ANY);
 
     if (firestorm) {
-         Addon_407190(ADDON_FIRESTORM);
+         Addon_Enabled(ADDON_FIRESTORM);
     }
 
     Set_Required_Addon(firestorm ? ADDON_FIRESTORM : ADDON_NONE);

--- a/src/util/winutil.cpp
+++ b/src/util/winutil.cpp
@@ -38,8 +38,12 @@
 
 const char *Get_Module_File_Name()
 {
-    static char outbuff[PATH_MAX] = "";
+    static char outbuff[PATH_MAX] = { '\0' };
     char buffer[PATH_MAX];
+
+    if (outbuff[0] != '\0') {
+        return outbuff;
+    }
 
     /**
      *  Get the fully-qualified path of the executable.
@@ -63,6 +67,41 @@ const char *Get_Module_File_Name()
     *(PathFindExtension(out)) = '\0';
 
     std::strcpy(outbuff, out);
+
+    return outbuff;
+}
+
+
+const char *Get_Module_Directory()
+{
+    static char outbuff[PATH_MAX] = { '\0' };
+    char buffer[PATH_MAX];
+
+    if (outbuff[0] != '\0') {
+        return outbuff;
+    }
+
+    /**
+     *  Get the fully-qualified path of the executable.
+     *  Output = "c:\folder\executable.exe"
+     */
+    if (GetModuleFileName(nullptr, buffer, sizeof(buffer)) == sizeof(buffer)) {
+        DEBUG_ERROR("Error with GetModuleFileName in Get_Module_Directory()!");
+        return nullptr;
+    }
+
+    /**
+     *  Go to the beginning of the file name.
+     *  Output = "executable.exe"
+     */
+    char *out = PathFindFileName(buffer);
+
+    /*
+     *  Insert a null character at the module name.
+     */
+    *(out) = '\0';
+
+    std::strcpy(outbuff, buffer);
 
     return outbuff;
 }

--- a/src/util/winutil.h
+++ b/src/util/winutil.h
@@ -34,6 +34,7 @@ const char *Last_System_Error_As_String();
 void Convert_System_Error_To_String(int id, char *buffer, int buf_len);
 
 const char *Get_Module_File_Name();
+const char *Get_Module_Directory();
 const char *Get_Module_File_Name_Ext();
 
 int Load_String_Ex(HINSTANCE hInstance, UINT uID, LPWSTR lpBuffer, INT nBufferMax, WORD wLanguage);

--- a/src/vinifera/vinifera_globals.h
+++ b/src/vinifera/vinifera_globals.h
@@ -30,10 +30,18 @@
 #include "always.h"
 #include "vector.h"
 #include "ccfile.h"
+#include "tibsun_defines.h"
 
 
 class EBoltClass;
 class TheaterTypeClass;
+
+
+/**
+ *  Externs to various Vinifera functions.
+ */
+extern void Vinifera_Play_Movie(const char *, ThemeType = THEME_NONE, bool = true, bool = true, bool = true);
+extern bool Vinifera_Is_Movie_Available(const char *);
 
 
 extern bool Vinifera_DeveloperMode;

--- a/src/vinifera/vinifera_util.cpp
+++ b/src/vinifera/vinifera_util.cpp
@@ -767,15 +767,15 @@ BSurface *Vinifera_Get_Image_Surface(const char *filename)
  * 
  *  @author: CCHyper
  */
-bool Scale_Video_Rect(Rect &rect, int max_width, int max_height, bool maintain_ratio)
+bool Scale_Video_Rect(Rect &rect, int area_width, int area_height, bool maintain_ratio, bool clamp)
 {
     /**
      *  No need to scale the rect if it is larger than the max width/height
      */
-    bool smaller = rect.Width < max_width && rect.Height < max_height;
-    if (!smaller) {
-        return false;
-    }
+    //bool smaller = rect.Width < area_width && rect.Height < area_height;
+    //if (!smaller) {
+    //    return false;
+    //}
 
     /**
      *  This is a workaround for edge case issues with some versions
@@ -783,13 +783,15 @@ bool Scale_Video_Rect(Rect &rect, int max_width, int max_height, bool maintain_r
      *  the resolution the user defines, not what the cnc-ddraw forces
      *  the primary surface to.
      */
-    int surface_width = std::clamp(HiddenSurface->Width, 0, Options.ScreenWidth);
-    int surface_height = std::clamp(HiddenSurface->Height, 0, Options.ScreenHeight);
+    if (clamp) {
+        area_width = std::clamp(HiddenSurface->Width, 0, Options.ScreenWidth);
+        area_height = std::clamp(HiddenSurface->Height, 0, Options.ScreenHeight);
+    }
 
     if (maintain_ratio) {
 
-        double dSurfaceWidth = surface_width;
-        double dSurfaceHeight = surface_height;
+        double dSurfaceWidth = area_width;
+        double dSurfaceHeight = area_height;
         double dSurfaceAspectRatio = dSurfaceWidth / dSurfaceHeight;
 
         double dVideoWidth = rect.Width;
@@ -801,33 +803,33 @@ bool Scale_Video_Rect(Rect &rect, int max_width, int max_height, bool maintain_r
          *  will do, otherwise we need to calculate the new rectangle.
          */
         if (dVideoAspectRatio > dSurfaceAspectRatio) {
-            int nNewHeight = (int)(surface_width/dVideoWidth*dVideoHeight);
-            int nCenteringFactor = (surface_height - nNewHeight) / 2;
+            int nNewHeight = (int)(area_width/dVideoWidth*dVideoHeight);
+            int nCenteringFactor = (area_height - nNewHeight) / 2;
             rect.X = 0;
             rect.Y = nCenteringFactor;
-            rect.Width = surface_width;
+            rect.Width = area_width;
             rect.Height = nNewHeight;
 
         } else if (dVideoAspectRatio < dSurfaceAspectRatio) {
-            int nNewWidth = (int)(surface_height/dVideoHeight*dVideoWidth);
-            int nCenteringFactor = (surface_width - nNewWidth) / 2;
+            int nNewWidth = (int)(area_height/dVideoHeight*dVideoWidth);
+            int nCenteringFactor = (area_width - nNewWidth) / 2;
             rect.X = nCenteringFactor;
             rect.Y = 0;
             rect.Width = nNewWidth;
-            rect.Height = surface_height;
+            rect.Height = area_height;
 
         } else {
             rect.X = 0;
             rect.Y = 0;
-            rect.Width = surface_width;
-            rect.Height = surface_height;
+            rect.Width = area_width;
+            rect.Height = area_height;
         }
 
     } else {
         rect.X = 0;
         rect.Y = 0;
-        rect.Width = surface_width;
-        rect.Height = surface_height;
+        rect.Width = area_width;
+        rect.Height = area_height;
     }
 
     return true;

--- a/src/vinifera/vinifera_util.h
+++ b/src/vinifera/vinifera_util.h
@@ -33,6 +33,7 @@
 
 class XSurface;
 class BSurface;
+class Rect;
 
 
 const char *Vinifera_Version_String();
@@ -68,3 +69,4 @@ HGLOBAL Vinifera_Fetch_Resource(HMODULE handle, const char *id, const char *type
 #endif
 
 BSurface *Vinifera_Get_Image_Surface(const char *filename);
+bool Scale_Video_Rect(Rect &rect, int max_width, int max_height, bool maintain_ratio = false);

--- a/src/vinifera/vinifera_util.h
+++ b/src/vinifera/vinifera_util.h
@@ -69,4 +69,4 @@ HGLOBAL Vinifera_Fetch_Resource(HMODULE handle, const char *id, const char *type
 #endif
 
 BSurface *Vinifera_Get_Image_Surface(const char *filename);
-bool Scale_Video_Rect(Rect &rect, int max_width, int max_height, bool maintain_ratio = false);
+bool Scale_Video_Rect(Rect &rect, int area_width, int area_height, bool maintain_ratio = false, bool clamp = true);


### PR DESCRIPTION
Closes #4 

This pull request implements support for MP4, WMV, MPG and AVI video formats using the Windows DirectShow interface. The tested limitations within the Tiberian Sun engine are 4K and 60FPS, but it is recommended to use 1080p and 30FPS, the engine will handle the scaling to the user-defined resolution size.

Included in the pull request artefacts will be a new video file for testing _(`MOVIES/VINIFERA.WMV`)_. Please extract all the contents of the pull request artefact into the Tiberian Sun directory. Launching the game will play this new signature video without any further changes to enable the system. 

The system is enabled by default, and the game will now auto-detect a video file placed in those locations that match the requested video filename, prioritising it over any existing VQA file. The new system will scan for the supported formats in the following order; MP4, WMV, MPG then AVI, and when it fails to find any supported format, rolling back to VQA.

The system also respects the `StretchMovies=` setting in `SUN.INI`, regardless of the video resolution. This means that with `StretchMovies=no`, all new videos will be played at 640x400, to ensure they match the expected user playback of the original videos.

**Please Note:**
The system is currently limited to full-screen videos only and does not support the new formats within MIX files _(due to a limitation with the Windows API)_. Videos can be placed in either the game root directory or the `MOVIES` sub-directory.

**Codecs:**
WMV, MPG and AVI should play without any additional required codecs on the end-users system, but MP4 overly likely will be required a codec or DirectShow filter to be installed. Once such DirectShow filter is the GDCL "Free DirectShow Mpeg-4 Filters" [http://www.gdcl.co.uk/mpeg4/](http://www.gdcl.co.uk/mpeg4/ ).

Because of this, it is recommended that you use WMV or MPG for your new video files to ensure they play correctly on most end-user systems.

**Testing**
As this is a whole new video system, thorough testing would need to be done on various setups to make sure this meets the expected requirements. Users who can test on **Windows**, **MacOS** and **Linux** are welcome. The following setups should give us a good indication it works correctly;

_The source video `VINIFERA.MP4` is set at 1920x1080 at 60FPS._

- `StretchMovies=yes`, and a screen resolution smaller than 1920x1080.
- `StretchMovies=yes`, and a screen resolution larger than 1920x1080.
- `StretchMovies=no`, and a screen resolution smaller than 1920x1080.
- `StretchMovies=no`, and a screen resolution larger than 1920x1080.

Various "ddraw.dll" setups would also be welcome for testing if available.

**Debug Keys**
When running Vinifera in developer mode, the follow keys are enabled during playback;
- **SPACE** - Pause/Resume the video playback.
- **R** - Restart playback.
- **"-" (Minus)** - Decrease playback rate.
- **"+" (Plus)** - Increase playback rate.
- **Numpad "-" (Minus)** - Decrease volume.
- **Numpad "+" (Plus)** - Increase volume.
- **F1** - Step forward one frame.
- **"," (Comma/<)** - Seek backwards .5 seconds.
- **"." (Peroid/>)** - Seek forward .5 seconds.

If you run into any issues, please identify your settings, operating system, and hardware profile.
