### PR TITLE
Fixes position of the health bar graphic on unit selection boxes.

### DIFF
--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -33,6 +33,7 @@
 
 
 RulesClassExtension *RulesExtension = nullptr;
+RulesClassExtension::UIControlsStruct RulesClassExtension::UIControls;
 
 
 /**
@@ -211,13 +212,41 @@ bool RulesClassExtension::General(CCINIClass &ini)
 bool RulesClassExtension::Read_UI_INI()
 {
     static char const * const GENERAL = "General";
+    static char const * const INGAME = "Ingame";
 
     CCFileClass file("UI.INI");
     CCINIClass ini(file);
 
-    if (!ini.Is_Present(GENERAL)) {
-        return false;
-    }
+    //if (!ini.Is_Present(GENERAL)) {
+    //    return false;
+    //}
+
+    UIControls.UnitHealthBarDrawPos = ini.Get_Point(INGAME, "UnitHealthBarPos", UIControls.UnitHealthBarDrawPos);
+    UIControls.InfantryHealthBarDrawPos = ini.Get_Point(INGAME, "InfantryHealthBarPos", UIControls.InfantryHealthBarDrawPos);
 
     return true;
+}
+
+
+/**
+ *  Initialises the UI controls defaults.
+ *  
+ *  @author: CCHyper
+ */
+bool RulesClassExtension::Init_UI_Controls()
+{
+    /**
+     *  #issue-541
+     * 
+     *  The health bar graphics "Y" position on selection boxes is off by 1 pixel.
+     * 
+     *  @author: CCHyper
+     */
+    UIControls.UnitHealthBarDrawPos.X = -25;
+    UIControls.UnitHealthBarDrawPos.Y = -16; // was -15
+
+    UIControls.InfantryHealthBarDrawPos.X = -24;
+    UIControls.InfantryHealthBarDrawPos.Y = -5;
+
+    return false;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -31,6 +31,7 @@
 #include "container.h"
 
 #include "noinit.h"
+#include "tpoint.h"
 
 
 class CCINIClass;
@@ -55,6 +56,20 @@ class RulesClassExtension final : public Extension<RulesClass>
         void Initialize(CCINIClass &ini);
 
         static bool Read_UI_INI();
+        static bool Init_UI_Controls();
+
+    public:
+        typedef struct UIControlsStruct
+        {
+            /**
+             *  Health bar draw positions.
+             */
+            TPoint2D<int> UnitHealthBarDrawPos;
+            TPoint2D<int> InfantryHealthBarDrawPos;
+
+        } UIControlsStruct;
+
+        static UIControlsStruct UIControls;
 
     private:
         bool General(CCINIClass &ini);

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -38,6 +38,7 @@
 #include "house.h"
 #include "housetype.h"
 #include "rules.h"
+#include "rulesext.h"
 #include "voc.h"
 #include "fatal.h"
 #include "vinifera_util.h"
@@ -46,6 +47,52 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-541
+ * 
+ *  Allow customisation of the infantry health bar draw position.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Draw_Health_Bars_Infantry_Draw_Pos_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, ebx);
+    static int x_pos;
+    static int y_pos;
+
+    x_pos = RulesClassExtension::UIControls.InfantryHealthBarDrawPos.X;
+    y_pos = RulesClassExtension::UIControls.InfantryHealthBarDrawPos.Y;
+
+    _asm { mov ecx, [x_pos] }
+    _asm { mov eax, [y_pos] }
+
+    JMP_REG(esi, 0x0062C565);
+}
+
+
+/**
+ *  #issue-541
+ * 
+ *  Allow customisation of the unit health bar draw position.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Draw_Health_Bars_Unit_Draw_Pos_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, ebx);
+    static int x_pos;
+    static int y_pos;
+
+    x_pos = RulesClassExtension::UIControls.UnitHealthBarDrawPos.X;
+    y_pos = RulesClassExtension::UIControls.UnitHealthBarDrawPos.Y;
+
+    _asm { mov ecx, [x_pos] }
+    _asm { mov eax, [y_pos] }
+
+    JMP_REG(esi, 0x0062C5DF);
+}
 
 
 /**
@@ -345,4 +392,6 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x0062F6B7, &_TechnoClass_Is_Ready_To_Uncloak_Cloak_Stop_BugFix_Patch);
     Patch_Jump(0x0062E6F0, &_TechnoClass_Null_House_Warning_Patch);
     Patch_Jump(0x006328DE, &_TechnoClass_Take_Damage_IsAffectsAllies_Patch);
+    Patch_Jump(0x0062C5D5, &_TechnoClass_Draw_Health_Bars_Unit_Draw_Pos_Patch);
+    Patch_Jump(0x0062C55B, &_TechnoClass_Draw_Health_Bars_Infantry_Draw_Pos_Patch);
 }

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -228,6 +228,8 @@ bool Vinifera_Shutdown()
  */
 int Vinifera_Pre_Init_Game(int argc, char *argv[])
 {
+    RulesClassExtension::Init_UI_Controls();
+
     /**
      *  Read the UI controls and overrides.
      */


### PR DESCRIPTION
Closes #541 

This pull request fixes the position of the health bar graphic on unit selection boxes.

Alongside this fix, you can now override the draw position. The game will now load a new INI file, `UI.INI` and the following INI keys have been added;

**`[Ingame]`**
`UnitHealthBarPos=` - _The draw position of the unit health bar (Defaults to `-25,-16`)_
`InfantryHealthBarPos=` - _The draw position of the infantry health bar (Defaults to `-24,-5`)_

Screenshot of before and after;
![image](https://user-images.githubusercontent.com/73803386/131930726-1109408a-529a-4a78-9d13-199d4a317122.png)
![image](https://user-images.githubusercontent.com/73803386/131930715-9387c1da-a8fa-4855-828a-ac52d6afefdb.png)

