### PR TITLE
Allow the score screen to be skipped at the end of a multiplayer game.

### DIFF
--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -27,12 +27,53 @@
  ******************************************************************************/
 #include "scenarioext_hooks.h"
 #include "scenarioext_functions.h"
+#include "tibsun_globals.h"
+#include "multiscore.h"
+#include "scenario.h"
+#include "session.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-522
+ * 
+ *  These patches make the multiplayer score screen to honour the value of
+ *  "IsSkipScore" from ScenarioClass.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Do_Win_Skip_MPlayer_Score_Screen_Patch)
+{
+    /**
+     *  Stolen bytes/code.
+     */
+    ++Session.GamesPlayed;
+
+    if (!Scen->IsSkipScore) {
+        MultiScore::Presentation();
+    }
+
+    JMP(0x005DC9DF);
+}
+
+DECLARE_PATCH(_Do_Lose_Skip_MPlayer_Score_Screen_Patch)
+{
+    /**
+     *  Stolen bytes/code.
+     */
+    ++Session.GamesPlayed;
+
+    if (!Scen->IsSkipScore) {
+        MultiScore::Presentation();
+    }
+
+    JMP(0x005DCD9D);
+}
 
 
 /**
@@ -46,4 +87,7 @@ void ScenarioClassExtension_Hooks()
      *  @author: CCHyper
      */
     Patch_Call(0x005E08E3, &Vinifera_Assign_Houses);
+
+    Patch_Jump(0x005DC9D4, &_Do_Win_Skip_MPlayer_Score_Screen_Patch);
+    Patch_Jump(0x005DCD92, &_Do_Lose_Skip_MPlayer_Score_Screen_Patch);
 }


### PR DESCRIPTION
Closes #522

This pull request adds a patch that makes the value of `SkipScore=` in a multiplayer maps `[Basic]` section considered when showing the multiplayer score screen. Setting to `SkipScore=yes` in the map file will now be all that is required for skip the score screen.

