### PR TITLE
Implements new local file search paths for various game formats.

### DIFF
--- a/src/extensions/cdfile/cdfileext_hooks.cpp
+++ b/src/extensions/cdfile/cdfileext_hooks.cpp
@@ -1,0 +1,160 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CDFILEEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CDFileClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "cdfileext_hooks.h"
+#include "cdfile.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or deconstructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+class CDFileClassFake : public CDFileClass
+{
+    public:
+        const char * _Set_Name(const char *filename);
+        bool _Open(const char *filename, FileAccessType rights);
+};
+
+
+/**
+ *  Performs a multiple directory scan to set the filename.
+ * 
+ *  @author: 10/18/1994 JLB - Red Alert source code.
+ *           CCHyper - Adjustments for Vinifera.
+ */
+const char * CDFileClassFake::_Set_Name(const char *filename)
+{
+    /**
+     *  Try to find the file in the current directory first. If it can be found, then
+     *  just return with the normal file name setting process. Do the same if there is
+     *  no multi-drive search path.
+     */
+    BufferIOFileClass::Set_Name(filename);
+    if (IsDisabled || !First || BufferIOFileClass::Is_Available()) {
+        return File_Name();
+    }
+
+    /**
+     *  Attempt to find the file first. Check the current directory. If not found there, then
+     *  search all the path specifications available. If it still can't be found, then just
+     *  fall into the normal raw file filename setting system.
+     */
+    SearchDriveType * srch = First;
+
+    while (srch) {
+        char path[_MAX_PATH];
+
+        /**
+         *  Build a pathname to search for.
+         */
+        std::strcpy(path, srch->Path);
+        std::strcat(path, filename);
+
+        /**
+         *  Check to see if the file could be found. The low level Is_Available logic will
+         *  prompt if necessary when the CD-ROM drive has been removed. In all other cases,
+         *  it will return false and the search process will continue.
+         */
+        BufferIOFileClass::Set_Name(path);
+        if (BufferIOFileClass::Is_Available()) {
+            DEV_DEBUG_INFO("CDFileClass::Set_Name - \"%s\" Found in: %s\n", filename, path);
+            return File_Name();
+        }
+
+        /**
+         *  It wasn't found, so try the next path entry.
+         */
+        srch = (SearchDriveType *)srch->Next;
+    }
+
+    /**
+     *  At this point, all path searching has failed. Just set the file name to the
+     *  plain text passed to this routine and be done with it.
+     */
+    BufferIOFileClass::Set_Name(filename);
+    return File_Name();
+}
+
+
+/**
+ *  Opens the file wherever it can be found.
+ * 
+ *  @author: 10/18/1994 JLB - Red Alert source code.
+ *           CCHyper - Adjustments for Vinifera.
+ */
+bool CDFileClassFake::_Open(const char *filename, FileAccessType rights)
+{
+    CDFileClass::Close();
+
+    /**
+     *  Verify that there is a filename associated with this file object. If not, then this is a
+     *  big error condition.
+     */
+    if (!filename) {
+        Error(FILE_ERROR_NOENT, false);
+    }
+
+    /**
+     *  If writing is requested, then multiple drive searching is not performed.
+     */
+    if (IsDisabled || rights == FILE_ACCESS_WRITE) {
+        BufferIOFileClass::Set_Name(filename);
+        return BufferIOFileClass::Open(rights);
+    }
+
+    /**
+     *  Perform normal multiple drive searching for the filename and open
+     *  using the normal procedure.
+     */
+    Set_Name(filename);
+    if (BufferIOFileClass::Open(rights)) {
+        DEV_DEBUG_INFO("CDFileClass::Open - Opened: %s\n", Filename);
+        return true;
+    }
+
+    return false;
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void CDFileClassExtension_Hooks()
+{
+    Patch_Jump(0x00450AD0, &CDFileClassFake::_Open);
+    Patch_Jump(0x004509D0, &CDFileClassFake::_Set_Name);
+}

--- a/src/extensions/cdfile/cdfileext_hooks.h
+++ b/src/extensions/cdfile/cdfileext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CDFILEEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CDFileClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void CDFileClassExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -86,6 +86,7 @@
 #include "dropshipext_hooks.h"
 
 #include "cciniext_hooks.h"
+#include "cdfileext_hooks.h"
 
 #include "skirmishdlg_hooks.h"
 
@@ -164,6 +165,7 @@ void Extension_Hooks()
     DropshipExtension_Hooks();
 
     CCINIClassExtension_Hooks();
+    CDFileClassExtension_Hooks();
 
     /**
      *  Dialogs and associated code.

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -87,6 +87,7 @@
 
 #include "cciniext_hooks.h"
 #include "cdfileext_hooks.h"
+#include "mixfileext_hooks.h"
 
 #include "skirmishdlg_hooks.h"
 
@@ -166,6 +167,7 @@ void Extension_Hooks()
 
     CCINIClassExtension_Hooks();
     CDFileClassExtension_Hooks();
+    MixFileClassExtension_Hooks();
 
     /**
      *  Dialogs and associated code.

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -31,13 +31,123 @@
 #include "special.h"
 #include "playmovie.h"
 #include "ccfile.h"
+#include "cd.h"
 #include "newmenu.h"
+#include "addon.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-478
+ * 
+ *  Reimplemention of Init_Bootstrap_Mixfiles()
+ *  
+ *  Registers and caches any mixfiles needed for bootstrapping.
+ * 
+ *  @author: CCHyper
+ */
+static bool Vinifera_Init_Bootstrap_Mixfiles()
+{
+    bool ok;
+    MFCC *mix;
+
+    int temp = CD::RequiredCD;
+    CD::Set_Required_CD(-2);
+
+    DEBUG_INFO("\n"); // Fixes missing new-line after "Bootstrap..." print.
+    //DEBUG_INFO("Init bootstrap mixfiles...\n");
+
+    if (RawFileClass("PATCH.MIX").Is_Available()) {
+        mix = new MFCC("PATCH.MIX", &FastKey);
+        ASSERT(mix);
+        if (mix) {
+            DEBUG_INFO(" PATCH.MIX\n");
+        }
+    }
+
+    if (CCFileClass("PCACHE.MIX").Is_Available()) {
+        mix = new MFCC("PCACHE.MIX", &FastKey);
+        ASSERT(mix);
+        if (mix) {
+            mix->Cache();
+            DEBUG_INFO(" PCACHE.MIX\n");
+        }
+    }
+
+    for (int i = 99; i >= 0; --i) {
+        char buffer[16];
+        std::snprintf(buffer, sizeof(buffer), "EXPAND%02d.MIX", i);
+        if (RawFileClass(buffer).Is_Available()) {
+            mix = new MFCC(buffer, &FastKey);
+            ASSERT(mix);
+            if (!mix) {
+                DEBUG_WARNING("Failed to load %s!\n", buffer);
+            } else {
+                ExpansionMixFiles.Add(mix);
+                DEBUG_INFO(" %s\n", buffer);
+            }
+        }
+    }
+
+    for (int i = 99; i >= 0; --i) {
+        char buffer[16];
+        std::snprintf(buffer, sizeof(buffer), "ECACHE%02d.MIX", i);
+        if (CCFileClass(buffer).Is_Available()) {
+            mix = new MFCC(buffer, &FastKey);
+            ASSERT(mix);
+            if (!mix) {
+                DEBUG_WARNING("Failed to load %s!\n", buffer);
+            } else {
+                mix->Cache();
+                ExpansionMixFiles.Add(mix);
+                DEBUG_INFO(" %s\n", buffer);
+            }
+        }
+    }
+
+    Addon_Present();
+
+    TibSunMix = new MFCC("TIBSUN.MIX", &FastKey);
+    ASSERT(TibSunMix);
+    if (!TibSunMix) {
+        DEBUG_WARNING("Failed to load TIBSUN.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" TIBSUN.MIX\n");
+
+    /*
+    **	Bootstrap enough of the system so that the error dialog
+    *   box can successfully be displayed.
+    */
+    CacheMix = new MFCC("CACHE.MIX", &FastKey);
+    ASSERT(CacheMix);
+    if (!CacheMix) {
+        DEBUG_WARNING("Failed to load CACHE.MIX!\n");
+        return false;
+    }
+    if (!CacheMix->Cache()) {
+        DEBUG_WARNING("Failed to cache CACHE.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" CACHE.MIX\n");
+
+    LocalMix = new MFCC("LOCAL.MIX", &FastKey);
+    ASSERT(LocalMix);
+    if (!LocalMix) {
+        DEBUG_WARNING("Failed to load LOCAL.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" LOCAL.MIX\n");
+
+    CD::Set_Required_CD(temp);
+
+    return true;
+}
 
 
 static bool CCFile_Is_Available(const char *filename)
@@ -95,4 +205,5 @@ skip_loading_screen:
 void GameInit_Hooks()
 {
     Patch_Jump(0x004E0786, &_Init_Game_Skip_Startup_Movies_Patch);
+    Patch_Jump(0x004E3D20, &Vinifera_Init_Bootstrap_Mixfiles);
 }

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -30,6 +30,7 @@
 #include "tibsun_globals.h"
 #include "special.h"
 #include "playmovie.h"
+#include "theme.h"
 #include "ccfile.h"
 #include "cd.h"
 #include "newmenu.h"
@@ -43,7 +44,7 @@
 
 
 /**
- *  #issue-478
+ *  #issue-
  * 
  *  Reimplemention of Init_Bootstrap_Mixfiles()
  *  
@@ -150,6 +151,129 @@ static bool Vinifera_Init_Bootstrap_Mixfiles()
 }
 
 
+/**
+ *  #issue-
+ * 
+ *  Reimplemention of Init_Secondary_Mixfiles()
+ *  
+ *  Register and cache secondary mixfiles.
+ * 
+ *  @author: CCHyper
+ */
+static bool Vinifera_Init_Secondary_Mixfiles()
+{
+    char buffer[16];
+
+    DEBUG_INFO("\n"); // Fixes missing new-line after "Init Secondary Mixfiles....." print.
+    //DEBUG_INFO("Init secondary mixfiles...\n");
+
+    if (CCFileClass("CONQUER.MIX").Is_Available()) {
+        ConquerMix = new MFCC("CONQUER.MIX", &FastKey);
+        ASSERT(ConquerMix);
+    }
+    if (!ConquerMix) {
+        DEBUG_WARNING("Failed to load CONQUER.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" CONQUER.MIX\n");
+
+    int cd = CD::Get_Volume_Index();
+
+    /**
+     *  Make sure we have a grounded volume index (invalid volumes will cause error).
+     */
+    if (CD::Get_Volume_Index() < 0) {
+        cd = 0;
+    }
+
+    /**
+     *  Mix file indices are 1 based.
+     */
+    cd += 1;
+
+    std::snprintf(buffer, sizeof(buffer), "MAPS%02d.MIX", cd);
+    if (CCFileClass(buffer).Is_Available()) {
+        MapsMix = new MFCC(buffer, &FastKey);
+        ASSERT(MapsMix);
+    }
+    if (!MapsMix) {
+        DEBUG_WARNING("Failed to load %s!\n", buffer);
+        return false;
+    }
+    DEBUG_INFO(" %s\n", buffer);
+
+    if (CCFileClass("MULTI.MIX").Is_Available()) {
+        MultiMix = new MFCC("MULTI.MIX", &FastKey);
+        ASSERT(MultiMix);
+    }
+    if (!MultiMix) {
+        DEBUG_WARNING("Failed to load MULTI.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" MULTI.MIX\n", buffer);
+
+    if (Addon_407120(ADDON_FIRESTORM)) {
+        if (CCFileClass("SOUNDS01.MIX").Is_Available()) {
+            FSSoundsMix = new MFCC("SOUNDS01.MIX", &FastKey);
+            ASSERT(FSSoundsMix);
+        }
+        if (!FSSoundsMix) {
+            DEBUG_WARNING("Failed to load SOUNDS01.MIX!\n");
+            return false;
+        }
+        DEBUG_INFO(" SOUNDS01.MIX\n", buffer);
+    }
+
+    if (CCFileClass("SOUNDS.MIX").Is_Available()) {
+        SoundsMix = new MFCC("SOUNDS.MIX", &FastKey);
+        ASSERT(SoundsMix);
+    }
+    if (!SoundsMix) {
+        DEBUG_WARNING("Failed to load SOUNDS.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" SOUNDS.MIX\n", buffer);
+
+    if (CCFileClass("SCORES01.MIX").Is_Available()) {
+        FSScoresMix = new MFCC("SCORES01.MIX", &FastKey);
+        ASSERT(FSScoresMix);
+    }
+    if (!FSScoresMix) {
+        DEBUG_WARNING("Failed to load SCORES01.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" SCORES01.MIX\n", buffer);
+
+	/*
+	**	Register the score mixfile.
+	*/
+    if (CCFileClass("SCORES.MIX").Is_Available()) {
+        ScoreMix = new MFCC("SCORES.MIX", &FastKey);
+        ASSERT(ScoreMix);
+    }
+    if (!ScoreMix) {
+        DEBUG_WARNING("Failed to load SCORES.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" SCORES.MIX\n", buffer);
+	ScoresPresent = true;
+	Theme.Scan();
+
+    std::snprintf(buffer, sizeof(buffer), "MOVIES%02d.MIX", cd);
+    if (CCFileClass(buffer).Is_Available()) {
+        MoviesMix = new MFCC(buffer, &FastKey);
+        ASSERT(MoviesMix);
+    }
+    if (!MoviesMix) {
+        DEBUG_WARNING("Failed to load %s!\n", buffer);
+        return false;
+    }
+    DEBUG_INFO(" %s\n", buffer);
+
+    return true;
+}
+
+
 static bool CCFile_Is_Available(const char *filename)
 {
     return CCFileClass(filename).Is_Available();
@@ -206,4 +330,5 @@ void GameInit_Hooks()
 {
     Patch_Jump(0x004E0786, &_Init_Game_Skip_Startup_Movies_Patch);
     Patch_Jump(0x004E3D20, &Vinifera_Init_Bootstrap_Mixfiles);
+    Patch_Jump(0x004E4120, &Vinifera_Init_Secondary_Mixfiles);
 }

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -274,6 +274,30 @@ static bool Vinifera_Init_Secondary_Mixfiles()
 }
 
 
+/**
+ *  #issue-513
+ * 
+ *  Patch to add check for CD::IsFilesLocal to make sure -CD really
+ *  was set by the user.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Init_CDROM_Access_Local_Files_Patch)
+{
+    _asm { add esp, 4 }
+
+    if (CCFileClass::Is_There_Search_Drives() && CD::IsFilesLocal) {
+        goto files_local;
+    }
+
+init_cdrom:
+    JMP(0x004E0471);
+
+files_local:
+    JMP(0x004E06F5);
+}
+
+
 static bool CCFile_Is_Available(const char *filename)
 {
     return CCFileClass(filename).Is_Available();
@@ -331,4 +355,5 @@ void GameInit_Hooks()
     Patch_Jump(0x004E0786, &_Init_Game_Skip_Startup_Movies_Patch);
     Patch_Jump(0x004E3D20, &Vinifera_Init_Bootstrap_Mixfiles);
     Patch_Jump(0x004E4120, &Vinifera_Init_Secondary_Mixfiles);
+    Patch_Jump(0x004E0461, &_Init_CDROM_Access_Local_Files_Patch);
 }

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -63,7 +63,13 @@ static bool Vinifera_Init_Bootstrap_Mixfiles()
     DEBUG_INFO("\n"); // Fixes missing new-line after "Bootstrap..." print.
     //DEBUG_INFO("Init bootstrap mixfiles...\n");
 
-    if (RawFileClass("PATCH.MIX").Is_Available()) {
+    /**
+     *  #issue-514
+     * 
+     *  Make sure the loading of PATCH.MIX honors the search path interface.
+     */
+    //if (RawFileClass("PATCH.MIX").Is_Available()) {
+    if (CCFileClass("PATCH.MIX").Is_Available()) {
         mix = new MFCC("PATCH.MIX", &FastKey);
         ASSERT(mix);
         if (mix) {
@@ -83,7 +89,13 @@ static bool Vinifera_Init_Bootstrap_Mixfiles()
     for (int i = 99; i >= 0; --i) {
         char buffer[16];
         std::snprintf(buffer, sizeof(buffer), "EXPAND%02d.MIX", i);
-        if (RawFileClass(buffer).Is_Available()) {
+        /**
+         *  #issue-514
+         * 
+         *  Make sure the loading of EXPAND##.MIX honors the search path interface.
+         */
+        //if (RawFileClass(buffer).Is_Available()) {
+        if (CCFileClass(buffer).Is_Available()) {
             mix = new MFCC(buffer, &FastKey);
             ASSERT(mix);
             if (!mix) {

--- a/src/extensions/mixfile/mixfileext_hooks.cpp
+++ b/src/extensions/mixfile/mixfileext_hooks.cpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          MIXFILEEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended MixFileClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "mixfileext_hooks.h"
+#include "mixfile.h"
+#include "cdfile.h"
+#include "vector.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+static DynamicVectorClass<void *> AllocPointers;
+
+
+/**
+ *  Allocates a buffer and loads the file into it.
+ * 
+ *  @author: 10/17/1994 JLB - Red Alert source code.
+ *           CCHyper - Adjustments for Vinifera.
+ */
+static void * Load_Alloc_Data(FileClass &file)
+{
+	void *ptr = nullptr;
+	long size = file.Size();
+
+	ptr = new char [size];
+	if (ptr) {
+		file.Read(ptr, size);
+	}
+
+	return ptr;
+}
+
+
+/**
+ *  Frees up any buffers we allocated.
+ * 
+ *  @author: CCHyper
+ */
+static void __cdecl Free_Alloc_Data()
+{
+    DEBUG_INFO("Cleanuping up locally loaded file memory...");
+
+    for (int i = 0; i < AllocPointers.Count(); ++i) {
+        delete [] AllocPointers[i];
+    }
+
+    AllocPointers.Clear();
+}
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or deconstructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+class MixFileClassFake : public MixFileClass
+{
+    public:
+        static const void * _Retrieve(const char *filename);
+};
+
+
+/**
+ *  Retrieves a pointer to the specified data file.
+ * 
+ *  @author: 08/23/1994 JLB - Red Alert source code.
+ *           CCHyper - Adjustments for Vinifera.
+ */
+const void * MixFileClassFake::_Retrieve(const char * filename)
+{
+    void * ptr = nullptr;
+
+    /**
+     *  #issue-515
+     * 
+     *  Various game assets are loaded with Retrieve only, and as a result
+     *  do not use the typical file searching interface. This addition makes
+     *  the game check if the file exists in the root directory before searching
+     *  the loaded mix files.
+     * 
+     *  @author: CCHyper
+     */
+    CDFileClass file;
+    file.Set_Name(filename);
+    if (file.Is_Available()) {
+        ptr = Load_Alloc_Data(file);
+        if (ptr) {
+            if (!AllocPointers.Count()) {
+                std::atexit(Free_Alloc_Data);
+            }
+            AllocPointers.Add(ptr);
+            return ptr;
+        }
+    }
+
+    /**
+     *  Original code from Retrieve().
+     */
+    ptr = nullptr;
+    Offset(filename, &ptr);
+    return ptr;
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void MixFileClassExtension_Hooks()
+{
+    Patch_Jump(0x00559DE0, &MixFileClassFake::_Retrieve);
+}

--- a/src/extensions/mixfile/mixfileext_hooks.h
+++ b/src/extensions/mixfile/mixfileext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          MIXFILEEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended MixFileClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void MixFileClassExtension_Hooks();

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -31,6 +31,8 @@
 #include "cncnet4.h"
 #include "cncnet4_globals.h"
 #include "cncnet5_globals.h"
+#include "ccfile.h"
+#include "cd.h"
 #include "debughandler.h"
 #include <string>
 
@@ -149,6 +151,16 @@ bool Vinifera_Parse_Command_Line(int argc, char *argv[])
             DEBUG_INFO("  - Skipping to Firestorm menu.\n");
             Vinifera_ExitAfterSkip = true;
             menu_skip = true;
+        }
+
+        /**
+         *  #issue-513
+         * 
+         *  Re-implements the file search path override logic of "-CD" from Red Alert.
+         */
+        if (std::strstr(string, "-CD")) {
+            CCFileClass::Set_Search_Drives(&string[3]);
+            CD::IsFilesLocal = true;
             continue;
         }
 

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -229,3 +229,15 @@ bool Vinifera_Shutdown()
 
     return true;
 }
+
+
+/**
+ *  This function will get called right before the games "Init_Game" fuction,
+ *  allowing you to perform any action that would effect the game initialisation process.
+ * 
+ *  @author: CCHyper
+ */
+int Vinifera_Init_Game(int argc, char *argv[])
+{
+    return EXIT_SUCCESS;
+}

--- a/src/vinifera_functions.h
+++ b/src/vinifera_functions.h
@@ -33,3 +33,4 @@
 bool Vinifera_Parse_Command_Line(int argc, char *argv[]);
 bool Vinifera_Startup();
 bool Vinifera_Shutdown();
+int Vinifera_Init_Game(int argc, char *argv[]);

--- a/src/vinifera_hooks.cpp
+++ b/src/vinifera_hooks.cpp
@@ -183,6 +183,46 @@ DECLARE_PATCH(_Game_Shutdown_Vinifera_Shutdown)
 
 
 /**
+ *  Patch in the Vinifera init game function.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Main_Game_Vinifera_Init_Game)
+{
+    GET_REGISTER_STATIC(int, argc, ecx);
+    GET_REGISTER_STATIC(char **, argv, edx);
+    static int retval;
+
+    retval = Vinifera_Init_Game(argc, argv);
+    if (retval) {
+        if (retval < 0) {
+            goto show_error;
+        }
+        goto failure;
+    }
+    DEV_DEBUG_INFO("Vinifera_Init_Game returned OK.\n");
+
+    retval = Init_Game(argc, argv);
+    if (retval) {
+        if (retval < 0) {
+            goto show_error;
+        }
+        goto failure;
+    }
+    DEV_DEBUG_INFO("Init_Game returned OK.\n");
+
+success:
+    JMP(0x00462990);
+
+failure:
+    JMP(0x00462932);
+
+show_error:
+    JMP(0x00462938);
+}
+
+
+/**
  *  #issue-96
  * 
  *  Remove the requirement for BLOWFISH.DLL (Blowfish encryption) and now
@@ -266,6 +306,7 @@ void Vinifera_Hooks()
     Patch_Jump(0x00601070, &_WinMain_Parse_Command_Line);
     Patch_Jump(0x005FF81C, &_WinMain_Vinifera_Startup);
     Patch_Jump(0x00602474, &_Game_Shutdown_Vinifera_Shutdown);
+    Patch_Jump(0x00462927, &_Main_Game_Vinifera_Init_Game);
 
     /**
      *  Remove the requirement for BLOWFISH.DLL (Blowfish encryption).


### PR DESCRIPTION
Closes #87, Closes #94, Closes #513, Closes #514, Closes #515

This pull request implements various new systems to allow users, mods and mod developers to use subdirectories to store game files.

-- **Local CD Files**
The `-CD` command-line argument from Red Alert has been implemented. This allows the user to define an additional local search directory for placing the contents of the game CD's.

-- **File Loading**
The following search directories have been added _(in order of priority, root folder is still highest)_;
`INI` - `.INI` control files and `.TXT` files.
`MIX` - `.MIX` archive files.
`SHP` - `.SHP` image files and `.PAL` palettes.
`AUD` - Any/all `.AUD` files.
`PCX` - `.PCX` image files.
`MAPS\MULTIPLAYER` - Multiplayer `.MAP` and `.MPR` maps, `.PKT` files.
`MAPS\MISSION` - Mission `.MAP` scenarios.
`MAPS` - Both Multiplayer and Mission maps, `.MAP` and `.MPR`, `.PKT` files.
`MOVIES` - `.VQA` video files.
`MUSIC` - `.AUD` theme files.
`SOUNDS` - `.AUD` sound effect files.

Also, for adding CD content locally;
`TS1`, `CD1`, and `GDI` - Contents of the GDI CD _(must also contain `TS1.DSK`)_.
`TS2`, `CD2`, and `NOD` - Contents of the NOD CD _(must also contain `TS2.DSK`)_.
`TS3`, `CD3`, and `FIRESTORM` - Contents of the Firestorm CD _(must also contain `TS1.DSK`)_.

In addition to this, three system environment variables have been added for you to define if you use version control or use a cloud storage system that syncs to your PC. For more on adding environment vars: https://superuser.com/questions/949560/how-do-i-set-system-environment-variables-in-windows-10

`TIBSUN_MOVIES` - `.VQA` video files.
`TIBSUN_MUSIC` - `.AUD` theme files.
`TIBSUN_FILES` - Any and all formats the game supports.
