### PR TITLE
Implements `Mechanic` and `OmniHealer` for InfantryTypes.

### DIFF
--- a/src/extensions/infantrytype/infantrytypeext.cpp
+++ b/src/extensions/infantrytype/infantrytypeext.cpp
@@ -44,7 +44,8 @@ ExtensionMap<InfantryTypeClass, InfantryTypeClassExtension> InfantryTypeClassExt
  *  @author: CCHyper
  */
 InfantryTypeClassExtension::InfantryTypeClassExtension(InfantryTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    IsMechanic(false)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("InfantryTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -155,6 +156,8 @@ void InfantryTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("InfantryTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    crc(IsMechanic);
 }
 
 
@@ -174,6 +177,8 @@ bool InfantryTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    IsMechanic = ini.Get_Bool(ini_name, "Mechanic", IsMechanic);
     
     return true;
 }

--- a/src/extensions/infantrytype/infantrytypeext.cpp
+++ b/src/extensions/infantrytype/infantrytypeext.cpp
@@ -45,7 +45,8 @@ ExtensionMap<InfantryTypeClass, InfantryTypeClassExtension> InfantryTypeClassExt
  */
 InfantryTypeClassExtension::InfantryTypeClassExtension(InfantryTypeClass *this_ptr) :
     Extension(this_ptr),
-    IsMechanic(false)
+    IsMechanic(false),
+    IsOmniHealer(false)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("InfantryTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -158,6 +159,7 @@ void InfantryTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     //DEV_DEBUG_TRACE("InfantryTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
 
     crc(IsMechanic);
+    crc(IsOmniHealer);
 }
 
 
@@ -179,6 +181,7 @@ bool InfantryTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     IsMechanic = ini.Get_Bool(ini_name, "Mechanic", IsMechanic);
+    IsOmniHealer = ini.Get_Bool(ini_name, "OmniHealer", IsOmniHealer);
     
     return true;
 }

--- a/src/extensions/infantrytype/infantrytypeext.h
+++ b/src/extensions/infantrytype/infantrytypeext.h
@@ -52,7 +52,11 @@ class InfantryTypeClassExtension final : public Extension<InfantryTypeClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
-
+        /**
+         *  If this infantry has a weapon with negative damage, does it target
+         *  units and aircraft rather than other infantry (e.g., like a medic?)?
+         */
+        bool IsMechanic;
 };
 
 

--- a/src/extensions/infantrytype/infantrytypeext.h
+++ b/src/extensions/infantrytype/infantrytypeext.h
@@ -57,6 +57,12 @@ class InfantryTypeClassExtension final : public Extension<InfantryTypeClass>
          *  units and aircraft rather than other infantry (e.g., like a medic?)?
          */
         bool IsMechanic;
+
+        /**
+         *  If this infantry has a weapon with negative damage, does it target
+         *  units, aircraft and other infantry (e.g., medic and mechanic combined)?
+         */
+        bool IsOmniHealer;
 };
 
 

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -73,12 +73,15 @@ DECLARE_PATCH(_TechnoClass_Greatest_Threat_Infantry_Mechanic_Patch)
     method = (method & (THREAT_RANGE|THREAT_AREA));
     
     /**
-     *  If this is a mechanic, then they only consider vehicles and aircraft
-     *  as valid targets, otherwise, we assume this is a medic and they can
-     *  only consider other infantry to be a threat.
+     *  The following;
+     *  - If this is a dual healer: Then infantry, vehicles and aircraft are valid targets.
+     *  - If this is a mechanic: Then only consider vehicles and aircraft as valid targets.
+     *  - Otherwise, we assume this is a medic and they can only consider other infantry to be a threat.
      */
     infantrytypeext = InfantryTypeClassExtensions.find(infantry_this_ptr->Class);
-    if (infantrytypeext && infantrytypeext->IsMechanic) {
+    if (infantrytypeext && infantrytypeext->IsOmniHealer) {
+        method = method|(THREAT_INFANTRY|THREAT_VEHICLES|THREAT_AIR|THREAT_4000);
+    } else if (infantrytypeext && infantrytypeext->IsMechanic) {
         method = method|(THREAT_VEHICLES|THREAT_AIR|THREAT_4000);
     } else {
         method = method|(THREAT_INFANTRY|THREAT_4000);

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -77,12 +77,15 @@ DECLARE_PATCH(_TechnoClass_Greatest_Threat_Infantry_Mechanic_Patch)
      *  - If this is a dual healer: Then infantry, vehicles and aircraft are valid targets.
      *  - If this is a mechanic: Then only consider vehicles and aircraft as valid targets.
      *  - Otherwise, we assume this is a medic and they can only consider other infantry to be a threat.
+     * 
+     *  #NOTE: Removed THREAT_AIR for IsMechanic and IsOmniHealer infantry and it causes
+     *         them to chase down damaged friendly aircraft in the air.
      */
     infantrytypeext = InfantryTypeClassExtensions.find(infantry_this_ptr->Class);
     if (infantrytypeext && infantrytypeext->IsOmniHealer) {
-        method = method|(THREAT_INFANTRY|THREAT_VEHICLES|THREAT_AIR|THREAT_4000);
+        method = method|(THREAT_INFANTRY|THREAT_VEHICLES/*|THREAT_AIR*/|THREAT_4000);
     } else if (infantrytypeext && infantrytypeext->IsMechanic) {
-        method = method|(THREAT_VEHICLES|THREAT_AIR|THREAT_4000);
+        method = method|(THREAT_VEHICLES/*|THREAT_AIR*/|THREAT_4000);
     } else {
         method = method|(THREAT_INFANTRY|THREAT_4000);
     }


### PR DESCRIPTION
Closes #226 

This pull request reimplements the legacy Mechanic logic from Red Alert. In addition to this, a new key to allow the healing of both infantry and units has been added.

**NOTE:** Both these systems require the warhead to deal negative damage.

**`[InfantryType]`**
`Mechanic=<boolean>`
Should this infantry only consider unit and aircraft as valid targets? Defaults to `no`.

`OmniHealer=<boolean>`
Should this infantry consider other infantry, unit, and aircraft as valid targets? Defaults to `no`.

**Additional Information:**
When an infantry with `Mechanic=yes` and `DualHealer=yes` is selected and the mouse is over a transport unit or aircraft, holding down the `Alt` key _(Force Move)_ will allow you to enter the transport instead of healing it.

