### PR TITLE
Implements JumpCamera (North, South, East and West) CommandClass's

### DIFF
--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -520,6 +520,158 @@ bool ScrollNWCommandClass::Process()
 
 
 /**
+ *  Jump the tactical map camera to the west edge of the map.
+ * 
+ *  @author: CCHyper
+ */
+const char *JumpCameraWestCommandClass::Get_Name() const
+{
+    return "JumpCameraWest";
+}
+
+const char *JumpCameraWestCommandClass::Get_UI_Name() const
+{
+    return "Jump Camera West";
+}
+
+const char *JumpCameraWestCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JumpCameraWestCommandClass::Get_Description() const
+{
+    return "Jump the tactical map camera to the west edge of the map.";
+}
+
+bool JumpCameraWestCommandClass::Process()
+{
+    /**
+     *  Find the largest distance on the map.
+     */
+    int dist = Cell_To_Lepton(Map.MapSize.Width <= Map.MapSize.Height ? Map.MapSize.Height : Map.MapSize.Width);
+
+    Map.Scroll_Map(FACING_W, dist);
+
+    return true;
+}
+
+
+/**
+ *  Jump the tactical map camera to the east edge of the map.
+ * 
+ *  @author: CCHyper
+ */
+const char *JumpCameraEastCommandClass::Get_Name() const
+{
+    return "JumpCameraEast";
+}
+
+const char *JumpCameraEastCommandClass::Get_UI_Name() const
+{
+    return "Jump Camera East";
+}
+
+const char *JumpCameraEastCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JumpCameraEastCommandClass::Get_Description() const
+{
+    return "Jump the tactical map camera to the east edge of the map.";
+}
+
+bool JumpCameraEastCommandClass::Process()
+{
+    /**
+     *  Find the largest distance on the map.
+     */
+    int dist = Cell_To_Lepton(Map.MapSize.Width <= Map.MapSize.Height ? Map.MapSize.Height : Map.MapSize.Width);
+
+    Map.Scroll_Map(FACING_E, dist);
+
+    return true;
+}
+
+
+/**
+ *  Jump the tactical map camera to the north edge of the map.
+ * 
+ *  @author: CCHyper
+ */
+const char *JumpCameraNorthCommandClass::Get_Name() const
+{
+    return "JumpCameraNorth";
+}
+
+const char *JumpCameraNorthCommandClass::Get_UI_Name() const
+{
+    return "Jump Camera North";
+}
+
+const char *JumpCameraNorthCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JumpCameraNorthCommandClass::Get_Description() const
+{
+    return "Jump the tactical map camera to the north edge of the map.";
+}
+
+bool JumpCameraNorthCommandClass::Process()
+{
+    /**
+     *  Find the largest distance on the map.
+     */
+    int dist = Cell_To_Lepton(Map.MapSize.Width <= Map.MapSize.Height ? Map.MapSize.Height : Map.MapSize.Width);
+
+    Map.Scroll_Map(FACING_N, dist);
+
+    return true;
+}
+
+
+/**
+ *  Jump the tactical map camera to the south edge of the map.
+ * 
+ *  @author: CCHyper
+ */
+const char *JumpCameraSouthCommandClass::Get_Name() const
+{
+    return "JumpCameraSouth";
+}
+
+const char *JumpCameraSouthCommandClass::Get_UI_Name() const
+{
+    return "Jump Camera South";
+}
+
+const char *JumpCameraSouthCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *JumpCameraSouthCommandClass::Get_Description() const
+{
+    return "Jump the tactical map camera to the south edge of the map.";
+}
+
+bool JumpCameraSouthCommandClass::Process()
+{
+    /**
+     *  Find the largest distance on the map.
+     */
+    int dist = Cell_To_Lepton(Map.MapSize.Width <= Map.MapSize.Height ? Map.MapSize.Height : Map.MapSize.Width);
+
+    Map.Scroll_Map(FACING_S, dist);
+
+    return true;
+}
+
+
+/**
  *  Produces a memory dump on request.
  * 
  *  @author: CCHyper

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -208,6 +208,82 @@ class ScrollNWCommandClass : public ViniferaCommandClass
 
 
 /**
+ *  Jump the tactical map camera to the west edge of the map.
+ */
+class JumpCameraWestCommandClass : public ViniferaCommandClass
+{
+    public:
+        JumpCameraWestCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JumpCameraWestCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_CTRL_BIT|KN_LEFT); }
+};
+
+
+/**
+ *  Jump the tactical map camera to the east edge of the map.
+ */
+class JumpCameraEastCommandClass : public ViniferaCommandClass
+{
+    public:
+        JumpCameraEastCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JumpCameraEastCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_CTRL_BIT|KN_RIGHT); }
+};
+
+
+/**
+ *  Jump the tactical map camera to the north edge of the map.
+ */
+class JumpCameraNorthCommandClass : public ViniferaCommandClass
+{
+    public:
+        JumpCameraNorthCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JumpCameraNorthCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_CTRL_BIT|KN_UP); }
+};
+
+
+/**
+ *  Jump the tactical map camera to the south edge of the map.
+ */
+class JumpCameraSouthCommandClass : public ViniferaCommandClass
+{
+    public:
+        JumpCameraSouthCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~JumpCameraSouthCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_CTRL_BIT|KN_DOWN); }
+};
+
+
+/**
  *  Produces a memory dump on request.
  */
 class MemoryDumpCommandClass : public ViniferaCommandClass

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -160,6 +160,18 @@ void Init_Vinifera_Commands()
     cmdptr = new ScrollNWCommandClass;
     Commands.Add(cmdptr);
 
+    cmdptr = new JumpCameraWestCommandClass;
+    Commands.Add(cmdptr);
+
+    cmdptr = new JumpCameraEastCommandClass;
+    Commands.Add(cmdptr);
+
+    cmdptr = new JumpCameraNorthCommandClass;
+    Commands.Add(cmdptr);
+
+    cmdptr = new JumpCameraSouthCommandClass;
+    Commands.Add(cmdptr);
+
     /**
      *  Next, initialised any new commands here if the developer mode is enabled.
      */
@@ -351,6 +363,38 @@ static void Process_Vinifera_Hotkeys()
 
     if (!ini.Is_Present("Hotkey", "NextTheme")) {
         cmdptr = CommandClass::From_Name("NextTheme");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "JumpCameraWest")) {
+        cmdptr = CommandClass::From_Name("JumpCameraWest");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "JumpCameraEast")) {
+        cmdptr = CommandClass::From_Name("JumpCameraEast");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "JumpCameraNorth")) {
+        cmdptr = CommandClass::From_Name("JumpCameraNorth");
+        if (cmdptr) {
+            key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
+            HotkeyIndex.Add_Index(key, cmdptr);
+        }
+    }
+
+    if (!ini.Is_Present("Hotkey", "JumpCameraSouth")) {
+        cmdptr = CommandClass::From_Name("JumpCameraSouth");
         if (cmdptr) {
             key = reinterpret_cast<ViniferaCommandClass *>(cmdptr)->Default_Key();
             HotkeyIndex.Add_Index(key, cmdptr);


### PR DESCRIPTION
This pull request implements four new keyboard commands from Red Alert 2 (see [Patch 1.004](https://cnc.fandom.com/wiki/Red_Alert_2_patch_1.004)).

**Jump Camera West**
Jump the tactical map camera to the west edge of the map. Defaults to `Ctrl` + `Left Arrow`.

**Jump Camera East**
Jump the tactical map camera to the east edge of the map. Defaults to `Ctrl` + `Right Arrow`.

**Jump Camera North**
Jump the tactical map camera to the north edge of the map. Defaults to `Ctrl` + `Up Arrow`.

**Jump Camera South**
Jump the tactical map camera to the north edge of the map. Defaults to `Ctrl` + `Down Arrow`.