### PR TITLE
Adds game options to allow MCV's to auto-deploy on game start and to pre-place construction yards instead of spawning an MCV.

### DIFF
--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -43,7 +43,8 @@ RulesClassExtension::UIControlsStruct RulesClassExtension::UIControls;
  */
 RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
     Extension(this_ptr),
-    IsMPAutoDeployMCV(false)
+    IsMPAutoDeployMCV(false),
+    IsMPPrePlacedConYards(false)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("RulesClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -157,6 +158,7 @@ void RulesClassExtension::Compute_CRC(WWCRCEngine &crc) const
     //DEV_DEBUG_TRACE("RulesClassExtension::Size_Of - 0x%08X\n", (uintptr_t)(ThisPtr));
 
     crc(IsMPAutoDeployMCV);
+    crc(IsMPPrePlacedConYards);
 }
 
 
@@ -219,6 +221,7 @@ bool RulesClassExtension::MPlayer(CCINIClass &ini)
     }
 
     IsMPAutoDeployMCV = ini.Get_Bool(MPLAYER, "AutoDeployMCV", IsMPAutoDeployMCV);
+    IsMPPrePlacedConYards = ini.Get_Bool(MPLAYER, "PrePlacedConYards", IsMPPrePlacedConYards);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -42,7 +42,8 @@ RulesClassExtension::UIControlsStruct RulesClassExtension::UIControls;
  *  @author: CCHyper
  */
 RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    IsMPAutoDeployMCV(false)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("RulesClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -155,6 +156,7 @@ void RulesClassExtension::Compute_CRC(WWCRCEngine &crc) const
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("RulesClassExtension::Size_Of - 0x%08X\n", (uintptr_t)(ThisPtr));
 
+    crc(IsMPAutoDeployMCV);
 }
 
 
@@ -169,6 +171,7 @@ void RulesClassExtension::Process(CCINIClass &ini)
     //DEV_DEBUG_TRACE("RulesClassExtension::Size_Of - 0x%08X\n", (uintptr_t)(ThisPtr));
 
     General(ini);
+    MPlayer(ini);
 }
 
 
@@ -197,6 +200,25 @@ bool RulesClassExtension::General(CCINIClass &ini)
     if (!ini.Is_Present(GENERAL)) {
         return false;
     }
+
+    return true;
+}
+
+
+/**
+ *  Process the general main game rules.
+ *  
+ *  @author: CCHyper
+ */
+bool RulesClassExtension::MPlayer(CCINIClass &ini)
+{
+    static char const * const MPLAYER = "MultiplayerDefaults";
+
+    if (!ini.Is_Present(MPLAYER)) {
+        return false;
+    }
+
+    IsMPAutoDeployMCV = ini.Get_Bool(MPLAYER, "AutoDeployMCV", IsMPAutoDeployMCV);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -71,11 +71,15 @@ class RulesClassExtension final : public Extension<RulesClass>
 
         static UIControlsStruct UIControls;
 
-    private:
+    public:
         bool General(CCINIClass &ini);
+        bool MPlayer(CCINIClass &ini);
 
     public:
-
+        /**
+         *  Should the MCV unit auto deploy on game start?
+         */
+        bool IsMPAutoDeployMCV;
 };
 
 

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -55,6 +55,9 @@ class RulesClassExtension final : public Extension<RulesClass>
         void Process(CCINIClass &ini);
         void Initialize(CCINIClass &ini);
 
+        bool General(CCINIClass &ini);
+        bool MPlayer(CCINIClass &ini);
+
         static bool Read_UI_INI();
         static bool Init_UI_Controls();
 
@@ -72,14 +75,15 @@ class RulesClassExtension final : public Extension<RulesClass>
         static UIControlsStruct UIControls;
 
     public:
-        bool General(CCINIClass &ini);
-        bool MPlayer(CCINIClass &ini);
-
-    public:
         /**
          *  Should the MCV unit auto deploy on game start?
          */
         bool IsMPAutoDeployMCV;
+
+        /**
+         *  Are construction yards pre-placed on the map rather than a MCV given to the player?
+         */
+        bool IsMPPrePlacedConYards;
 };
 
 

--- a/src/extensions/rules/rulesext_hooks.cpp
+++ b/src/extensions/rules/rulesext_hooks.cpp
@@ -183,6 +183,7 @@ DECLARE_PATCH(_Init_Rules_Extended_Class_Patch)
      */
     if (SessionExtension && RulesExtension) {
         SessionExtension->ExtOptions.IsAutoDeployMCV = RulesExtension->IsMPAutoDeployMCV; 
+        SessionExtension->ExtOptions.IsPrePlacedConYards = RulesExtension->IsMPPrePlacedConYards; 
     }
 
     /**

--- a/src/extensions/rules/rulesext_hooks.cpp
+++ b/src/extensions/rules/rulesext_hooks.cpp
@@ -35,6 +35,7 @@
 #include "session.h"
 #include "sessionext.h"
 #include "ccini.h"
+#include "addon.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
@@ -164,6 +165,20 @@ void RulesClassFake::_Process(CCINIClass &ini)
  */
 DECLARE_PATCH(_Init_Rules_Extended_Class_Patch)
 {
+    /**
+     *  #issue-583
+     * 
+     *  Allow Colors, AudioVisual and MPlayer sections to be read
+     *  from FSRuleINI on rules init.
+     * 
+     *  @author: CCHyper
+     */
+    if (Addon_407120(ADDON_FIRESTORM)) {
+        Rule->Colors(FSRuleINI);
+        Rule->AudioVisual(FSRuleINI);
+        Rule->MPlayer(FSRuleINI);
+    }
+
     /**
      *  Original code.
      */

--- a/src/extensions/rules/rulesext_init.cpp
+++ b/src/extensions/rules/rulesext_init.cpp
@@ -265,6 +265,38 @@ original_code:
 
 
 /**
+ *  Patch for including the extended class members when processing the MPlayer section.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_RulesClass_MPlayer_Patch)
+{
+    GET_REGISTER_STATIC(RulesClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(CCINIClass *, ini, edi);
+
+    /**
+     *  Find the extension instance.
+     */
+    if (!RulesExtension) {
+        goto original_code;
+    }
+
+    RulesExtension->MPlayer(*ini);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov al, 1 }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void RulesClassExtension_Init()
@@ -275,4 +307,5 @@ void RulesClassExtension_Init()
     Patch_Jump(0x005C66FF, &_RulesClass_Initialize_Patch);
     Patch_Jump(0x005C6A4D, &_RulesClass_Process_Patch);
     Patch_Jump(0x005D17F5, &_RulesClass_Detach_Patch);
+    Patch_Jump(0x005CC3BF, &_RulesClass_MPlayer_Patch);
 }

--- a/src/extensions/scenario/scenarioext_functions.cpp
+++ b/src/extensions/scenario/scenarioext_functions.cpp
@@ -42,6 +42,8 @@
 #include "unit.h"
 #include "unittype.h"
 #include "language.h"
+#include "sessionext.h"
+#include "session.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -813,7 +815,23 @@ void Vinifera_Create_Units(bool official)
                     if (Special.IsCaptureTheFlag) {
                         hptr->Flag_Attach((UnitClass *)obj, true);
                     }
+
+                    /**
+                     *  #issue-206
+                     * 
+                     *  Adds game option to allow MCV's to auto-deploy on game start.
+                     * 
+                     *  @author: CCHyper
+                     */
+                    if (Session.Options.UnitCount == 1) {
+                        if (SessionExtension && SessionExtension->ExtOptions.IsAutoDeployMCV) {
+                            if (hptr->Is_Human_Control()) {
+                                obj->Set_Mission(MISSION_UNLOAD);
+                            }
+                        }
+                    }
                 }
+
             } else if (obj) {
                 delete obj;
                 obj = nullptr;

--- a/src/extensions/session/sessionext.cpp
+++ b/src/extensions/session/sessionext.cpp
@@ -56,6 +56,7 @@ SessionClassExtension::SessionClassExtension(SessionClass *this_ptr) :
      *  Initialises the default game options.
      */
     ExtOptions.IsAutoDeployMCV = false;
+    ExtOptions.IsPrePlacedConYards = false;
     
     IsInitialized = true;
 }

--- a/src/extensions/session/sessionext.cpp
+++ b/src/extensions/session/sessionext.cpp
@@ -52,6 +52,11 @@ SessionClassExtension::SessionClassExtension(SessionClass *this_ptr) :
     //DEV_DEBUG_TRACE("SessionClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
     //DEV_DEBUG_WARNING("SessionClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
 
+   /**
+     *  Initialises the default game options.
+     */
+    ExtOptions.IsAutoDeployMCV = false;
+    
     IsInitialized = true;
 }
 

--- a/src/extensions/session/sessionext.h
+++ b/src/extensions/session/sessionext.h
@@ -60,6 +60,11 @@ class SessionClassExtension final : public Extension<SessionClass>
              */
             bool IsAutoDeployMCV;
 
+            /**
+             *  Are construction yards pre-placed on the map rather than a MCV given to the player?
+             */
+            bool IsPrePlacedConYards;
+
         } ExtGameOptionsType;
 
         ExtGameOptionsType ExtOptions;

--- a/src/extensions/session/sessionext.h
+++ b/src/extensions/session/sessionext.h
@@ -53,6 +53,16 @@ class SessionClassExtension final : public Extension<SessionClass>
         void Write_MultiPlayer_Settings();
 
     public:
+        typedef struct ExtGameOptionsType
+        {
+            /**
+             *  Should the MCV unit auto deploy on game start?
+             */
+            bool IsAutoDeployMCV;
+
+        } ExtGameOptionsType;
+
+        ExtGameOptionsType ExtOptions;
 };
 
 


### PR DESCRIPTION
Closes #206, Closes #583

This pull request adds two new game mode options;

These new options have been added to the `[MultiplayerDefaults]` section in RULES.INI;

`AutoDeployMCV=<boolean>`
_Player MCV's will auto-deploy on game start. (Defaults to `no`)._
_**NOTE:** This option only has an effect if the unit count is set to `1`._

`PrePlacedConYards=<boolean>`
_Pre-place construction yards instead of spawning an MCV. (Defaults to `no`)._
_**NOTE:** This option has priority over `AutoDeployMCV`._

Also included in this pull request is a fix for allowing the `[Colors]`, `[AudioVisual]` and `[MPlayerDefaults]` sections to be loaded from `FIRESTRM.INI`.
