### PR TITLE
Implements `Soylent` for TechnoTypes.

### DIFF
--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -53,6 +53,48 @@
 
 
 /**
+ *  #issue-434
+ * 
+ *  Implements Soylent value (refund amount override) for technos.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Refund_Amount_Soylent_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    static TechnoTypeClassExtension *technotypext;
+    static TechnoTypeClass *technotype;
+    static int cost;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    technotype = this_ptr->Techno_Type_Class();
+
+    /**
+     *  Fetch the techno type extension.
+     */
+    technotypext = TechnoTypeClassExtensions.find(technotype);
+
+    /**
+     *  If the object has a soylent value defined, return this.
+     */
+    if (technotypext && technotypext->SoylentValue > 0) {
+        cost = technotypext->SoylentValue;
+        goto return_amount;
+    }
+
+continue_function:
+    _asm { mov eax, technotype }    // restore EAX pointer.
+    JMP_REG(ecx, 0x0063809D);
+
+return_amount:
+    _asm { mov edi, [cost] }
+    JMP(0x006380DC);
+}
+
+
+/**
  *  #issue-226
  * 
  *  Ensures infantry with IsMechanic only auto-target units and aircraft.
@@ -441,4 +483,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x0062C5D5, &_TechnoClass_Draw_Health_Bars_Unit_Draw_Pos_Patch);
     Patch_Jump(0x0062C55B, &_TechnoClass_Draw_Health_Bars_Infantry_Draw_Pos_Patch);
     Patch_Jump(0x0062DD70, &_TechnoClass_Greatest_Threat_Infantry_Mechanic_Patch);
+    Patch_Jump(0x00638095, &_TechnoClass_Refund_Amount_Soylent_Patch);
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -47,7 +47,6 @@ ExtensionMap<TechnoTypeClass, TechnoTypeClassExtension> TechnoTypeClassExtension
  */
 TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     Extension(this_ptr),
-
     CloakSound(VOC_NONE),
     UncloakSound(VOC_NONE),
     IsShakeScreen(false),
@@ -56,7 +55,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     ShakePixelYLo(0),
     ShakePixelXHi(0),
     ShakePixelXLo(0),
-    UnloadingClass(nullptr)
+    UnloadingClass(nullptr),
+    SoylentValue(0)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TechnoTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -176,6 +176,7 @@ void TechnoTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(ShakePixelYLo);
     crc(ShakePixelXHi);
     crc(ShakePixelXLo);
+    crc(SoylentValue);
 }
 
 
@@ -205,6 +206,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);
     ShakePixelXLo = ini.Get_Int(ini_name, "ShakeXlo", ShakePixelXLo);
     UnloadingClass = ini.Get_Techno(ini_name, "UnloadingClass", UnloadingClass);
+    SoylentValue = ini.Get_Int(ini_name, "Soylent", SoylentValue);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -88,6 +88,11 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
          *  The graphic class to switch to when this unit is unloading (e.g., at a refinery).
          */
         const TechnoTypeClass *UnloadingClass;
+
+        /**
+         *  The refund value for the unit when it is sold at a Service Depot.
+         */
+        unsigned SoylentValue;
 };
 
 


### PR DESCRIPTION
Closes #434

This pull request adds the `Soylent` key from Red Alert 2.

**`[TechnoType]`**
`Soylent=<unsigned integer>` - The refund value for the unit when it is sold at a Service Depot, or a building when sold by the player. Defaults to `0` _(uses normal refund amount logic)_.