### PR TITLE
Adds various controls for customising the Sonic Beam weapon effect.

### DIFF
--- a/src/extensions/saveload/saveload.cpp
+++ b/src/extensions/saveload/saveload.cpp
@@ -69,6 +69,7 @@
 #include "aircraftext.h"
 #include "buildingext.h"
 #include "infantryext.h"
+#include "unitext.h"
 #include "terrainext.h"
 
 #include "waveext.h"
@@ -122,6 +123,7 @@ unsigned ViniferaSaveGameVersion =
             + sizeof(AircraftClassExtension)
             + sizeof(BuildingClassExtension)
             + sizeof(InfantryClassExtension)
+            + sizeof(UnitClassExtension)
             + sizeof(TerrainClassExtension)
             + sizeof(WaveClassExtension)
 ;
@@ -355,6 +357,7 @@ DEFINE_EXTENSION_SAVE(TechnoClassExtension, TechnoClassExtensions);
 DEFINE_EXTENSION_SAVE(AircraftClassExtension, AircraftClassExtensions);
 DEFINE_EXTENSION_SAVE(BuildingClassExtension, BuildingClassExtensions);
 DEFINE_EXTENSION_SAVE(InfantryClassExtension, InfantryClassExtensions);
+DEFINE_EXTENSION_SAVE(UnitClassExtension, UnitClassExtensions);
 DEFINE_EXTENSION_SAVE(TerrainClassExtension, TerrainClassExtensions);
 
 DEFINE_EXTENSION_SAVE(WaveClassExtension, WaveClassExtensions);
@@ -391,6 +394,7 @@ DEFINE_EXTENSION_LOAD(TechnoClassExtension, TechnoClassExtensions);
 DEFINE_EXTENSION_LOAD(AircraftClassExtension, AircraftClassExtensions);
 DEFINE_EXTENSION_LOAD(BuildingClassExtension, BuildingClassExtensions);
 DEFINE_EXTENSION_LOAD(InfantryClassExtension, InfantryClassExtensions);
+DEFINE_EXTENSION_LOAD(UnitClassExtension, UnitClassExtensions);
 DEFINE_EXTENSION_LOAD(TerrainClassExtension, TerrainClassExtensions);
 
 DEFINE_EXTENSION_LOAD(WaveClassExtension, WaveClassExtensions);
@@ -621,6 +625,12 @@ bool Vinifera_Put_All(IStream *pStm)
 
     DEBUG_INFO("Saving InfantryClassExtension\n");
     if (!Vinifera_Save_InfantryClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
+
+    DEBUG_INFO("Saving UnitClassExtension\n");
+    if (!Vinifera_Save_UnitClassExtension(pStm)) {
         DEBUG_INFO("\t***** FAILED!\n");
         return false;
     }
@@ -893,6 +903,12 @@ bool Vinifera_Load_All(IStream *pStm)
 
     DEBUG_INFO("Loading InfantryClassExtension\n");
     if (!Vinifera_Load_InfantryClassExtension(pStm)) {
+        DEBUG_INFO("\t***** FAILED!\n");
+        return false;
+    }
+
+    DEBUG_INFO("Loading UnitClassExtension\n");
+    if (!Vinifera_Load_UnitClassExtension(pStm)) {
         DEBUG_INFO("\t***** FAILED!\n");
         return false;
     }

--- a/src/extensions/unit/unitext.cpp
+++ b/src/extensions/unit/unitext.cpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          UNITEXT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended UnitClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "unitext.h"
+#include "unit.h"
+#include "wwcrc.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+
+/**
+ *  Provides the map for all UnitClass extension instances.
+ */
+ExtensionMap<UnitClass, UnitClassExtension> UnitClassExtensions;
+
+
+/**
+ *  Class constructor.
+ *  
+ *  @author: CCHyper
+ */
+UnitClassExtension::UnitClassExtension(UnitClass *this_ptr) :
+    Extension(this_ptr)
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("UnitClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //DEV_DEBUG_WARNING("UnitClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = true;
+}
+
+
+/**
+ *  Class no-init constructor.
+ *  
+ *  @author: CCHyper
+ */
+UnitClassExtension::UnitClassExtension(const NoInitClass &noinit) :
+    Extension(noinit)
+{
+    IsInitialized = false;
+}
+
+
+/**
+ *  Class deconstructor.
+ *  
+ *  @author: CCHyper
+ */
+UnitClassExtension::~UnitClassExtension()
+{
+    //DEV_DEBUG_TRACE("UnitClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    //DEV_DEBUG_WARNING("UnitClassExtension deconstructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    IsInitialized = false;
+}
+
+
+/**
+ *  Initializes an object from the stream where it was saved previously.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT UnitClassExtension::Load(IStream *pStm)
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("UnitClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Load(pStm);
+    if (FAILED(hr)) {
+        return E_FAIL;
+    }
+
+    new (this) UnitClassExtension(NoInitClass());
+    
+    return hr;
+}
+
+
+/**
+ *  Saves an object to the specified stream.
+ *  
+ *  @author: CCHyper
+ */
+HRESULT UnitClassExtension::Save(IStream *pStm, BOOL fClearDirty)
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("UnitClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    HRESULT hr = Extension::Save(pStm, fClearDirty);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Return the raw size of class data for save/load purposes.
+ *  
+ *  @author: CCHyper
+ */
+int UnitClassExtension::Size_Of() const
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("UnitClassExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    return sizeof(*this);
+}
+
+
+/**
+ *  Removes the specified target from any targeting and reference trackers.
+ *  
+ *  @author: CCHyper
+ */
+void UnitClassExtension::Detach(TARGET target, bool all)
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("UnitClassExtension::Detach - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}
+
+
+/**
+ *  Compute a unique crc value for this instance.
+ *  
+ *  @author: CCHyper
+ */
+void UnitClassExtension::Compute_CRC(WWCRCEngine &crc) const
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("UnitClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+}

--- a/src/extensions/unit/unitext.h
+++ b/src/extensions/unit/unitext.h
@@ -1,0 +1,56 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          UNITEXT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended UnitClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "extension.h"
+#include "container.h"
+
+
+class UnitClass;
+class HouseClass;
+
+
+class UnitClassExtension final : public Extension<UnitClass>
+{
+    public:
+        UnitClassExtension(UnitClass *this_ptr);
+        UnitClassExtension(const NoInitClass &noinit);
+        ~UnitClassExtension();
+
+        virtual HRESULT Load(IStream *pStm) override;
+        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
+        virtual int Size_Of() const override;
+
+        virtual void Detach(TARGET target, bool all = true) override;
+        virtual void Compute_CRC(WWCRCEngine &crc) const override;
+
+    public:
+};
+
+
+extern ExtensionMap<UnitClass, UnitClassExtension> UnitClassExtensions;

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -26,6 +26,7 @@
  *
  ******************************************************************************/
 #include "unitext_hooks.h"
+#include "unitext_init.h"
 #include "tibsun_inline.h"
 #include "vinifera_globals.h"
 #include "tibsun_globals.h"
@@ -363,6 +364,11 @@ continue_check_scatter:
  */
 void UnitClassExtension_Hooks()
 {
+    /**
+     *  Initialises the extended class.
+     */
+    //UnitClassExtension_Init();
+
     Patch_Jump(0x006517BE, &_UnitClass_Per_Cell_Process_AutoHarvest_Assign_Harvest_Mission_Patch);
     Patch_Jump(0x0065B547, &_UnitClass_Explode_ShakeScreen_Division_BugFix_Patch);
     Patch_Jump(0x006530EB, &_UnitClass_Draw_Shape_Primary_Facing_Patch);

--- a/src/extensions/unit/unitext_init.cpp
+++ b/src/extensions/unit/unitext_init.cpp
@@ -1,0 +1,205 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          UNITEXT_INIT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended UnitClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "unitext.h"
+#include "unittypeext.h"
+#include "unit.h"
+#include "unittype.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+#include "vinifera_util.h"
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_UnitClass_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(UnitClass *, this_ptr, esi); // Current "this" pointer.
+    static UnitClassExtension *exttype_ptr;
+
+    /**
+     *  Find existing or create an extended class instance.
+     */
+    exttype_ptr = UnitClassExtensions.find_or_create(this_ptr);
+    if (!exttype_ptr) {
+        DEBUG_ERROR("Failed to create UnitClassExtension instance for 0x%08X!\n", (uintptr_t)this_ptr);
+        ShowCursor(TRUE);
+        MessageBoxA(MainWindow, "Failed to create UnitClassExtensions instance!\n", "Vinifera", MB_OK|MB_ICONEXCLAMATION);
+        Vinifera_Generate_Mini_Dump();
+        Fatal("Failed to create UnitClassExtensions instance!\n");
+        goto original_code; // Keep this for clean code analysis.
+    }
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { add esp, 0x0C }
+    _asm { ret 8 }
+}
+
+
+/**
+ *  Patch for including the extended class members in the noinit creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_UnitClass_NoInit_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(UnitClass *, this_ptr, esi);
+    GET_STACK_STATIC(const NoInitClass *, noinit, esp, 0x18);
+    static UnitClassExtension *ext_ptr;
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov dword ptr [ebx], 0x006D8B6C } // this->vftable = const UnitClass::`vftable';
+    JMP(0x00659680);
+}
+
+
+/**
+ *  Patch for including the extended class members in the destruction process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_UnitClass_Deconstructor_Patch)
+{
+    GET_REGISTER_STATIC(UnitClass *, this_ptr, esi);
+
+    /**
+     *  Remove the extended class from the global index.
+     */
+    UnitClassExtensions.remove(this_ptr);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { add esp, 0x8 }
+    _asm { ret }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class detach process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_UnitClass_Detach_Patch)
+{
+    GET_REGISTER_STATIC(UnitClass *, this_ptr, esi);
+    GET_STACK_STATIC(TARGET, target, esp, 0x10);
+    GET_STACK_STATIC8(bool, all, esp, 0x8);
+    static UnitClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = UnitClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Detach(target, all);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 8 }
+}
+
+
+/**
+ *  Patch for including the extended class members to the base class crc calculation.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_UnitClass_Compute_CRC_Patch)
+{
+    GET_REGISTER_STATIC(UnitClass *, this_ptr, esi);
+    GET_STACK_STATIC(WWCRCEngine *, crc, esp, 0xC);
+    static UnitClassExtension *ext_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    ext_ptr = UnitClassExtensions.find(this_ptr);
+    if (!ext_ptr) {
+        goto original_code;
+    }
+
+    ext_ptr->Compute_CRC(*crc);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void UnitClassExtension_Init()
+{
+    Patch_Jump(0x0064D7B4, &_UnitClass_Constructor_Patch);
+    Patch_Jump(0x0065967A, &_UnitClass_NoInit_Constructor_Patch);
+    Patch_Jump(0x0064D9C0, &_UnitClass_Deconstructor_Patch);
+    Patch_Jump(0x00659863, &_UnitClass_Detach_Patch);
+    Patch_Jump(0x00659825, &_UnitClass_Compute_CRC_Patch);
+}

--- a/src/extensions/unit/unitext_init.h
+++ b/src/extensions/unit/unitext_init.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          UNITEXT_INIT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended UnitClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void UnitClassExtension_Init();

--- a/src/extensions/wave/waveext.cpp
+++ b/src/extensions/wave/waveext.cpp
@@ -321,6 +321,15 @@ void WaveClassExtension::Draw_Sonic_Beam_Pixel(int a1, int a2, int a3, unsigned 
     int pos = std::abs(SonicBeamSineTable[wave_pos]);
 
     /**
+     *  #issue-540
+     * 
+     *  Possible bug-fix for the common crash, back-ported from Red Alert 2.
+     */
+    if (pos > 9) {
+        pos = 9;
+    }
+
+    /**
      *  Get the intensity adjustment value based on the pattern position.
      */
     int intensity = SonicBeamIntensityTable[pos];

--- a/src/extensions/wave/waveext.cpp
+++ b/src/extensions/wave/waveext.cpp
@@ -27,7 +27,10 @@
  ******************************************************************************/
 #include "waveext.h"
 #include "wave.h"
+#include "weapontypeext.h"
+#include "weapontype.h"
 #include "wwcrc.h"
+#include "wwmath.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -39,12 +42,35 @@ ExtensionMap<WaveClass, WaveClassExtension> WaveClassExtensions;
 
 
 /**
+ *  This is a temporary pointer to the weapon type that the wave object belongs to.
+ */
+WeaponTypeClass *Wave_TempWeaponTypePtr = nullptr;
+
+
+/**
  *  Class constructor.
  *  
  *  @author: CCHyper
  */
 WaveClassExtension::WaveClassExtension(WaveClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    WeaponTypePtr(nullptr),
+    SonicBeamColor{0,0,0},
+    SonicBeamIsClear(false),
+    SonicBeamAlpha(0.5),
+    SonicBeamSineDuration(0.125),
+    SonicBeamSineAmplitude(12.0),
+    SonicBeamOffset(0.49),
+    SonicBeamSurfacePattern(SURFACE_PATTERN_CIRCLE),
+    SonicBeamSinePattern(SINE_PATTERN_CIRCLE),
+    SonicBeamStartPinLeft(-30.0, -100.0, 0.0),
+    SonicBeamStartPinRight(-30.0, 100.0, 0.0),
+    SonicBeamEndPinLeft(30.0, -100.0, 0.0),
+    SonicBeamEndPinRight(30.0, 100.0, 0.0),
+    SonicBeamTablesCalculated(false),
+    SonicBeamSineTable(),
+    SonicBeamSurfacePatternTable(),
+    SonicBeamIntensityTable()
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("WaveClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -155,4 +181,215 @@ void WaveClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("WaveClassExtension::Compute_CRC - 0x%08X\n", (uintptr_t)(ThisPtr));
+}
+
+
+/**
+ *  Copies any data required into the newly created wave class extension.
+ *  
+ *  @author: CCHyper
+ */
+void WaveClassExtension::Init()
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("WaveClassExtension::Init - 0x%08X\n", (uintptr_t)(ThisPtr));
+
+    /**
+     *  Fetch the sonic beam overrides from the weapon.
+     */
+    if (WeaponTypePtr) {
+
+        WeaponTypeClassExtension *weapontypeext;
+        weapontypeext = WeaponTypeClassExtensions.find(WeaponTypePtr);
+    
+        if (weapontypeext && ThisPtr->Type == WAVE_SONIC) {
+            SonicBeamAlpha = weapontypeext->SonicBeamAlpha;
+            SonicBeamSineDuration = weapontypeext->SonicBeamSineDuration;
+            SonicBeamSineAmplitude = weapontypeext->SonicBeamSineAmplitude;
+            SonicBeamOffset = weapontypeext->SonicBeamOffset;
+            SonicBeamSurfacePattern = weapontypeext->SonicBeamSurfacePattern;
+            SonicBeamSinePattern = weapontypeext->SonicBeamSinePattern;
+            SonicBeamColor = weapontypeext->SonicBeamColor;
+            SonicBeamIsClear = weapontypeext->SonicBeamIsClear;
+            SonicBeamStartPinLeft = weapontypeext->SonicBeamStartPinLeft;
+            SonicBeamStartPinRight = weapontypeext->SonicBeamStartPinRight;
+            SonicBeamEndPinLeft = weapontypeext->SonicBeamEndPinLeft;
+            SonicBeamEndPinRight = weapontypeext->SonicBeamEndPinRight;
+        }
+    }
+}
+
+
+/**
+ *  Generate the tables for the sonic beam.
+ *  
+ *  @authors: CCHyper, tomsons26 (additional research by askhati and Morton)
+ */
+bool WaveClassExtension::Calculate_Sonic_Beam_Tables()
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("WaveClassExtension::Calculate_Sonic_Beam_Tables - 0x%08X\n", (uintptr_t)(ThisPtr));
+
+    if (!SonicBeamTablesCalculated) {
+
+        /**
+         *  Generate the sonic beam surface pattern table.
+         */
+        for (int x = 0; x < 300; ++x) {
+            for (int y = 0; y < 300; ++y) {
+                switch (SonicBeamSurfacePattern) {
+                    default:
+                    case SURFACE_PATTERN_CIRCLE:
+                        SonicBeamSurfacePatternTable[x][y] = WWMath::Sqrt(x * x + y * y);
+                        break;
+                    case SURFACE_PATTERN_ELLIPSE:
+                    {
+                        double x_stretch_coeff = 2.0;
+                        double y_stretch_coeff = 1.0;
+                        SonicBeamSurfacePatternTable[x][y] = WWMath::Sqrt((x * 2) / x_stretch_coeff + (y * 2) / y_stretch_coeff);
+                        break;
+                    }
+                    case SURFACE_PATTERN_RHOMBUS:
+                        SonicBeamSurfacePatternTable[x][y] = WWMath::Sqrt(x + y);
+                        break;
+                    case SURFACE_PATTERN_SQUARE:
+                        SonicBeamSurfacePatternTable[x][y] = WWMath::Sqrt(std::max(std::abs(x), std::abs(y)));
+                        break;
+                };
+            }
+        }
+
+        /**
+         *  Generate the sonic beam sine pattern table.
+         */
+        for (int i = 0; i < ARRAY_SIZE(SonicBeamSineTable); ++i) {
+            switch (SonicBeamSinePattern) {
+                default:
+                case SINE_PATTERN_CIRCLE:
+                    SonicBeamSineTable[i] = (short)(WWMath::Sin(i * SonicBeamSineDuration) * SonicBeamSineAmplitude + SonicBeamOffset);
+                    break;
+                case SINE_PATTERN_SQUARE:
+                    SonicBeamSineTable[i] = (short)(WWMath::Signum(WWMath::Sin(i)));
+                    break;
+                case SINE_PATTERN_SAWTOOTH:
+                    SonicBeamSineTable[i] = (short)(2 * (i/SonicBeamSineDuration - WWMath::Floor(i/SonicBeamSineDuration + 1/2)));
+                    break;
+                case SINE_PATTERN_TRIANGLE:
+                {
+                    double sawtooth = 2 * (i/SonicBeamSineDuration - WWMath::Floor(i/SonicBeamSineDuration + 1/2));
+                    SonicBeamSineTable[i] = (short)(2 * std::abs(sawtooth) - 1);
+                    break;
+                }
+            };
+        }
+
+        /**
+         *  The pixel offset of the wave.
+         */
+        for (int i = 0; i < ARRAY_SIZE(SonicBeamIntensityTable); ++i) {
+            SonicBeamIntensityTable[i] = 110 + (i * 8);
+        }
+
+        SonicBeamTablesCalculated = true;
+    }
+
+    return true;
+}
+
+
+/**
+ *  Re-implementation of Draw_Sonic_Beam_Pixel() for WaveClassExtension.
+ * 
+ *  @authors: CCHyper, tomsons26 (additional research by askhati and Morton)
+ */
+void WaveClassExtension::Draw_Sonic_Beam_Pixel(int a1, int a2, int a3, unsigned short *buffer)
+{
+    ASSERT(ThisPtr != nullptr);
+    //DEV_DEBUG_TRACE("WaveClassExtension::Draw_Sonic_Beam_Pixel - 0x%08X\n", (uintptr_t)(ThisPtr));
+
+    /**
+     *  One-time generate the required sonic beam effect tables.
+     */
+    if (!SonicBeamTablesCalculated) {
+        Calculate_Sonic_Beam_Tables();
+    }
+
+    /**
+     *  Calculate the pixel offset position based on the surface pattern.
+     */
+    int wave_pos = ThisPtr->SonicEC + (unsigned short)SonicBeamSurfacePatternTable[a3][std::abs(a1 - ThisPtr->field_6C.X - a2)];
+    int pos = std::abs(SonicBeamSineTable[wave_pos]);
+
+    /**
+     *  Get the intensity adjustment value based on the pattern position.
+     */
+    int intensity = SonicBeamIntensityTable[pos];
+
+    /**
+     *  Fetch the offset pixel from the buffer.
+     */
+    unsigned short pixel = buffer[ThisPtr->field_188[pos]];
+
+    /**
+     *  Re-color the buffer pixel.
+     */
+    int r = 0;
+    int g = 0;
+    int b = 0;
+
+    /**
+     *  Clear beam, not color change.
+     */
+    if (SonicBeamIsClear) {
+
+        r = (unsigned char)((unsigned char)(pixel >> DSurface::RedLeft) << DSurface::RedRight);
+        g = (unsigned char)((unsigned char)(pixel >> DSurface::GreenLeft) << DSurface::GreenRight);
+        b = (unsigned char)((unsigned char)(pixel >> DSurface::BlueLeft) << DSurface::BlueRight);
+
+
+    /**
+     *  Custom color has been set.
+     */
+    } else if (SonicBeamColor.R != 0 && SonicBeamColor.G != 0 && SonicBeamColor.B != 0) {
+
+        int color_r = SonicBeamColor.R;
+        int color_g = SonicBeamColor.G;
+        int color_b = SonicBeamColor.B;
+
+        /**
+         *  Calculate the alpha of the beam.
+         */
+        int alpha = float(intensity) * 1.0;
+        color_r += float((unsigned char)((unsigned char)(pixel >> DSurface::RedLeft) << DSurface::RedRight)) * SonicBeamAlpha;
+        color_g += float((unsigned char)((unsigned char)(pixel >> DSurface::GreenLeft) << DSurface::GreenRight)) * SonicBeamAlpha;
+        color_b += float((unsigned char)((unsigned char)(pixel >> DSurface::BlueLeft) << DSurface::BlueRight)) * SonicBeamAlpha;
+        
+        r = color_r + ((alpha * (unsigned char)((unsigned char)(pixel >> DSurface::RedLeft) << DSurface::RedRight)) / 256);
+        g = color_g + ((alpha * (unsigned char)((unsigned char)(pixel >> DSurface::GreenLeft) << DSurface::GreenRight)) / 256);
+        b = color_b + ((alpha * (unsigned char)((unsigned char)(pixel >> DSurface::BlueLeft) << DSurface::BlueRight)) / 256);
+
+    
+    /**
+     *  Original sonic beam color code.
+     */
+    } else {
+
+        r = (unsigned char)((unsigned char)(pixel >> DSurface::RedLeft) << DSurface::RedRight);
+
+        g = ((intensity * (unsigned char)((unsigned char)(pixel >> DSurface::GreenLeft) << DSurface::GreenRight)) / 256)
+                        + (unsigned char)((unsigned char)(pixel >> DSurface::GreenLeft) << DSurface::GreenRight);
+
+        b = ((intensity * (unsigned char)((unsigned char)(pixel >> DSurface::BlueLeft) << DSurface::BlueRight)) / 256)
+                        + (unsigned char)((unsigned char)(pixel >> DSurface::BlueLeft) << DSurface::BlueRight);
+    
+    }
+
+    /**
+     *  Clamp the color within expected ranges and put the new pixel
+     *  back into the buffer.
+     */
+    r = std::min<int>(r, 255);
+    g = std::min<int>(g, 255);
+    b = std::min<int>(b, 255);
+    *buffer = DSurface::RGBA_To_Pixel(r, g, b);
 }

--- a/src/extensions/wave/waveext.h
+++ b/src/extensions/wave/waveext.h
@@ -30,6 +30,8 @@
 #include "extension.h"
 #include "container.h"
 #include "wave.h"
+#include "vector3.h"
+#include "weapontypeext.h"
 
 
 class WaveClassExtension final : public Extension<WaveClass>
@@ -46,8 +48,45 @@ class WaveClassExtension final : public Extension<WaveClass>
         virtual void Detach(TARGET target, bool all = true) override;
         virtual void Compute_CRC(WWCRCEngine &crc) const override;
 
+        void Init();
+
+        void Draw_Sonic_Beam_Pixel(int a1, int a2, int a3, unsigned short *buffer);
+
+        bool Calculate_Sonic_Beam_Tables();
+
     public:
+        /**
+         *  Pointer to the weapon this is firing this wave.
+         */
+        WeaponTypeClass *WeaponTypePtr;
+
+        /**
+         *  The following are copied from WeaponTypeExtension on creation.
+         */
+        RGBStruct SonicBeamColor;
+        bool SonicBeamIsClear;
+        double SonicBeamAlpha;
+        double SonicBeamSineDuration;
+        double SonicBeamSineAmplitude;
+        double SonicBeamOffset;
+        SonicBeamSurfacePatternType SonicBeamSurfacePattern;
+        SonicBeamSinePatternType SonicBeamSinePattern;
+        Vector3 SonicBeamStartPinLeft;
+        Vector3 SonicBeamStartPinRight;
+        Vector3 SonicBeamEndPinLeft;
+        Vector3 SonicBeamEndPinRight;
+
+    private:
+        /**
+         *  Generated tables based on the custom values.
+         */
+        bool SonicBeamTablesCalculated;
+        short SonicBeamSineTable[500];
+        short SonicBeamSurfacePatternTable[300][300];
+        int SonicBeamIntensityTable[14];
 };
 
 
 extern ExtensionMap<WaveClass, WaveClassExtension> WaveClassExtensions;
+
+extern WeaponTypeClass *Wave_TempWeaponTypePtr;

--- a/src/extensions/wave/waveext_hooks.cpp
+++ b/src/extensions/wave/waveext_hooks.cpp
@@ -28,12 +28,190 @@
 #include "waveext_hooks.h"
 #include "waveext_init.h"
 #include "wave.h"
+#include "waveext.h"
+#include "weapontype.h"
+#include "weapontypeext.h"
+#include "dsurface.h"
+#include "tibsun_globals.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or deconstructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+class WaveClassFake : public WaveClass
+{
+    public:
+        void Draw_Sonic_Beam_Pixel_Intercept(int a1, int a2, int a3, unsigned short *buffer)
+        {
+            WaveClassExtension *waveext;
+            waveext = WaveClassExtensions.find(this);
+            if (waveext) {
+                waveext->Draw_Sonic_Beam_Pixel(a1, a2, a3, buffer);
+            } else {
+                func_670370(a1, a2, a3, buffer);
+            }
+        }
+
+        bool Generate_Tables_Intercept()
+        {
+            WaveClassExtension *waveext;
+            waveext = WaveClassExtensions.find(this);
+            if (waveext) {
+                waveext->Calculate_Sonic_Beam_Tables();
+            } else {
+                func_670580();
+            }
+        }
+};
+
+
+/**
+ *  Patch in the new Calculate_Sonic_Beam_Tables function.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_WaveClass_Default_Constructor_Calculate_Sonic_Beam_Tables_Patch)
+{
+    GET_REGISTER_STATIC(WaveClass *, this_ptr, esi);
+
+    WaveClassExtension *waveext;
+    waveext = WaveClassExtensions.find(this_ptr);
+    if (waveext) {
+        waveext->Calculate_Sonic_Beam_Tables();
+    } else {
+        WaveClass::func_670580();
+    }
+
+    JMP(0x006702B2);
+}
+
+DECLARE_PATCH(_WaveClass_Constructor_Calculate_Sonic_Beam_Tables_Patch)
+{
+    GET_REGISTER_STATIC(WaveClass *, this_ptr, esi);
+
+    WaveClassExtension *waveext;
+    waveext = WaveClassExtensions.find(this_ptr);
+    if (waveext) {
+        waveext->Calculate_Sonic_Beam_Tables();
+    } else {
+        WaveClass::func_670580();
+    }
+
+    JMP(0x00670007);
+}
+
+
+/**
+ *  Setup the wave size vectors. This replaces the existing one-time
+ *  code in the game and is now done on each wave creation.
+ * 
+ *  @author: CCHyper
+ */
+static void Wave_Setup_Size_Vectors(WaveClass *this_ptr)
+{
+    bool use_sonic_beam_defaults = true;
+
+    WaveClassExtension *waveext;
+    waveext = WaveClassExtensions.find(this_ptr);
+    if (waveext) {
+
+        /**
+         *  Copy over this waves custom sonic beam values.
+         */
+        Wave_SizeVectors[WAVE_SONIC][0] = waveext->SonicBeamEndPinLeft;
+        Wave_SizeVectors[WAVE_SONIC][1] = waveext->SonicBeamEndPinRight;
+        Wave_SizeVectors[WAVE_SONIC][2] = waveext->SonicBeamStartPinLeft;
+        Wave_SizeVectors[WAVE_SONIC][3] = waveext->SonicBeamStartPinRight;
+
+        use_sonic_beam_defaults = false;
+    }
+
+    if (use_sonic_beam_defaults) {
+        /**
+         *  Original sonic beam values.
+         */
+        Wave_SizeVectors[WAVE_SONIC][0] = Vector3(-30.0, -100.0, 0.0);
+        Wave_SizeVectors[WAVE_SONIC][1] = Vector3(-30.0, 100.0, 0.0);
+        Wave_SizeVectors[WAVE_SONIC][2] = Vector3(30.0, -100.0, 0.0);
+        Wave_SizeVectors[WAVE_SONIC][3] = Vector3(30.0, 100.0, 0.0);
+    }
+
+    /**
+     *  Original game values.
+     */
+    Wave_SizeVectors[WAVE_BIG_LASER][0] = Vector3(-34.0, -44.0, 0.0);
+    Wave_SizeVectors[WAVE_BIG_LASER][1] = Vector3(-34.0, 44.0, 0.0);
+    Wave_SizeVectors[WAVE_BIG_LASER][2] = Vector3(34.0, -44.0, 0.0);
+    Wave_SizeVectors[WAVE_BIG_LASER][3] = Vector3(34.0, 44.0, 0.0);
+
+    Wave_SizeVectors[WAVE_LASER][0] = Vector3(-27.0, -34.0, 0.0);
+    Wave_SizeVectors[WAVE_LASER][1] = Vector3(-27.0, 34.0, 0.0);
+    Wave_SizeVectors[WAVE_LASER][2] = Vector3(27.0, -34.0, 0.0);
+    Wave_SizeVectors[WAVE_LASER][3] = Vector3(27.0, 34.0, 0.0);
+}
+
+
+/**
+ *  Patch in the new Generate_Tables.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_WaveClass_Setup_Wave_Size)
+{
+    GET_REGISTER_STATIC(WaveClass *, this_ptr, edi);
+
+    Wave_Setup_Size_Vectors(this_ptr);
+
+    JMP(0x00672414);
+}
+
+
+/**
+ *  These patches allow us to store the firing weapon type pointer
+ *  to allow us to fetch custom overrides. Nasty hack...
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Laser_Zap_Store_WeaponType_Ptr)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, edi);
+    GET_REGISTER_STATIC(WeaponTypeClass *, weapontype, esi);
+
+    Wave_TempWeaponTypePtr = weapontype;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    _asm { mov dl, [esi+0x0E3] } // WeaponTypeClass.IsBigLaser
+
+    JMP_REG(ecx, 0x006301DE);
+}
+
+DECLARE_PATCH(_TechnoClass_Fire_At_Store_WeaponType_Ptr)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(WeaponTypeClass *, weapontype, ebx);
+
+    Wave_TempWeaponTypePtr = weapontype;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    _asm { mov ecx, [ebp+8] }
+    _asm { mov eax, [esi] }
+
+    JMP_REG(edx, 0x006311B5);
+}
 
 
 /**
@@ -45,4 +223,21 @@ void WaveClassExtension_Hooks()
      *  Initialises the extended class.
      */
     WaveClassExtension_Init();
+
+    Patch_Jump(0x006701E0, &_WaveClass_Default_Constructor_Calculate_Sonic_Beam_Tables_Patch);
+    Patch_Jump(0x0066FF23, &_WaveClass_Constructor_Calculate_Sonic_Beam_Tables_Patch);
+
+    Patch_Jump(0x00670370, &WaveClassFake::Draw_Sonic_Beam_Pixel_Intercept);
+
+    /**
+     *  Removes the one-time initialisation of the wave size vectors
+     *  and replaces it with our own.
+     */
+    Patch_Jump(0x00672171, &_WaveClass_Setup_Wave_Size);
+
+    /**
+     *  Ulgy workaround to getting the WeaponType pointer for WaveClassExtension.
+     */
+    Patch_Jump(0x006301D8, &_TechnoClass_Laser_Zap_Store_WeaponType_Ptr);
+    Patch_Jump(0x006311B0, &_TechnoClass_Fire_At_Store_WeaponType_Ptr);
 }

--- a/src/extensions/wave/waveext_init.cpp
+++ b/src/extensions/wave/waveext_init.cpp
@@ -61,6 +61,18 @@ DECLARE_PATCH(_WaveClass_Default_Constructor_Patch)
     }
 
     /**
+     *  Store a pointer to the weapon type that fired this wave.
+     */
+    if (Wave_TempWeaponTypePtr) {
+        ext_ptr->WeaponType = Wave_TempWeaponTypePtr;
+    }
+
+    /**
+     *  Initialise the new created extension.
+     */
+    ext_ptr->Init();
+
+    /**
      *  Stolen bytes here.
      */
 original_code:
@@ -105,6 +117,18 @@ DECLARE_PATCH(_WaveClass_Default_Constructor_Before_Init_Patch)
     }
 
     /**
+     *  Store a pointer to the weapon type that fired this wave.
+     */
+    if (Wave_TempWeaponTypePtr) {
+        ext_ptr->WeaponTypePtr = Wave_TempWeaponTypePtr;
+    }
+
+    /**
+     *  Initialise the new created extension.
+     */
+    ext_ptr->Init();
+
+    /**
      *  Stolen bytes here.
      */
 original_code:
@@ -140,6 +164,18 @@ DECLARE_PATCH(_WaveClass_Constructor_Patch)
         Fatal("Failed to create WaveClassExtensions instance!\n");
         goto original_code; // Keep this for clean code analysis.
     }
+
+    /**
+     *  Store a pointer to the weapon type that fired this wave.
+     */
+    if (Wave_TempWeaponTypePtr) {
+        ext_ptr->WeaponType = Wave_TempWeaponTypePtr;
+    }
+
+    /**
+     *  Initialise the new created extension.
+     */
+    ext_ptr->Init();
 
     /**
      *  Stolen bytes here.
@@ -183,6 +219,18 @@ DECLARE_PATCH(_WaveClass_Constructor_Before_Init_Patch)
         Fatal("Failed to create WaveClassExtensions instance!\n");
         goto original_code; // Keep this for clean code analysis.
     }
+
+    /**
+     *  Store a pointer to the weapon type that fired this wave.
+     */
+    if (Wave_TempWeaponTypePtr) {
+        ext_ptr->WeaponTypePtr = Wave_TempWeaponTypePtr;
+    }
+
+    /**
+     *  Initialise the new created extension.
+     */
+    ext_ptr->Init();
 
     /**
      *  Stolen bytes here.

--- a/src/extensions/weapontype/weapontypeext.h
+++ b/src/extensions/weapontype/weapontypeext.h
@@ -29,10 +29,34 @@
 
 #include "extension.h"
 #include "container.h"
+#include "rgb.h"
+#include "vector3.h"
 
 
 class WeaponTypeClass;
 class CCINIClass;
+
+
+typedef enum SonicBeamSurfacePatternType
+{
+    SURFACE_PATTERN_CIRCLE,
+    SURFACE_PATTERN_ELLIPSE,
+    SURFACE_PATTERN_RHOMBUS,
+    SURFACE_PATTERN_SQUARE,
+
+    SURFACE_PATTERN_COUNT
+} SonicBeamSurfacePatternType;
+
+
+typedef enum SonicBeamSinePatternType
+{
+    SINE_PATTERN_CIRCLE,
+    SINE_PATTERN_SQUARE,
+    SINE_PATTERN_SAWTOOTH,
+    SINE_PATTERN_TRIANGLE,
+
+    SINE_PATTERN_COUNT
+} SonicBeamSinePatternType;
 
 
 class WeaponTypeClassExtension final : public Extension<WeaponTypeClass>
@@ -52,6 +76,49 @@ class WeaponTypeClassExtension final : public Extension<WeaponTypeClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
+        /**
+         *  Color of the sonic beam, in 24-bit RGB.
+         */
+        RGBStruct SonicBeamColor;
+
+        /**
+         *  Is the wave clear (no color)?
+         */
+        bool SonicBeamIsClear;
+
+        /**
+         *  The alpha blending of the sonic beam.
+         */
+        double SonicBeamAlpha;
+        
+        /**
+         *  The duration of one wave cycle.
+         */
+        double SonicBeamSineDuration;
+        
+        /**
+         *  The amplitude of the wave.
+         */
+        double SonicBeamSineAmplitude;
+        
+        /**
+         *  The amount to offset the pixel data.
+         */
+        double SonicBeamOffset;
+
+        /**
+         *  Start and end pins for the shape of the sonic beam.
+         */
+        Vector3 SonicBeamStartPinLeft;
+        Vector3 SonicBeamStartPinRight;
+        Vector3 SonicBeamEndPinLeft;
+        Vector3 SonicBeamEndPinRight;
+
+        /**
+         *  The pattern type for the sonic beam effect.
+         */
+        SonicBeamSurfacePatternType SonicBeamSurfacePattern;
+        SonicBeamSinePatternType SonicBeamSinePattern;
 };
 
 


### PR DESCRIPTION
Closes #540, Closes #547

This pull request adds various controls for customising the Sonic Beam weapon effect. It also implements a possible fix for the common "WaveClass" crashes see on older hardware (see issue #540).

Special thanks to @askhati and @MortonPL for assistance with the math calculations, and @tomsons26 with the drawing code.
 
**`SonicBeamColor=<r,g,b>`**
Color of the sonic beam, in 24-bit RGB. This color entry is used to enable the new drawing system, so you may need to experiment with the options below to get the desired drawing effect.

**`SonicBeamIsClear=<boolean>`**
Is the sonic beam clear (no color)? Defaults to `false`.

**`SonicBeamAlpha=<float>`**
The alpha blending of the sonic beam. Defaults to `0.5`.

**`SonicBeamSineDuration=<float>`**
The duration of one wave effect pattern cycle. Defaults to `0.125`.
        
**`SonicBeamSineAmplitude=<float>`**
The amplitude of the sonic beam pattern effect. Defaults to `12.0`.

**`SonicBeamOffset=<float>`**
The amount to offset the pixel data under the sonic beam. Defaults to `0.49`.

**`SonicBeamStartPinLeft=<x,y,z>`** _Defaults to `-30.0, -100.0, 0.0`_
**`SonicBeamStartPinRight=<x,y,z>`** _Defaults to `-30.0, 100.0, 0.0`_
**`SonicBeamEndPinLeft=<x,y,z>`** _Defaults to `30.0, -100.0, 0.0`_
**`SonicBeamEndPinRight=<x,y,z>`** _Defaults to `30.0, 100.0, 0.0`_
Start and end pins for the shape of the sonic beam. 

**`SonicBeamSurfacePattern=<string>`**
The pattern for the sonic beam effect. Available options are; `circle`, `ellipse`, `rhombus`, and `square`. Defaults to `circle`.

**`SonicBeamSinePattern=<string>`**
The sine wave pattern for the sonic beam effect. Available options are; `circle`, `square`, `sawtooth`, and `triangle`. Defaults to `circle`.

Example screenshot;
![image](https://user-images.githubusercontent.com/73803386/132772686-ae5f3dd7-9381-4e61-8a26-299b839980d1.png)
