### PR TITLE
Fixes a bug where animations with a `DetailLevel` value greater than 2 would not show in-game.

### DIFF
--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -184,6 +184,15 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
         return false;
     }
 
+    /**
+     *  #issue-646
+     * 
+     *  Some animations in the vanilla game have a DetailLevel of 3, which is out
+     *  of range and as a result do not play in-game. This makes sure the values
+     *  are never outside of the expected range.
+     */
+    ThisPtr->DetailLevel = std::clamp(ThisPtr->DetailLevel, 0, 2);
+
     IsHideIfNotTiberium = ini.Get_Bool(ini_name, "HideIfNoTiberium", IsHideIfNotTiberium);
     IsForceBigCraters = ini.Get_Bool(ini_name, "ForceBigCraters", IsForceBigCraters);
     ZAdjust = ini.Get_Int(ini_name, "ZAdjust", ZAdjust);


### PR DESCRIPTION
Closes #646

This pull request fixes a bug where animations with a `DetailLevel` value greater than 2 would not show in-game. This was most noticeable in unmodded Tiberian Sun where both the Civilian Armory and Civilian Hospital active animations incorrect had a `DetailLevel` of 3, and because the game does not clamp this value, the animations did not show in-game.
