### PR TITLE
Adds support for 8-bit PCX and PNG cameos.

### DIFF
--- a/src/extensions/animtype/animtypeext_hooks.cpp
+++ b/src/extensions/animtype/animtypeext_hooks.cpp
@@ -27,11 +27,33 @@
  ******************************************************************************/
 #include "animtypeext_hooks.h"
 #include "animtypeext_init.h"
+#include "animtype.h"
 #include "animtypeext.h"
 #include "supertype.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
+
+
+/**
+ *  Patches in an assertion check for image data.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_AnimTypeClass_Get_Image_Data_Assertion_Patch)
+{
+    GET_REGISTER_STATIC(AnimTypeClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(const ShapeFileStruct *, image, eax);
+
+    if (image == nullptr) {
+        DEBUG_WARNING("Anim %s has NULL image data!\n", this_ptr->Name());
+    }
+
+    _asm { mov eax, image } // restore eax state.
+    _asm { pop esi }
+    _asm { add esp, 0x264 }
+    _asm { ret }
+}
 
 
 /**
@@ -43,4 +65,6 @@ void AnimTypeClassExtension_Hooks()
      *  Initialises the extended class.
      */
     AnimTypeClassExtension_Init();
+
+    Patch_Jump(0x00419B37, &_AnimTypeClass_Get_Image_Data_Assertion_Patch);
 }

--- a/src/extensions/buildingtype/buildingtypeext_hooks.cpp
+++ b/src/extensions/buildingtype/buildingtypeext_hooks.cpp
@@ -35,6 +35,27 @@
 
 
 /**
+ *  Patches in an assertion check for image data.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingTypeClass_Get_Image_Data_Assertion_Patch)
+{
+    GET_REGISTER_STATIC(BuildingTypeClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(const ShapeFileStruct *, image, eax);
+
+    if (image == nullptr) {
+        DEBUG_WARNING("Building %s has NULL image data!\n", this_ptr->Name());
+    }
+
+    _asm { mov eax, image } // restore eax state.
+    _asm { pop esi }
+    _asm { add esp, 0x64 }
+    _asm { ret }
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void BuildingTypeClassExtension_Hooks()
@@ -43,4 +64,6 @@ void BuildingTypeClassExtension_Hooks()
      *  Initialises the extended class.
      */
     BuildingTypeClassExtension_Init();
+
+    Patch_Jump(0x00440365, &_BuildingTypeClass_Get_Image_Data_Assertion_Patch);
 }

--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -40,6 +40,7 @@
 #include "tacticalext_hooks.h"
 #include "scenarioext_hooks.h"
 #include "displayext_hooks.h"
+#include "sidebarext_hooks.h"
 #include "tooltipext_hooks.h"
 #include "commandext_hooks.h"
 #include "optionsext_hooks.h"
@@ -217,6 +218,7 @@ void Extension_Hooks()
     TacticalExtension_Hooks();
     ScenarioClassExtension_Hooks();
     DisplayClassExtension_Hooks();
+    SidebarClassExtension_Hooks();
     ToolTipManagerExtension_Hooks();
     CommandExtension_Hooks();
     OptionsClassExtension_Hooks();

--- a/src/extensions/isotiletype/isotiletypeext_hooks.cpp
+++ b/src/extensions/isotiletype/isotiletypeext_hooks.cpp
@@ -27,11 +27,48 @@
  ******************************************************************************/
 #include "isotiletypeext_hooks.h"
 #include "isotiletypeext_init.h"
+#include "isotiletype.h"
 #include "isotiletypeext.h"
-#include "supertype.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or deconstructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+static class IsometricTileTypeClassFake final : public IsometricTileTypeClass
+{
+    public:
+        const ShapeFileStruct * _Get_Image_Data();
+};
+
+
+/**
+ *  Reimplementation of IsometricTileTypeClass::Get_Image_Data with added assertion.
+ * 
+ *  @author: CCHyper
+ */
+const ShapeFileStruct * IsometricTileTypeClassFake::_Get_Image_Data()
+{
+    if (Image) {
+        return Image;
+    }
+
+    if (IsFileLoaded) {
+        Load_Image_Data();
+    }
+    
+    if (Image == nullptr) {
+        DEBUG_WARNING("IsoTile %s has NULL image data!\n", Name());
+    }
+
+    return Image;
+}
 
 
 /**
@@ -43,4 +80,6 @@ void IsometricTileTypeClassExtension_Hooks()
      *  Initialises the extended class.
      */
     IsometricTileTypeClassExtension_Init();
+
+    Patch_Jump(0x004F3570, &IsometricTileTypeClassFake::_Get_Image_Data);
 }

--- a/src/extensions/objecttype/objecttypeext_hooks.cpp
+++ b/src/extensions/objecttype/objecttypeext_hooks.cpp
@@ -49,6 +49,7 @@ static class ObjectTypeClassFake final : public ObjectTypeClass
 {
     public:
         void _Assign_Theater_Name(char *buffer, TheaterType theater);
+        const ShapeFileStruct * _Get_Image_Data() const;
 };
 
 
@@ -103,6 +104,21 @@ DECLARE_PATCH(_ObjectTypeClass_Load_Theater_Art_Assign_Theater_Name_Theater_Patc
 
 
 /**
+ *  Reimplementation of ObjectTypeClass::Get_Image_Data with added assertion.
+ * 
+ *  @author: CCHyper
+ */
+const ShapeFileStruct * ObjectTypeClassFake::_Get_Image_Data() const
+{
+    if (Image == nullptr) {
+        DEBUG_WARNING("Object %s has NULL image data!\n", Name());
+    }
+
+    return Image;
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void ObjectTypeClassExtension_Hooks()
@@ -112,6 +128,7 @@ void ObjectTypeClassExtension_Hooks()
      */
     ObjectTypeClassExtension_Init();
 
+    Patch_Jump(0x004101A0, &ObjectTypeClassFake::_Get_Image_Data);
     Patch_Jump(0x00588D00, &ObjectTypeClassFake::_Assign_Theater_Name);
     Patch_Jump(0x0058891D, &_ObjectTypeClass_Load_Theater_Art_Assign_Theater_Name_Theater_Patch);
 }

--- a/src/extensions/overlaytype/overlaytypeext_hooks.cpp
+++ b/src/extensions/overlaytype/overlaytypeext_hooks.cpp
@@ -35,6 +35,27 @@
 
 
 /**
+ *  Patches in an assertion check for image data.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_OverlayTypeClass_Get_Image_Data_Assertion_Patch)
+{
+    GET_REGISTER_STATIC(OverlayTypeClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(const ShapeFileStruct *, image, eax);
+
+    if (image == nullptr) {
+        DEBUG_WARNING("Overlay %s has NULL image data!\n", this_ptr->Name());
+    }
+
+    _asm { mov eax, image } // restore eax state.
+    _asm { pop esi }
+    _asm { add esp, 0x264 }
+    _asm { ret }
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void OverlayTypeClassExtension_Hooks()
@@ -43,4 +64,6 @@ void OverlayTypeClassExtension_Hooks()
      *  Initialises the extended class.
      */
     OverlayTypeClassExtension_Init();
+
+    Patch_Jump(0x0058DC18, &_OverlayTypeClass_Get_Image_Data_Assertion_Patch);
 }

--- a/src/extensions/sidebar/sidebarext_hooks.cpp
+++ b/src/extensions/sidebar/sidebarext_hooks.cpp
@@ -1,0 +1,169 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          SIDEBAREXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended SidebarClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "sidebarext_hooks.h"
+#include "tibsun_globals.h"
+#include "sidebar.h"
+#include "technotype.h"
+#include "technotypeext.h"
+#include "supertype.h"
+#include "supertypeext.h"
+#include "spritecollection.h"
+#include "bsurface.h"
+#include "drawshape.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+static const ObjectTypeClass *_SidebarClass_StripClass_obj = nullptr;
+static const SuperWeaponTypeClass *_SidebarClass_StripClass_spc = nullptr;
+static BSurface *_SidebarClass_StripClass_CustomImage = nullptr;
+
+
+/**
+ *  #issue-487
+ * 
+ *  Adds support for PCX/PNG cameo icons.
+ * 
+ *  The following two patches store the PCX/PNG image for the factory object or special.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_SidebarClass_StripClass_ObjectTypeClass_Custom_Cameo_Image_Patch)
+{
+    GET_REGISTER_STATIC(const ObjectTypeClass *, obj, ebp);
+    static const TechnoTypeClassExtension *technotypeext;
+    static const ShapeFileStruct *shapefile;
+
+    shapefile = obj->Get_Cameo_Data();
+
+    _SidebarClass_StripClass_obj = obj;
+    _SidebarClass_StripClass_CustomImage = nullptr;
+
+    technotypeext = TechnoTypeClassExtensions.find(reinterpret_cast<const TechnoTypeClass *>(obj));
+    if (technotypeext && technotypeext->CameoImageSurface) {
+        _SidebarClass_StripClass_CustomImage = technotypeext->CameoImageSurface;
+    }
+
+    _asm { mov eax, shapefile }
+
+    JMP_REG(ebx, 0x005F5193);
+}
+
+DECLARE_PATCH(_SidebarClass_StripClass_SuperWeaponType_Custom_Cameo_Image_Patch)
+{
+    GET_REGISTER_STATIC(const SuperWeaponTypeClass *, supertype, eax);
+    static const SuperWeaponTypeClassExtension *supertypeext;
+    static const ShapeFileStruct *shapefile;
+
+    shapefile = supertype->SidebarIcon;
+
+    _SidebarClass_StripClass_spc = supertype;
+    _SidebarClass_StripClass_CustomImage = nullptr;
+
+    supertypeext = SuperWeaponTypeClassExtensions.find(supertype);
+    if (supertypeext && supertypeext->CameoImageSurface) {
+        _SidebarClass_StripClass_CustomImage = supertypeext->CameoImageSurface;
+    }
+
+    _asm { mov ebx, shapefile }
+
+    JMP(0x005F5220);
+}
+
+
+/**
+ *  #issue-487
+ * 
+ *  Adds support for PCX/PNG cameo icons.
+ * 
+ *  @author: CCHyper
+ */
+static Point2D pointxy;
+static Rect pcxrect;
+DECLARE_PATCH(_SidebarClass_StripClass_Custom_Cameo_Image_Patch)
+{
+    GET_STACK_STATIC(SidebarClass::StripClass *, this_ptr, esp, 0x24);
+    LEA_STACK_STATIC(Rect *, window_rect, esp, 0x34);
+    GET_REGISTER_STATIC(int, pos_x, edi);
+    GET_REGISTER_STATIC(int, pos_y, esi);
+    GET_REGISTER_STATIC(const ShapeFileStruct *, shapefile, ebx);
+    static BSurface *image_surface;
+
+    image_surface = nullptr;
+
+    /**
+     *  Was a factory object or special image found?
+     */
+    if (_SidebarClass_StripClass_CustomImage) {
+        image_surface = _SidebarClass_StripClass_CustomImage;
+    }
+
+    /**
+     *  Draw the cameo pcx image.
+     */
+    if (image_surface) {
+        pcxrect.X = window_rect->X + pos_x;
+        pcxrect.Y = window_rect->Y + pos_y;
+        pcxrect.Width = image_surface->Get_Width();
+        pcxrect.Height = image_surface->Get_Height();
+
+        SpriteCollection.Draw(pcxrect, *SidebarSurface, *image_surface);
+
+    /**
+     *  Draw shape cameo image.
+     */
+    } else if (shapefile) {
+        pointxy.X = pos_x;
+        pointxy.Y = pos_y;
+
+        CC_Draw_Shape(SidebarSurface, CameoDrawer, shapefile, 0, &pointxy, window_rect, SHAPE_400|SHAPE_NORMAL);
+    }
+
+    _SidebarClass_StripClass_CustomImage = nullptr;
+
+    /**
+     *  Next, draw the clock darken shape.
+     */
+draw_darken_shape:
+    JMP(0x005F52F3);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void SidebarClassExtension_Hooks()
+{
+    Patch_Jump(0x005F5188, &_SidebarClass_StripClass_ObjectTypeClass_Custom_Cameo_Image_Patch);
+    Patch_Jump(0x005F5216, &_SidebarClass_StripClass_SuperWeaponType_Custom_Cameo_Image_Patch);
+    Patch_Jump(0x005F52AF, &_SidebarClass_StripClass_Custom_Cameo_Image_Patch);
+}

--- a/src/extensions/sidebar/sidebarext_hooks.h
+++ b/src/extensions/sidebar/sidebarext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          SUPERTYPEEXT.H
+ *  @file          SIDEBAREXT_HOOKS.H
  *
  *  @author        CCHyper
  *
- *  @brief         Extended SuperWeaponTypeClass class.
+ *  @brief         Contains the hooks for the extended SidebarClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,43 +27,5 @@
  ******************************************************************************/
 #pragma once
 
-#include "extension.h"
-#include "container.h"
 
-
-class SuperWeaponTypeClass;
-class CCINIClass;
-class BSurface;
-
-
-class SuperWeaponTypeClassExtension final : public Extension<SuperWeaponTypeClass>
-{
-    public:
-        SuperWeaponTypeClassExtension(SuperWeaponTypeClass *this_ptr);
-        SuperWeaponTypeClassExtension(const NoInitClass &noinit);
-        ~SuperWeaponTypeClassExtension();
-
-        virtual HRESULT Load(IStream *pStm) override;
-        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
-        virtual int Size_Of() const override;
-
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
-
-        bool Read_INI(CCINIClass &ini);
-
-    public:
-        /**
-         *  When this super weapon is active, does its recharge timer display
-         *  on the tactical view?
-         */
-        bool IsShowTimer;
-
-        /**
-         *  Pointer to the cameo image surface.
-         */
-        BSurface *CameoImageSurface;
-};
-
-
-extern ExtensionMap<SuperWeaponTypeClass, SuperWeaponTypeClassExtension> SuperWeaponTypeClassExtensions;
+void SidebarClassExtension_Hooks();

--- a/src/extensions/supertype/supertypeext.cpp
+++ b/src/extensions/supertype/supertypeext.cpp
@@ -27,6 +27,7 @@
  ******************************************************************************/
 #include "supertypeext.h"
 #include "supertype.h"
+#include "vinifera_util.h"
 #include "ccini.h"
 #include "asserthandler.h"
 #include "debughandler.h"
@@ -45,7 +46,8 @@ ExtensionMap<SuperWeaponTypeClass, SuperWeaponTypeClassExtension> SuperWeaponTyp
  */
 SuperWeaponTypeClassExtension::SuperWeaponTypeClassExtension(SuperWeaponTypeClass *this_ptr) :
     Extension(this_ptr),
-    IsShowTimer(false)
+    IsShowTimer(false),
+    CameoImageSurface(nullptr)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("SuperWeaponTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -77,6 +79,9 @@ SuperWeaponTypeClassExtension::~SuperWeaponTypeClassExtension()
     //EXT_DEBUG_TRACE("SuperWeaponTypeClassExtension destructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
     //EXT_DEBUG_WARNING("SuperWeaponTypeClassExtension destructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
 
+    delete CameoImageSurface;
+    CameoImageSurface = nullptr;
+
     IsInitialized = false;
 }
 
@@ -97,6 +102,14 @@ HRESULT SuperWeaponTypeClassExtension::Load(IStream *pStm)
     }
 
     new (this) SuperWeaponTypeClassExtension(NoInitClass());
+
+    /**
+     *  Fetch the cameo image surface if it exists.
+     */
+    BSurface *imagesurface = Vinifera_Get_Image_Surface(ThisPtr->SidebarImage);
+    if (imagesurface) {
+        CameoImageSurface = imagesurface;
+    }
     
     return hr;
 }
@@ -177,6 +190,14 @@ bool SuperWeaponTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     IsShowTimer = ini.Get_Bool(ini_name, "ShowTimer", IsShowTimer);
+
+    /**
+     *  Fetch the cameo image surface if it exists.
+     */
+    BSurface *imagesurface = Vinifera_Get_Image_Surface(ThisPtr->SidebarImage);
+    if (imagesurface) {
+        CameoImageSurface = imagesurface;
+    }
     
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -35,6 +35,7 @@
 
 class TechnoTypeClass;
 class CCINIClass;
+class BSurface;
 
 
 class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
@@ -140,6 +141,11 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
          *  The rate at which this unit animates when it is standing idle (not moving).
          */
         unsigned IdleRate;
+
+        /**
+         *  Pointer to the cameo image surface.
+         */
+        BSurface *CameoImageSurface;
 };
 
 

--- a/src/vinifera/vinifera_util.cpp
+++ b/src/vinifera/vinifera_util.cpp
@@ -34,6 +34,10 @@
 #include "colorscheme.h"
 #include "textprint.h"
 #include "dsurface.h"
+#include "bsurface.h"
+#include "spritecollection.h"
+#include "filepng.h"
+#include "filepcx.h"
 #include "cncnet4_globals.h"
 #include "wwfont.h"
 #include "msgbox.h"
@@ -676,4 +680,45 @@ HGLOBAL Vinifera_Fetch_Resource(HMODULE handle, const char *id, const char *type
     //DEBUGINFO("Fetch_Resource() - Resource loaded sucessfully.\n");
 
     return res_data;
+}
+
+
+/**
+ *  Fetch a image surface from the specified filename if it exists.
+ *  
+ *  @return      NULL if the image file was not found.
+ * 
+ *  @warning     The input filename must not contain an extension!
+ * 
+ *  @author: CCHyper
+ */
+BSurface *Vinifera_Get_Image_Surface(const char *filename)
+{
+    BSurface *surface = nullptr;
+    CCFileClass file;
+
+    Wstring fname = filename;
+    fname.To_Upper();
+
+    Wstring png_fname = fname;
+    png_fname += ".PNG";
+
+    file.Set_Name(png_fname.Peek_Buffer());
+
+    surface = Read_PNG_File(&file);
+    if (surface) {
+        return surface;
+    }
+
+    surface = Get_BMP_Image_Surface(fname.Peek_Buffer());
+    if (surface) {
+        return surface;
+    }
+
+    surface = Get_PCX_Image_Surface(fname.Peek_Buffer());
+    if (surface) {
+        return surface;
+    }
+
+    return nullptr;
 }

--- a/src/vinifera/vinifera_util.h
+++ b/src/vinifera/vinifera_util.h
@@ -32,6 +32,7 @@
 
 
 class XSurface;
+class BSurface;
 
 
 const char *Vinifera_Version_String();
@@ -64,3 +65,5 @@ HGLOBAL Vinifera_Fetch_Resource(HMODULE handle, const char *id, const char *type
 #define FETCH_STRING Vinifera_Fetch_String
 #define FETCH_RESOURCE Vinifera_Fetch_Resource
 #endif
+
+BSurface *Vinifera_Get_Image_Surface(const char *filename);


### PR DESCRIPTION
Closes #487

This pull request adds support for 8-bit _(paletted and non-paletted)_ PCX and 8-bit PNG cameos. This system auto-detects and prioritises the PNG or PCX file if found, no additional settings are required.

Attached are two example PCX files and one PNG file that can be used for testing, rename as you see fit;
[vinifera_pcx_cameos.zip](https://github.com/Vinifera-Developers/Vinifera/files/7245748/vinifera_pcx_cameos.zip)
[vinifera_png_cameo.zip](https://github.com/Vinifera-Developers/Vinifera/files/7406339/vinifera_png_cameo.zip)

