### PR TITLE
Implements `SpawnDelay` for BulletTypes.

### DIFF
--- a/src/extensions/bullettype/bullettypeext.cpp
+++ b/src/extensions/bullettype/bullettypeext.cpp
@@ -44,7 +44,8 @@ ExtensionMap<BulletTypeClass, BulletTypeClassExtension> BulletTypeClassExtension
  *  @author: CCHyper
  */
 BulletTypeClassExtension::BulletTypeClassExtension(BulletTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    SpawnDelay(3)           // Default hardcoded value.
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("BulletTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -174,6 +175,17 @@ bool BulletTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    const char *graphic_name = ThisPtr->Graphic_Name();
+    
+    //if (!ArtINI.Is_Present(graphic_name)) {
+    //    return false;
+    //}
+
+    /**
+     *  The following keys are loaded from the ArtINI database.
+     */
+    SpawnDelay = ArtINI.Get_Int(graphic_name, "SpawnDelay", SpawnDelay);
     
     return true;
 }

--- a/src/extensions/bullettype/bullettypeext.h
+++ b/src/extensions/bullettype/bullettypeext.h
@@ -52,7 +52,10 @@ class BulletTypeClassExtension final : public Extension<BulletTypeClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
-
+        /**
+         *  The number of frames between trailer anim spawns.
+         */
+        unsigned SpawnDelay;
 };
 
 


### PR DESCRIPTION
Closes #563 

This pull request adds `SpawnDelay` from Red Alert 2.

**`[BulletType]`**
`SpawnDelay=<unsigned integer>`.
The number of frames between each of the spawned trailer animations. Defaults to `3`.