### PR TITLE
Implements `OmniFire` for WeaponTypes.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -138,6 +138,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement exclusive factories.
   - Change the behavior MultipleFactory and implements build speed overrides.
   - Implement `StopSound` for `AnimTypes` and `VoxelAnimTypes`.
+  - Implement 'OmniFire' for WeaponTypes.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1534,3 +1534,17 @@ DeleteOnSuicide=no  ; boolean, logical option for Suicide=yes which will instant
 ```{note}
 `DeleteOnSuicide=yes` mimics Red Alert 2 behavior.
 ```
+
+### OmniFire
+
+- Vinifera implements `OmniFire` from Red Alert 2 for `WeaponTypes`.
+
+In `RULES.INI`:
+```ini
+[WeaponType]
+OmniFire=yes  ; boolean, does the unit firing this weapon have to perform a turn to face its target before firing.
+```
+
+```{note}
+`OmniFire` only applies to `UnitTypes`.
+```

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -191,6 +191,7 @@ New:
 - Implement exclusive factories (by ZivDero)
 - Change the behavior MultipleFactory and implements build speed overrides (by CCHyper)
 - Implement `StopSound` for `AnimTypes` and `VoxelAnimTypes` (by CCHyper)
+- Implement 'OmniFire' for WeaponTypes (by CCHyper)
 
 
 Vanilla fixes:

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -32,9 +32,12 @@
 #include "tibsun_globals.h"
 #include "tibsun_functions.h"
 #include "tag.h"
+#include "unittypeext.h"
 #include "technotype.h"
 #include "technotypeext.h"
 #include "warheadtype.h"
+#include "weapontype.h"
+#include "weapontypeext.h"
 #include "unit.h"
 #include "unitext.h"
 #include "unittype.h"
@@ -252,6 +255,97 @@ DECLARE_PATCH(_UnitClass_Draw_Voxel_Patch)
     _asm mov ebx, color
 
     JMP(0x006528E9);
+}
+
+
+/**
+ *  #issue-550
+ * 
+ *  Implements IsOmniFire for units.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_UnitClass_Can_Fire_IsOmniFire_Patch)
+{
+    GET_REGISTER_STATIC(UnitClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(WeaponTypeClass *, weapon, ebx);
+    static WeaponTypeClassExtension *weapontypeext;
+
+    weapontypeext = Extension::Fetch<WeaponTypeClassExtension>(weapon);
+
+    /**
+     *  Do we need to perform a turn to face the target before firing?
+     */
+    if (weapontypeext->IsOmniFire) {
+        goto locomotor_Can_Fire;
+    }
+
+    /**
+     *  Stolen bytes/code.
+     */
+    if (this_ptr->Class->IsLargeVisceroid) {
+        goto locomotor_Can_Fire;
+    }
+
+continue_facing_check:
+    static UnitTypeClass *class_ptr;    // Restore EAX pointer.
+    class_ptr = this_ptr->Class;
+    _asm { mov eax, class_ptr }
+
+    /**
+     *  Final check to make sure the locomotor allows firing.
+     */
+locomotor_Can_Fire:
+    JMP(0x00656FA7);
+}
+
+
+/**
+ *  #issue-550
+ * 
+ *  Implements IsOmniFire for units.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_UnitClass_Rotation_AI_IsOmniFire_Patch)
+{
+    GET_REGISTER_STATIC(UnitClass *, this_ptr, esi);
+    GET_STACK_STATIC(DirStruct *, tarcom_dir, esp, 0x8);
+    static const WeaponInfoStruct *weaponinfo;
+    static WeaponTypeClass *weapontype;
+    static WeaponTypeClassExtension *weapontypeext;
+
+    /**
+     *  Fetch this units primary weapon.
+     */
+    weaponinfo = this_ptr->Get_Weapon(WEAPON_SLOT_PRIMARY);
+    if (weaponinfo->Weapon) {
+
+        weapontypeext = Extension::Fetch<WeaponTypeClassExtension>(weaponinfo->Weapon);
+
+        /**
+         *  Do we need turn to face the target?
+         */
+        if (weapontypeext->IsOmniFire) {
+            goto continue_rotation_checks;
+        }
+
+    }
+
+    /**
+     *  Original code.
+     *  
+     *  Set the desired facing for the turret to that of the target.
+     */
+    this_ptr->SecondaryFacing.Set_Desired(*tarcom_dir);
+
+    JMP(0x0064E612);
+
+    /**
+     *  Skip setting turret facing, continue rotation checks.
+     */
+continue_rotation_checks:
+    JMP(0x0064E612);
 }
 
 
@@ -1364,4 +1458,6 @@ void UnitClassExtension_Hooks()
     Patch_Jump(0x00654EEE, &_UnitClass_Mission_Harvest_FINDHOME_Find_Nearest_Refinery_Patch);
     //Patch_Jump(0x0065054F, &_UnitClass_Enter_Idle_Mode_Block_Harvesting_On_Bridge_Patch); // Removed, keeping code for reference.
     //Patch_Jump(0x00654AB0, &_UnitClass_Mission_Harvest_Block_Harvesting_On_Bridge_Patch); // Removed, keeping code for reference.
+    Patch_Jump(0x0064E5A6, &_UnitClass_Rotation_AI_IsOmniFire_Patch);
+    Patch_Jump(0x00656F99, &_UnitClass_Can_Fire_IsOmniFire_Patch);
 }

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -271,7 +271,7 @@ DECLARE_PATCH(_UnitClass_Can_Fire_IsOmniFire_Patch)
     GET_REGISTER_STATIC(WeaponTypeClass *, weapon, ebx);
     static WeaponTypeClassExtension *weapontypeext;
 
-    weapontypeext = Extension::Fetch<WeaponTypeClassExtension>(weapon);
+    weapontypeext = Extension::Fetch(weapon);
 
     /**
      *  Do we need to perform a turn to face the target before firing?
@@ -310,7 +310,7 @@ locomotor_Can_Fire:
 DECLARE_PATCH(_UnitClass_Rotation_AI_IsOmniFire_Patch)
 {
     GET_REGISTER_STATIC(UnitClass *, this_ptr, esi);
-    GET_STACK_STATIC(DirStruct *, tarcom_dir, esp, 0x8);
+    GET_STACK_STATIC(DirType *, tarcom_dir, esp, 0x8);
     static const WeaponInfoStruct *weaponinfo;
     static WeaponTypeClass *weapontype;
     static WeaponTypeClassExtension *weapontypeext;
@@ -321,7 +321,7 @@ DECLARE_PATCH(_UnitClass_Rotation_AI_IsOmniFire_Patch)
     weaponinfo = this_ptr->Get_Weapon(WEAPON_SLOT_PRIMARY);
     if (weaponinfo->Weapon) {
 
-        weapontypeext = Extension::Fetch<WeaponTypeClassExtension>(weaponinfo->Weapon);
+        weapontypeext = Extension::Fetch(weaponinfo->Weapon);
 
         /**
          *  Do we need turn to face the target?

--- a/src/extensions/weapontype/weapontypeext.cpp
+++ b/src/extensions/weapontype/weapontypeext.cpp
@@ -44,6 +44,7 @@ WeaponTypeClassExtension::WeaponTypeClassExtension(const WeaponTypeClass *this_p
     AbstractTypeClassExtension(this_ptr),
     IsSuicide(false),
     IsDeleteOnSuicide(false),
+    IsOmniFire(true),
     IsElectricBolt(false),
     ElectricBoltColor1(EBOLT_DEFAULT_COLOR_1),
     ElectricBoltColor2(EBOLT_DEFAULT_COLOR_2),
@@ -177,6 +178,7 @@ void WeaponTypeClassExtension::Object_CRC(CRCEngine &crc) const
 {
     //EXT_DEBUG_TRACE("WeaponTypeClassExtension::Object_CRC - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
+    crc(IsOmniFire);
     crc(IsElectricBolt);
     crc(IsSpawner);
     crc(IsRevealOnFire);
@@ -200,6 +202,7 @@ bool WeaponTypeClassExtension::Read_INI(CCINIClass &ini)
     
     IsSuicide = ini.Get_Bool(ini_name, "Suicide", IsSuicide);
     IsDeleteOnSuicide = ini.Get_Bool(ini_name, "DeleteOnSuicide", IsDeleteOnSuicide);
+    IsOmniFire = ini.Get_Bool(ini_name, "OmniFire", IsOmniFire);
 
     IsElectricBolt = ini.Get_Bool(ini_name, "IsElectricBolt", IsElectricBolt);
     ElectricBoltColor1 = ini.Get_RGB(ini_name, "EBoltColor1", ElectricBoltColor1);

--- a/src/extensions/weapontype/weapontypeext.h
+++ b/src/extensions/weapontype/weapontypeext.h
@@ -73,6 +73,11 @@ WeaponTypeClassExtension final : public AbstractTypeClassExtension
         bool IsDeleteOnSuicide;
 
         /**
+         *  Does the unit firing this weapon have to perform a turn to face its target before firing?
+         */
+        bool IsOmniFire;
+
+        /**
          *  Is this a electric bolt weapon (Uses custom drawing)?
          */
         bool IsElectricBolt;


### PR DESCRIPTION
Closes #550

This pull request implements `OmniFire` from Red Alert 2 for WeaponTypes.

**`[WeaponType]`**
`OmniFire=<boolean>`
Does the unit firing this weapon have to perform a turn to face its target before firing _(Only applies to `UnitTypes`)_? Defaults to `yes`.
