### PR TITLE
Fixes a number of issues related to the "multi-engineer" logic.

### DIFF
--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -543,4 +543,13 @@ void InfantryClassExtension_Hooks()
     Patch_Jump(0x004D87E9, &_InfantryClass_Firing_AI_Mechanic_Patch);
     Patch_Jump(0x004D3A7B, &_InfantryClass_Per_Cell_Process_Transport_Attach_Sound_Patch);
     Patch_Jump(0x004D35F9, &_InfantryClass_Per_Cell_Process_Engineer_Capture_Damage_Patch);
+
+    /**
+     *  ACTION_DAMAGE no longer a case in DisplayClass::Left_Mouse_Up to show the
+     *  correct mouse cursor for the multi-engineer damage (MOUSE.SHP also does not
+     *  contain any artwork for this), so with the multi-engineer fixes above it shows
+     *  the default arrow cursor. We fix this by making it use ACTION_CAPTURE still
+     *  to make sure the mouse shows the correct visual cursor.
+     */
+    Patch_Byte(0x004D7124+1, ACTION_CAPTURE);
 }

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -66,14 +66,21 @@ static int Get_Engineer_Damage(TechnoClass *tech)
 }
 
 
-/**
+/** 
  *  Is the target buildings health low enough to be captured? 
  * 
  *  @author: CCHyper
  */
 static bool Health_Low_Enough_To_Capture(TechnoClass *tech)
 {
-    return tech->Health_Ratio() <= Rule->ConditionRed;
+    /**
+     *  #issue-633
+     * 
+     *  Changed to use Rule->EngineerCaptureLevel.
+     * 
+     *  @author: CCHyper
+     */
+    return tech->Health_Ratio() <= Rule->EngineerCaptureLevel;
 }
 
 

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -404,6 +404,16 @@ bool RulesClassExtension::General(CCINIClass &ini)
         return false;
     }
 
+    /**
+     *  #issue-632
+     *
+     *  "EngineerDamage" was incorrectly loaded with "EngineerCaptureLevel", so
+     *  the value the value correctly.
+     *
+     *  @author: CCHyper
+     */
+    This()->EngineerDamage = ini.Get_Float(GENERAL, "EngineerDamage", This()->EngineerDamage);
+
     return true;
 }
 

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -67,7 +67,7 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
 
     private:
         void Check();
-        void Fixups();
+        void Fixups(CCINIClass &ini);
 
     public:
         /**


### PR DESCRIPTION
Closes #632, Closes #633, Closes #635 

This pull request fixes a number of issues related to the "multi-engineer" logic;
_- Fixes bug where `EngineerDamage` was incorrectly loaded with `EngineerCaptureLevel=`._
_- Fixes a bug where `EngineerDamage` was not used to calculate the engineer damage._
_- Fixes a bug where `EngineerCaptureLevel` was not considered when checking the target building._

`EngineerDamage=<float>`
The engineer will damage a building by this percent of its full health each time it enters. Defaults to `0.0`.

`EngineerCaptureLevel=<float>`
If the building’s health is equal to or below this percentage of its strength it can be captured by an engineer. Defaults to `1.0`.

**NOTE:** Upon observing the values used in `FIRESTRM.INI`, this could potentially cause an issue with the vanilla game. `FIRESTRM.INI` has the values `EngineerCaptureLevel=1.0` and `EngineerDamage=0.0`. Below are some values to help test these bug fixes and their potential impact on the vanilla game;

Red Alert Default values;
`EngineerDamage=0.33`
`EngineerCaptureLevel=0.25`

Red Alert Multiplayer (`MPLAYER.INI`) values;
`EngineerDamage=0.33`
`EngineerCaptureLevel=0.66`
