### PR TITLE
Output screenshots to their own sub-directory.

### DIFF
--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -178,9 +178,19 @@ bool PNGScreenCaptureCommandClass::Process()
     std::snprintf(buffer, sizeof(buffer), "SCRN_%02u-%02u-%04u_%02u-%02u-%02u.PNG", day, month, year, hour, min, sec);
 
     /**
+     *  #issue-195
+     * 
+     *  Output screenshots to its own sub-directory.
+     * 
+     *  @author: CCHyper
+     */
+    char fullpath_buffer[PATH_MAX];
+    std::snprintf(fullpath_buffer, sizeof(fullpath_buffer), "%s\\%s", Vinifera_ScreenshotDirectory, buffer);
+
+    /**
      *  We found a free filename, now write the buffer to a PNG file.
      */
-    bool success = Write_PNG_File(&RawFileClass(buffer), *HiddenSurface, &GamePalette);
+    bool success = Write_PNG_File(&RawFileClass(fullpath_buffer), *HiddenSurface, &GamePalette);
 
     if (success) {
         DEBUG_INFO("PNG screenshot \"%s\" written sucessfully.\n", buffer);

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -288,6 +288,11 @@ void Init_Vinifera_Commands()
     //DEBUG_INFO("Initialising debug commands.\n");
 
 #endif
+
+    /**
+     *  Create any supporting directories.
+     */
+    CreateDirectory(Vinifera_ScreenshotDirectory, nullptr);
     
     DEBUG_INFO("Init_Vinifera_Commands(exit).\n");
 }

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -33,6 +33,7 @@
 bool Vinifera_DeveloperMode = false;
 
 char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
+char Vinifera_ScreenshotDirectory[PATH_MAX] = { "Screenshots" };
 
 bool Vinifera_Developer_InstantBuild = false;
 bool Vinifera_Developer_AIInstantBuild = false;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -33,6 +33,7 @@
 extern bool Vinifera_DeveloperMode;
 
 extern char Vinifera_DebugDirectory[PATH_MAX];
+extern char Vinifera_ScreenshotDirectory[PATH_MAX];
 
 
 /**


### PR DESCRIPTION
Closes #195

This pull request redirects saved screenshots using the keyboard command to a new sub-directory in the games folders, `Screenshots`.