### PR TITLE
Allow the Chat to All hotkey to be reassigned and enables the right mouse click to cancel the current in-game message input.

### DIFF
--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -520,6 +520,40 @@ bool ScrollNWCommandClass::Process()
 
 
 /**
+ *  Send a message to all players.
+ * 
+ *  @note: Process() should be empty, logic for this can be found
+ *         in the Message_Input patches!
+ * 
+ *  @author: CCHyper
+ */
+const char *ChatToAllCommandClass::Get_Name() const
+{
+    return TEXT_CHAT_TO_ALL_INI;
+}
+
+const char *ChatToAllCommandClass::Get_UI_Name() const
+{
+    return TEXT_CHAT_TO_ALL;
+}
+
+const char *ChatToAllCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *ChatToAllCommandClass::Get_Description() const
+{
+    return TEXT_CHAT_TO_ALL_DESC;
+}
+
+bool ChatToAllCommandClass::Process()
+{
+    return true;
+}
+
+
+/**
  *  Produces a memory dump on request.
  * 
  *  @author: CCHyper

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -208,6 +208,25 @@ class ScrollNWCommandClass : public ViniferaCommandClass
 
 
 /**
+ *  Remapable representation of the chat-to-all hotkey.
+ */
+class ChatToAllCommandClass : public ViniferaCommandClass
+{
+    public:
+        ChatToAllCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~ChatToAllCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_F8); }
+};
+
+
+/**
  *  Produces a memory dump on request.
  */
 class MemoryDumpCommandClass : public ViniferaCommandClass

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -160,6 +160,9 @@ void Init_Vinifera_Commands()
     cmdptr = new ScrollNWCommandClass;
     Commands.Add(cmdptr);
 
+    cmdptr = new ChatToAllCommandClass;
+    Commands.Add(cmdptr);
+
     /**
      *  Next, initialised any new commands here if the developer mode is enabled.
      */
@@ -345,6 +348,14 @@ static void Process_Vinifera_Hotkeys()
 
     if (!ini.Is_Present("Hotkey", "NextTheme")) {
         cmdptr = CommandClass::From_Name("NextTheme");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", TEXT_CHAT_TO_ALL_INI)) {
+        cmdptr = CommandClass::From_Name(TEXT_CHAT_TO_ALL_INI);
         if (cmdptr) {
             key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
             HotkeyIndex.Add_Index(key, cmdptr);

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -42,6 +42,7 @@
 #include "displayext_hooks.h"
 #include "tooltipext_hooks.h"
 #include "commandext_hooks.h"
+#include "inputext_hooks.h"
 #include "msglistext_hooks.h"
 #include "sessionext_hooks.h"
 #include "cdext_hooks.h"
@@ -127,6 +128,7 @@ void Extension_Hooks()
     DisplayClassExtension_Hooks();
     ToolTipManagerExtension_Hooks();
     CommandExtension_Hooks();
+    InputExtension_Hooks();
     MessageListClassExtension_Hooks();
     SessionClassExtension_Hooks();
     CDExtension_Hooks();

--- a/src/extensions/input/inputext_hooks.cpp
+++ b/src/extensions/input/inputext_hooks.cpp
@@ -1,0 +1,154 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          INPUTEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended message input function.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "inputext_hooks.h"
+#include "tibsun_globals.h"
+#include "vinifera_util.h"
+#include "command.h"
+#include "language.h"
+#include "session.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  This patch allows custom keys to be checked at the entry
+ *  point of Message_Input().
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Message_Input_Allow_Remap_Keys_Patch)
+{
+    GET_REGISTER_STATIC(KeyNumType *, input, ebp);
+    static CommandClass *cmd;
+    static KeyNumType cmd_key;
+    static GameEnum session_type;
+    static int session_max_players;
+
+    /**
+     *  New case to handle reassignment of the new chat-to-all command.
+     */
+    cmd_key = Get_Command_Key_From_Name("ChatToAll");
+    if (cmd_key > KN_NONE && *input == cmd_key) {
+        goto key_passes;
+    }
+
+    /**
+     *	Default behaviour: Make sure the key is in the expected range.
+     */
+    if (*input < KN_F1) {
+        goto key_failed_check;
+    }
+
+    /**
+     *  Continue check for key range (F1 to F7).
+     */
+key_continue_check:
+    session_type = Session.Type;
+    _asm { mov eax, session_type }
+    _asm { mov ecx, [input] }
+    JMP_REG(edx, 0x005098FD);
+
+    /**
+     *  Key passes the check, continue.
+     */
+key_passes:
+    session_type = Session.Type;
+    session_max_players = Session.MaxPlayers;
+    _asm { mov eax, session_type }
+    _asm { mov edx, session_max_players }
+    JMP_REG(ecx, 0x0050991B);
+
+    /**
+     *  Not an expected key.
+     */
+key_failed_check:
+    JMP_REG(edx, 0x00509A6C);
+}
+
+
+/**
+ *  #issue-525
+ * 
+ *  This patch allows the chat-to-all command to be remapped by the user
+ *  by checking the key assigned to ChatToAllCommandClass. 
+ * 
+ *  @see: ChatToAllCommandClass
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Message_Input_Chat_To_All_Key_Patch)
+{
+    GET_REGISTER_STATIC(KeyNumType *, input, ebp);
+    static CommandClass *cmd;
+    static KeyNumType cmd_key;
+
+    /**
+     *  New case to handle reassignment of the new chat-to-all command.
+     */
+    cmd_key = Get_Command_Key_From_Name("ChatToAll");
+    if (cmd_key > KN_NONE) {
+        if (*input == cmd_key) {
+            goto message_to_all;
+        } else {
+            goto process_next;
+        }
+    }
+
+    /**
+     *	Default value for a network/internet game is F8 = "To All:"
+     */
+    if (*input == (KN_F1 + Session.MaxPlayers - 1)) {
+        goto message_to_all;
+    }
+
+    /**
+     *  Next key range check (Next check is for specific player F1 to F7).
+     */
+process_next:
+    JMP_REG(eax, 0x00509975);
+
+    /**
+     *  Enter the "send to all" routine.
+     */
+message_to_all:
+    JMP_REG(ecx, 0x00509947);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void InputExtension_Hooks()
+{
+    Patch_Jump(0x005098F1, &_Message_Input_Allow_Remap_Keys_Patch);
+    Patch_Jump(0x00509940, &_Message_Input_Chat_To_All_Key_Patch);
+}

--- a/src/extensions/input/inputext_hooks.h
+++ b/src/extensions/input/inputext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          INPUTEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended message input function.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void InputExtension_Hooks();

--- a/src/extensions/msglist/msglistext_hooks.cpp
+++ b/src/extensions/msglist/msglistext_hooks.cpp
@@ -27,9 +27,11 @@
  ******************************************************************************/
 #include "msglistext_hooks.h"
 #include "vinifera_globals.h"
+#include "vinifera_util.h"
 #include "tibsun_globals.h"
 #include "session.h"
 #include "msglist.h"
+#include "command.h"
 #include "house.h"
 #include "housetype.h"
 #include "rules.h"
@@ -44,6 +46,77 @@
 static int Get_Message_Delay()
 {
     return Rule->MessageDelay * TICKS_PER_MINUTE;
+}
+
+
+/**
+ *  Related to #issue-525
+ * 
+ *  If the player reassigns the chat-to-all command to a ascii key, it will
+ *  end up repeating into the edit buffer. This patch makes sure this does
+ *  not happen in all cases (hopefully).
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_MessageListClass_Skip_Assigned_Key_Echo_Patch)
+{
+    GET_REGISTER_STATIC(MessageListClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(KeyNumType *, input, ebp);
+    GET_REGISTER_STATIC(KeyASCIIType, ascii, eax);
+    static CommandClass *cmd;
+    static KeyNumType cmd_key;
+    static KeyASCIIType cmd_key_ascii;
+
+    /**
+     *  Mask off any irrelevant bits.
+     */
+    ascii = KeyASCIIType(ascii & 0x00FF);
+
+    /**
+     *  Is this a simple work-around/lock for handling the echo of the
+     *  hotkey being passed into the message buffer. 
+     */
+    static bool _initial_flag = false;
+    if (!_initial_flag) {
+
+        /**
+         *  Make sure the buffer is empty of any user input, future instances
+         *  of this key could be legitimate input we need to process.
+         */
+        if (this_ptr->EditInitPos == this_ptr->EditCurPos) {
+
+            cmd_key = Get_Command_Key_From_Name("ChatToAll");
+            cmd_key_ascii = KeyASCIIType(WWKeyboard->To_ASCII(cmd_key));
+
+            _initial_flag = true;
+
+            /**
+             *  Invalidate the input character if it matches the trigger key.
+             */
+            if (cmd_key_ascii > KA_SPACE && cmd_key_ascii == ascii) {
+                ascii = KA_NONE;
+            }
+
+        }
+
+    }
+
+    /**
+     *  Check if the user has entered any text, and reset the lock flag.
+     */
+    if (this_ptr->EditBuf[this_ptr->EditInitPos] != '\0') {
+        _initial_flag = false;
+    }
+
+    /**
+     *  Stolen bytes/code.
+     */
+    _asm { mov ebx, ascii }
+
+    _asm { mov eax, [input+0] } // Restore EAX just to be sure.
+    _asm { mov eax, [eax] }
+
+    JMP_REG(ecx, 0x00573B0A);
 }
 
 
@@ -89,4 +162,5 @@ DECLARE_PATCH(_MessageListClass_Echo_Sent_Messages_Patch)
 void MessageListClassExtension_Hooks()
 {
     Patch_Jump(0x00509D16, &_MessageListClass_Echo_Sent_Messages_Patch);
+    Patch_Jump(0x00573B05, &_MessageListClass_Skip_Assigned_Key_Echo_Patch);
 }

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -224,6 +224,8 @@ bool RulesClassExtension::Read_UI_INI()
     UIControls.UnitHealthBarDrawPos = ini.Get_Point(INGAME, "UnitHealthBarPos", UIControls.UnitHealthBarDrawPos);
     UIControls.InfantryHealthBarDrawPos = ini.Get_Point(INGAME, "InfantryHealthBarPos", UIControls.InfantryHealthBarDrawPos);
 
+    UIControls.IsRightClickCancelMessage = ini.Get_Bool(INGAME, "RightClickCancelMessage", UIControls.IsRightClickCancelMessage);
+
     return true;
 }
 
@@ -247,6 +249,8 @@ bool RulesClassExtension::Init_UI_Controls()
 
     UIControls.InfantryHealthBarDrawPos.X = -24;
     UIControls.InfantryHealthBarDrawPos.Y = -5;
+
+    UIControls.IsRightClickCancelMessage = true;
 
     return false;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -67,6 +67,11 @@ class RulesClassExtension final : public Extension<RulesClass>
             TPoint2D<int> UnitHealthBarDrawPos;
             TPoint2D<int> InfantryHealthBarDrawPos;
 
+            /**
+             *  QoL Improvement: Does a right mouse click cancel player message input?
+             */
+            bool IsRightClickCancelMessage;
+
         } UIControlsStruct;
 
         static UIControlsStruct UIControls;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -41,6 +41,9 @@ extern char Vinifera_ScreenshotDirectory[PATH_MAX];
 /**
  *  Defines and constants.
  */
+#define TEXT_CHAT_TO_ALL			"Chat to all players"
+#define TEXT_CHAT_TO_ALL_INI		"ChatToAll"
+#define TEXT_CHAT_TO_ALL_DESC		"Send a message to all players (multiplayer only)."
 #define TEXT_S_S					"%s: %s"
 
 

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -43,7 +43,7 @@ extern char Vinifera_ScreenshotDirectory[PATH_MAX];
  */
 #define TEXT_CHAT_TO_ALL			"Chat to all players"
 #define TEXT_CHAT_TO_ALL_INI		"ChatToAll"
-#define TEXT_CHAT_TO_ALL_DESC		"Send a message to all players (multiplayer only)."
+#define TEXT_CHAT_TO_ALL_DESC		"Send a message to all players (multiplayer only). Right-click to cancel message."
 #define TEXT_S_S					"%s: %s"
 
 

--- a/src/vinifera_util.cpp
+++ b/src/vinifera_util.cpp
@@ -34,6 +34,8 @@
 #include "colorscheme.h"
 #include "textprint.h"
 #include "dsurface.h"
+#include "command.h"
+#include "search.h"
 #include "cncnet4_globals.h"
 #include "wwfont.h"
 #include "msgbox.h"
@@ -286,4 +288,27 @@ void Vinifera_DeveloperMode_Warning_WWMessageBox(const char *msg, ...)
 
         WWMessageBox().Process(buffer, 0, "OK");
     }
+}
+
+
+/**
+ *  What this function does should not be done normally, it goes against
+ *  the design of IndexClass, but it is the only way for us to fetch assigned
+ *  hotkeys.
+ * 
+ *  @author: CCHyper
+ */
+KeyNumType Get_Command_Key_From_Name(const char *name, KeyNumType default)
+{
+    CommandClass *cmd = CommandClass::From_Name(name);
+    if (cmd) {
+        KeyNumType key = HotkeyIndex.Fetch_ID_By_Data(cmd);
+        //DEV_DEBUG_INFO("Get_Command_Key_From_Name: Returning %X\n", key);
+        return key;
+    }
+
+    /**
+     *  Failed to find the command, use the specified default return value.
+     */
+    return default;
 }

--- a/src/vinifera_util.h
+++ b/src/vinifera_util.h
@@ -27,6 +27,9 @@
  ******************************************************************************/
 #pragma once
 
+#include "tibsun_defines.h"
+#include "wwkeyboard.h"
+
 
 class XSurface;
 
@@ -40,3 +43,5 @@ bool Vinifera_Generate_Mini_Dump();
 
 int Vinifera_Do_WWMessageBox(const char *msg, const char *btn1, const char *btn2 = nullptr, const char *btn3 = nullptr);
 void Vinifera_DeveloperMode_Warning_WWMessageBox(const char *msg, ...);
+
+KeyNumType Get_Command_Key_From_Name(const char *name, KeyNumType default = KN_NONE);


### PR DESCRIPTION
Closes #525, Closes #526

This pull request allows the Chat to All hotkey _(default **F8**)_ to be reassigned by the user and enables the right mouse click to cancel the current in-game message input.

You will find the new keyboard command listed as `Chat to all players` under `Interface` in the keyboard settings.

![image](https://user-images.githubusercontent.com/73803386/130709687-182622e2-1ff6-4877-b156-2c8195207f8d.png)

