### PR TITLE
Reimplements the command line argument `-CD` from Red Alert to allow file search path override logic.

### DIFF
--- a/src/extensions/cd/cdext_hooks.cpp
+++ b/src/extensions/cd/cdext_hooks.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CDEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CD class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "cdext_hooks.h"
+#include "cd.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  #issue-513
+ * 
+ *  Patch to add check for CD::IsFilesLocal in CD::Is_Available
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_CD_Is_Available_Local_Files_Patch)
+{
+	GET_REGISTER_STATIC(CD *, this_ptr, ecx);
+	GET_REGISTER_STATIC(int, disk, eax);
+	static bool retval;
+
+	/**
+	 *  If the CD system has been flagged that the files are local, then
+	 *  return true as they are always available.
+	 */
+	if (CD::IsFilesLocal) {
+		retval = true;
+		goto function_return;
+	}
+
+	/**
+	 *  Stolen bytes/code.
+	 */
+	this_ptr->ThemePlaying = THEME_NONE;
+
+	retval = this_ptr->Force_Available(disk);
+
+function_return:
+	_asm { mov al, retval }
+	_asm { ret 4 }
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void CDExtension_Hooks()
+{
+	Patch_Jump(0x0044E7AE, &_CD_Is_Available_Local_Files_Patch);
+}

--- a/src/extensions/cd/cdext_hooks.h
+++ b/src/extensions/cd/cdext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CDEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended CD class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void CDExtension_Hooks();

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -44,6 +44,7 @@
 #include "commandext_hooks.h"
 #include "msglistext_hooks.h"
 #include "sessionext_hooks.h"
+#include "cdext_hooks.h"
 
 #include "objecttypeext_hooks.h"
 #include "technotypeext_hooks.h"
@@ -128,6 +129,7 @@ void Extension_Hooks()
     CommandExtension_Hooks();
     MessageListClassExtension_Hooks();
     SessionClassExtension_Hooks();
+    CDExtension_Hooks();
 
     /**
      *  All type class extensions here.

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -42,6 +42,112 @@
 
 
 /**
+ *  Reimplemention of Init_Bootstrap_Mixfiles()
+ *  
+ *  Registers and caches any mixfiles needed for bootstrapping.
+ * 
+ *  @author: CCHyper
+ */
+static bool Vinifera_Init_Bootstrap_Mixfiles()
+{
+    bool ok;
+    MFCC *mix;
+
+    int temp = CD::RequiredCD;
+    CD::Set_Required_CD(-2);
+
+    DEBUG_INFO("\n"); // Fixes missing new-line after "Bootstrap..." print.
+    //DEBUG_INFO("Init bootstrap mixfiles...\n");
+
+    if (RawFileClass("PATCH.MIX").Is_Available()) {
+        mix = new MFCC("PATCH.MIX", &FastKey);
+        ASSERT(mix);
+        if (mix) {
+            DEBUG_INFO(" PATCH.MIX\n");
+        }
+    }
+
+    if (CCFileClass("PCACHE.MIX").Is_Available()) {
+        mix = new MFCC("PCACHE.MIX", &FastKey);
+        ASSERT(mix);
+        if (mix) {
+            mix->Cache();
+            DEBUG_INFO(" PCACHE.MIX\n");
+        }
+    }
+
+    for (int i = 99; i >= 0; --i) {
+        char buffer[16];
+        std::snprintf(buffer, sizeof(buffer), "EXPAND%02d.MIX", i);
+        if (RawFileClass(buffer).Is_Available()) {
+            mix = new MFCC(buffer, &FastKey);
+            ASSERT(mix);
+            if (!mix) {
+                DEBUG_WARNING("Failed to load %s!\n", buffer);
+            } else {
+                ExpansionMixFiles.Add(mix);
+                DEBUG_INFO(" %s\n", buffer);
+            }
+        }
+    }
+
+    for (int i = 99; i >= 0; --i) {
+        char buffer[16];
+        std::snprintf(buffer, sizeof(buffer), "ECACHE%02d.MIX", i);
+        if (CCFileClass(buffer).Is_Available()) {
+            mix = new MFCC(buffer, &FastKey);
+            ASSERT(mix);
+            if (!mix) {
+                DEBUG_WARNING("Failed to load %s!\n", buffer);
+            } else {
+                mix->Cache();
+                ExpansionMixFiles.Add(mix);
+                DEBUG_INFO(" %s\n", buffer);
+            }
+        }
+    }
+
+    Addon_Present();
+
+    TibSunMix = new MFCC("TIBSUN.MIX", &FastKey);
+    ASSERT(TibSunMix);
+    if (!TibSunMix) {
+        DEBUG_WARNING("Failed to load TIBSUN.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" TIBSUN.MIX\n");
+
+    /*
+    **	Bootstrap enough of the system so that the error dialog
+    *   box can successfully be displayed.
+    */
+    CacheMix = new MFCC("CACHE.MIX", &FastKey);
+    ASSERT(CacheMix);
+    if (!CacheMix) {
+        DEBUG_WARNING("Failed to load CACHE.MIX!\n");
+        return false;
+    }
+    if (!CacheMix->Cache()) {
+        DEBUG_WARNING("Failed to cache CACHE.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" CACHE.MIX\n");
+
+    LocalMix = new MFCC("LOCAL.MIX", &FastKey);
+    ASSERT(LocalMix);
+    if (!LocalMix) {
+        DEBUG_WARNING("Failed to load LOCAL.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" LOCAL.MIX\n");
+
+    CD::Set_Required_CD(temp);
+
+    return true;
+}
+
+
+/**
  *  #issue-513
  * 
  *  Patch to add check for CD::IsFilesLocal to make sure -CD really
@@ -143,4 +249,5 @@ void GameInit_Hooks()
 {
     Patch_Jump(0x004E0786, &_Init_Game_Skip_Startup_Movies_Patch);
     Patch_Jump(0x004E0461, &_Init_CDROM_Access_Local_Files_Patch);
+    Patch_Jump(0x004E3D20, &Vinifera_Init_Bootstrap_Mixfiles);
 }

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -33,12 +33,135 @@
 #include "ccfile.h"
 #include "cd.h"
 #include "newmenu.h"
+#include "addon.h"
+#include "theme.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  Reimplemention of Init_Secondary_Mixfiles()
+ *  
+ *  Register and cache secondary mixfiles.
+ * 
+ *  @author: CCHyper
+ */
+static bool Vinifera_Init_Secondary_Mixfiles()
+{
+    char buffer[16];
+
+    DEBUG_INFO("\n"); // Fixes missing new-line after "Init Secondary Mixfiles....." print.
+    //DEBUG_INFO("Init secondary mixfiles...\n");
+
+    if (CCFileClass("CONQUER.MIX").Is_Available()) {
+        ConquerMix = new MFCC("CONQUER.MIX", &FastKey);
+        ASSERT(ConquerMix);
+    }
+    if (!ConquerMix) {
+        DEBUG_WARNING("Failed to load CONQUER.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" CONQUER.MIX\n");
+
+    int cd = CD::Get_Volume_Index();
+
+    /**
+     *  Make sure we have a grounded volume index (invalid volumes will cause error).
+     */
+    if (CD::Get_Volume_Index() < 0) {
+        cd = 0;
+    }
+
+    /**
+     *  Mix file indices are 1 based.
+     */
+    cd += 1;
+
+    std::snprintf(buffer, sizeof(buffer), "MAPS%02d.MIX", cd);
+    if (CCFileClass(buffer).Is_Available()) {
+        MapsMix = new MFCC(buffer, &FastKey);
+        ASSERT(MapsMix);
+    }
+    if (!MapsMix) {
+        DEBUG_WARNING("Failed to load %s!\n", buffer);
+        return false;
+    }
+    DEBUG_INFO(" %s\n", buffer);
+
+    if (CCFileClass("MULTI.MIX").Is_Available()) {
+        MultiMix = new MFCC("MULTI.MIX", &FastKey);
+        ASSERT(MultiMix);
+    }
+    if (!MultiMix) {
+        DEBUG_WARNING("Failed to load MULTI.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" MULTI.MIX\n", buffer);
+
+    if (Addon_407120(ADDON_FIRESTORM)) {
+        if (CCFileClass("SOUNDS01.MIX").Is_Available()) {
+            FSSoundsMix = new MFCC("SOUNDS01.MIX", &FastKey);
+            ASSERT(FSSoundsMix);
+        }
+        if (!FSSoundsMix) {
+            DEBUG_WARNING("Failed to load SOUNDS01.MIX!\n");
+            return false;
+        }
+        DEBUG_INFO(" SOUNDS01.MIX\n", buffer);
+    }
+
+    if (CCFileClass("SOUNDS.MIX").Is_Available()) {
+        SoundsMix = new MFCC("SOUNDS.MIX", &FastKey);
+        ASSERT(SoundsMix);
+    }
+    if (!SoundsMix) {
+        DEBUG_WARNING("Failed to load SOUNDS.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" SOUNDS.MIX\n", buffer);
+
+    if (CCFileClass("SCORES01.MIX").Is_Available()) {
+        FSScoresMix = new MFCC("SCORES01.MIX", &FastKey);
+        ASSERT(FSScoresMix);
+    }
+    if (!FSScoresMix) {
+        DEBUG_WARNING("Failed to load SCORES01.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" SCORES01.MIX\n", buffer);
+
+	/*
+	**	Register the score mixfile.
+	*/
+    if (CCFileClass("SCORES.MIX").Is_Available()) {
+        ScoreMix = new MFCC("SCORES.MIX", &FastKey);
+        ASSERT(ScoreMix);
+    }
+    if (!ScoreMix) {
+        DEBUG_WARNING("Failed to load SCORES.MIX!\n");
+        return false;
+    }
+    DEBUG_INFO(" SCORES.MIX\n", buffer);
+	ScoresPresent = true;
+	Theme.Scan();
+
+    std::snprintf(buffer, sizeof(buffer), "MOVIES%02d.MIX", cd);
+    if (CCFileClass(buffer).Is_Available()) {
+        MoviesMix = new MFCC(buffer, &FastKey);
+        ASSERT(MoviesMix);
+    }
+    if (!MoviesMix) {
+        DEBUG_WARNING("Failed to load %s!\n", buffer);
+        return false;
+    }
+    DEBUG_INFO(" %s\n", buffer);
+
+    return true;
+}
 
 
 /**
@@ -250,4 +373,5 @@ void GameInit_Hooks()
     Patch_Jump(0x004E0786, &_Init_Game_Skip_Startup_Movies_Patch);
     Patch_Jump(0x004E0461, &_Init_CDROM_Access_Local_Files_Patch);
     Patch_Jump(0x004E3D20, &Vinifera_Init_Bootstrap_Mixfiles);
+    Patch_Jump(0x004E4120, &Vinifera_Init_Secondary_Mixfiles);
 }

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -52,6 +52,7 @@
  */
 static bool Vinifera_Init_Secondary_Mixfiles()
 {
+    MFCC *mix;
     char buffer[16];
 
     DEBUG_INFO("\n"); // Fixes missing new-line after "Init Secondary Mixfiles....." print.
@@ -81,16 +82,44 @@ static bool Vinifera_Init_Secondary_Mixfiles()
      */
     cd += 1;
 
-    std::snprintf(buffer, sizeof(buffer), "MAPS%02d.MIX", cd);
-    if (CCFileClass(buffer).Is_Available()) {
-        MapsMix = new MFCC(buffer, &FastKey);
-        ASSERT(MapsMix);
+    /**
+     *  #issue-513
+     * 
+     *  If the CD system has been flagged that the files are local, we
+     *  just glob all the map mix files in the game directory.
+     * 
+     *  @author: CCHyper
+     */
+    if (CD::IsFilesLocal) {
+
+        std::snprintf(buffer, sizeof(buffer), "MAPS*.MIX");
+        if (CCFileClass::Find_First_File(buffer)) {
+            DEBUG_INFO(" %s\n", buffer);
+            MapsMix = new MFCC(buffer, &FastKey);
+            ASSERT(MapsMix);
+            while (CCFileClass::Find_Next_File(buffer)) {
+                DEBUG_INFO(" %s\n", buffer);
+                mix = new MFCC(buffer, &FastKey);
+                ASSERT(mix);
+                if (mix) {
+                    ViniferaMapsMixes.Add(mix);
+                }
+            }
+        }
+        CCFileClass::Find_Close();
+
+    } else {
+        std::snprintf(buffer, sizeof(buffer), "MAPS%02d.MIX", cd);
+        if (CCFileClass(buffer).Is_Available()) {
+            MapsMix = new MFCC(buffer, &FastKey);
+            ASSERT(MapsMix);
+        }
     }
     if (!MapsMix) {
         DEBUG_WARNING("Failed to load %s!\n", buffer);
         return false;
     }
-    DEBUG_INFO(" %s\n", buffer);
+    if (!CD::IsFilesLocal) DEBUG_INFO(" %s\n", buffer);
 
     if (CCFileClass("MULTI.MIX").Is_Available()) {
         MultiMix = new MFCC("MULTI.MIX", &FastKey);
@@ -149,16 +178,44 @@ static bool Vinifera_Init_Secondary_Mixfiles()
 	ScoresPresent = true;
 	Theme.Scan();
 
-    std::snprintf(buffer, sizeof(buffer), "MOVIES%02d.MIX", cd);
-    if (CCFileClass(buffer).Is_Available()) {
-        MoviesMix = new MFCC(buffer, &FastKey);
-        ASSERT(MoviesMix);
+    /**
+     *  #issue-513
+     * 
+     *  If the CD system has been flagged that the files are local, we
+     *  just glob all the movies mix files in the game directory.
+     * 
+     *  @author: CCHyper
+     */
+    if (CD::IsFilesLocal) {
+
+        std::snprintf(buffer, sizeof(buffer), "MOVIES*.MIX");
+        if (CCFileClass::Find_First_File(buffer)) {
+            DEBUG_INFO(" %s\n", buffer);
+            MoviesMix = new MFCC(buffer, &FastKey);
+            ASSERT(MoviesMix);
+            while (CCFileClass::Find_Next_File(buffer)) {
+                DEBUG_INFO(" %s\n", buffer);
+                mix = new MFCC(buffer, &FastKey);
+                ASSERT(mix);
+                if (mix) {
+                    ViniferaMoviesMixes.Add(mix);
+                }
+            }
+        }
+        CCFileClass::Find_Close();
+
+    } else {
+        std::snprintf(buffer, sizeof(buffer), "MOVIES%02d.MIX", cd);
+        if (CCFileClass(buffer).Is_Available()) {
+            MoviesMix = new MFCC(buffer, &FastKey);
+            ASSERT(MoviesMix);
+        }
     }
     if (!MoviesMix) {
         DEBUG_WARNING("Failed to load %s!\n", buffer);
         return false;
     }
-    DEBUG_INFO(" %s\n", buffer);
+    if (!CD::IsFilesLocal) DEBUG_INFO(" %s\n", buffer);
 
     return true;
 }

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -32,6 +32,8 @@
 #include "cncnet4_globals.h"
 #include "cncnet5_globals.h"
 #include "rulesext.h"
+#include "ccfile.h"
+#include "cd.h"
 #include "debughandler.h"
 #include <string>
 
@@ -150,6 +152,25 @@ bool Vinifera_Parse_Command_Line(int argc, char *argv[])
             DEBUG_INFO("  - Skipping to Firestorm menu.\n");
             Vinifera_ExitAfterSkip = true;
             menu_skip = true;
+            continue;
+        }
+
+        /**
+         *  #issue-513
+         * 
+         *  Re-implements the file search path override logic of "-CD" from Red Alert.
+         */
+        if (std::strstr(string, "-CD")) {
+            DEBUG_INFO("  - \"-CD\" argument detected.\n");
+            CCFileClass::Set_Search_Drives(&string[3]);
+            if (CCFileClass::Is_There_Search_Drives()) {
+                DEBUG_INFO("  - Search path set to \"%s\".\n", &string[3]);
+
+                /**
+                 *  Flag the cd search system to search for files locally.
+                 */
+                CD::IsFilesLocal = true;            
+            }
             continue;
         }
 

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -47,6 +47,9 @@ bool Vinifera_Developer_AIControl = false;
 bool Vinifera_SkipWWLogoMovie = false;
 bool Vinifera_SkipStartupMovies = false;
 
+DynamicVectorClass<MFCC *> ViniferaMapsMixes;
+DynamicVectorClass<MFCC *> ViniferaMoviesMixes;
+
 bool Vinifera_SkipToTSMenu = false;
 bool Vinifera_SkipToFSMenu = false;
 bool Vinifera_SkipToLAN = false;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -28,6 +28,8 @@
 #pragma once
 
 #include "always.h"
+#include "vector.h"
+#include "ccfile.h"
 
 
 extern bool Vinifera_DeveloperMode;
@@ -60,6 +62,9 @@ extern bool Vinifera_Developer_AIControl;
  */
 extern bool Vinifera_SkipWWLogoMovie;
 extern bool Vinifera_SkipStartupMovies;
+
+extern DynamicVectorClass<MFCC *> ViniferaMapsMixes;
+extern DynamicVectorClass<MFCC *> ViniferaMoviesMixes;
 
 
 /**


### PR DESCRIPTION
Closes #513 

This pull request reimplements the file search path override logic of `-CD` from Red Alert. This effectively allows the end-user to copy the CD contents to the game directory and run the game without any CD required to be inserted.

The argument supports multiple entries separated by the `;` character. Below are some examples;

`-CD.` - Sets the games root directory as the location to search for the CD contents.
`-CDcd_path` - Sets the `cd_path` sub-directory as the location to search for the CD contents.
`-CDcd1;cd2;cd3` - Sets the sub-directories `cd1`, `cd2`, and `cd3` as the  search locations for the CD contents.
