### PR TITLE
Implements `EnterTransportSound` and `LeaveTransportSound` for TechnoTypes.

### DIFF
--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -30,7 +30,10 @@
 #include "infantry.h"
 #include "infantrytype.h"
 #include "infantrytypeext.h"
+#include "technotype.h"
+#include "technotypeext.h"
 #include "target.h"
+#include "voc.h"
 #include "tibsun_globals.h"
 #include "options.h"
 #include "wwkeyboard.h"
@@ -40,6 +43,36 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-264
+ * 
+ *  Implements EnterTransportSound for infantry when they enter a transport.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_InfantryClass_Per_Cell_Process_Transport_Attach_Sound_Patch)
+{
+    GET_REGISTER_STATIC(InfantryClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(TechnoClass *, techno, edi);        // Radio contact
+    static TechnoTypeClassExtension *radio_technotypeext;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    techno->Cargo.Attach(this_ptr);
+
+    /**
+     *  If this transport we are entering has a passenger entering sound, play it now.
+     */
+    radio_technotypeext = TechnoTypeClassExtensions.find(techno->Techno_Type_Class());
+    if (radio_technotypeext && radio_technotypeext->EnterTransportSound != VOC_NONE) {
+        Sound_Effect(radio_technotypeext->EnterTransportSound, techno->Coord);
+    }
+
+    JMP(0x004D3A87);
+}
 
 
 /**
@@ -430,4 +463,5 @@ void InfantryClassExtension_Hooks()
     Patch_Jump(0x004D5AB4, &_InfantryClass_Can_Fire_Target_Check_Patch);
     Patch_Jump(0x004D7168, &_InfantryClass_What_Action_Mechanic_Patch);
     Patch_Jump(0x004D87E9, &_InfantryClass_Firing_AI_Mechanic_Patch);
+    Patch_Jump(0x004D3A7B, &_InfantryClass_Per_Cell_Process_Transport_Attach_Sound_Patch);
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -56,7 +56,9 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     ShakePixelXHi(0),
     ShakePixelXLo(0),
     UnloadingClass(nullptr),
-    SoylentValue(0)
+    SoylentValue(0),
+    EnterTransportSound(VOC_NONE),
+    LeaveTransportSound(VOC_NONE)
 {
     ASSERT(ThisPtr != nullptr);
     //DEV_DEBUG_TRACE("TechnoTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -207,6 +209,8 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     ShakePixelXLo = ini.Get_Int(ini_name, "ShakeXlo", ShakePixelXLo);
     UnloadingClass = ini.Get_Techno(ini_name, "UnloadingClass", UnloadingClass);
     SoylentValue = ini.Get_Int(ini_name, "Soylent", SoylentValue);
+    EnterTransportSound = ini.Get_VocType(ini_name, "EnterTransportSound", EnterTransportSound);
+    LeaveTransportSound = ini.Get_VocType(ini_name, "LeaveTransportSound", LeaveTransportSound);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -93,6 +93,16 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
          *  The refund value for the unit when it is sold at a Service Depot.
          */
         unsigned SoylentValue;
+
+        /**
+         *  This is the sound effect to play when a passenger enters this unit.
+         */
+        VocType EnterTransportSound;
+
+        /**
+         *  This is the sound effect to play when a passenger leaves this unit.
+         */
+        VocType LeaveTransportSound;
 };
 
 


### PR DESCRIPTION
Closes #264 

This pull request implements `EnterTransportSound` and `LeaveTransportSound` from Red Alert 2 for TechnoTypes.

**`[TechnoType]`**
`EnterTransportSound=<VocType>`
The sound effect to play when a passenger enters this unit. Defaults to `<none>`.

`LeaveTransportSound=<VocType>`
The sound effect to play when a passenger leaves this unit. Defaults to `<none>`.
