### PR TITLE
Adds background fill behind in-game user typed messages.

### DIFF
--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -96,6 +96,8 @@
 #include "empulseext_hooks.h"
 #include "waveext_hooks.h"
 
+#include "txtlabelext_hooks.h"
+
 #include "dropshipext_hooks.h"
 
 #include "cciniext_hooks.h"
@@ -185,6 +187,8 @@ void Extension_Hooks()
 
     EMPulseClassExtension_Hooks();
     WaveClassExtension_Hooks();
+
+    TextLabelClassExtension_Hooks();
 
     DropshipExtension_Hooks();
 

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -249,6 +249,9 @@ bool RulesClassExtension::Read_UI_INI()
     UIControls.UnitHealthBarDrawPos = ini.Get_Point(INGAME, "UnitHealthBarPos", UIControls.UnitHealthBarDrawPos);
     UIControls.InfantryHealthBarDrawPos = ini.Get_Point(INGAME, "InfantryHealthBarPos", UIControls.InfantryHealthBarDrawPos);
 
+    UIControls.IsTextLabelOutline = ini.Get_Bool(INGAME, "TextLabelOutline", UIControls.IsTextLabelOutline);
+    UIControls.TextLabelBackgroundTransparency = ini.Get_Int_Clamp(INGAME, "TextLabelBackgroundTransparency", 0, 100, UIControls.TextLabelBackgroundTransparency);
+
     return true;
 }
 
@@ -272,6 +275,9 @@ bool RulesClassExtension::Init_UI_Controls()
 
     UIControls.InfantryHealthBarDrawPos.X = -24;
     UIControls.InfantryHealthBarDrawPos.Y = -5;
+
+    UIControls.IsTextLabelOutline = true;
+    UIControls.TextLabelBackgroundTransparency = 50;
 
     return false;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -70,6 +70,16 @@ class RulesClassExtension final : public Extension<RulesClass>
             TPoint2D<int> UnitHealthBarDrawPos;
             TPoint2D<int> InfantryHealthBarDrawPos;
 
+            /**
+             *  Should the text label be drawn with an outline?
+             */
+            bool IsTextLabelOutline;
+
+            /**
+             *  Transparency of the text background.
+             */
+            unsigned TextLabelBackgroundTransparency;
+
         } UIControlsStruct;
 
         static UIControlsStruct UIControls;

--- a/src/extensions/textlabel/txtlabelext_hooks.cpp
+++ b/src/extensions/textlabel/txtlabelext_hooks.cpp
@@ -1,0 +1,150 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TXTLABEL_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended TextLabelClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "txtlabelext_hooks.h"
+#include "txtlabel.h"
+#include "tibsun_globals.h"
+#include "colorscheme.h"
+#include "wwfont.h"
+#include "rulesext.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+#include "vinifera_util.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or deconstructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+class TextLabelClassFake final : public TextLabelClass
+{
+    public:
+        bool _Draw_Me(bool forced = false);
+};
+
+
+/**
+ *  Reimplementation of TextLabelClass::Draw_Me.
+ * 
+ *  @author: CCHyper
+ */
+bool TextLabelClassFake::_Draw_Me(bool forced)
+{
+    if (!GadgetClass::Draw_Me(forced)) {
+        return false;
+    }
+
+    if (!ColorSchemes.Count()) {
+        return false;
+    }
+
+    ColorScheme *scheme = ColorSchemes[Color];
+    if (!scheme) {
+        return false;
+    }
+
+    Point2D xy = Point2D(X, Y);
+    Rect rect = TempSurface->Get_Rect();
+    TextPrintType style = Style;
+
+    /**
+     *  #issue-74
+     * 
+     *  Adds option to control the transparency of the text background.
+     * 
+     *  @author: CCHyper
+     */
+    if (RulesClassExtension::UIControls.TextLabelBackgroundTransparency > 0) {
+
+        RGBClass black_color(0,0,0);
+        WWFontClass *font = Font_Ptr(style);
+
+        Rect text_rect;
+        font->String_Pixel_Rect(Text, &text_rect);
+
+        /**
+         *  Kludge to remove the space at the end of a line as it is being typed.
+         */
+        if (Text[std::strlen(Text)-1] == ' ') {
+            text_rect.Width -= font->Char_Pixel_Width(' ');
+        }
+
+        /**
+         *  Move the rect into place. Due to the returned rect of the text and
+         *  how the text label is positioned, we need to manually adjust all
+         *  all lines other than the first.
+         */
+        if (Y == TacticalRect.Y) {
+            text_rect.Y += Y;
+        } else {
+            text_rect.Y += Y+2;
+            text_rect.Height -= 2;
+        }
+
+        TempSurface->Fill_Rect_Trans(text_rect, black_color,
+            RulesClassExtension::UIControls.TextLabelBackgroundTransparency);
+    }
+
+    /**
+     *  #issue-74
+     * 
+     *  Adds option to set if the text has an outline or not.
+     * 
+     *  @author: CCHyper
+     */
+    if (!RulesClassExtension::UIControls.IsTextLabelOutline) {
+        style |= TPF_NOSHADOW;
+    }
+
+    if (PixWidth == -1) {
+        Simple_Text_Print(Text, TempSurface, &rect, &xy, scheme, COLOR_TBLACK, style);
+    } else {
+        Conquer_Clip_Text_Print(Text, TempSurface, &rect, &xy, scheme, COLOR_TBLACK, style, PixWidth);
+    }
+
+#ifndef NDEBUG
+    //DEV_DEBUG_INFO("Label: '%s'\n", Text);
+#endif
+
+    return true;
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void TextLabelClassExtension_Hooks()
+{
+    Patch_Jump(0x0064D120, &TextLabelClassFake::_Draw_Me);
+}

--- a/src/extensions/textlabel/txtlabelext_hooks.h
+++ b/src/extensions/textlabel/txtlabelext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TXTLABELEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended TextLabelClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void TextLabelClassExtension_Hooks();


### PR DESCRIPTION
Closes #74 

This pull request adds a background behind the user typed messages that appear in-game to provide better readability.

Example screenshot of the new default behaviour;
![image](https://user-images.githubusercontent.com/73803386/137031682-3f265d48-7f28-410f-bf0d-3260e24f1748.png)

There are also new overrides for `UI.INI` to control the visual style of these text labels;

**`[Ingame]`**
`TextLabelOutline=<boolean>`
Should the text be drawn with a black outline? Defaults to `yes`.

`TextLabelBackgroundTransparency=<unsigned integer>`
The transparency of the text background fill. Ranged between `0` and `100`. Defaults to `50`.
