### PR TITLE
Changes the behaviour of `MultipleFactory` and implements build speed overrides.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -136,6 +136,7 @@ This page lists all the individual contributions to the project by their author.
   - Help with implementing Jumpjet Locomotion improvements.
   - Implement naval yard rally points, AI naval yard base spacing.
   - Implement exclusive factories.
+  - Change the behavior MultipleFactory and implements build speed overrides.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1074,6 +1074,33 @@ ExclusiveFactory=no  ; boolean, if true, this factory will only be able to produ
 To recreate the dog from Red Alert that is trained in a kennel, set `[KENN]->Factory=InfantryType`, `[KENN]->ExclusiveFactory=yes` and `[DOG]->BuiltAt=KENN`.
 ```
 
+### Multiple Factory Modifier
+
+- Vinifera changes the effect of the `MultipleFactory` bonus to be the same as Red Alert 2 when calculating an object's build time. Now this is a straight discount multiplier that is cumulative.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]           ; TechnoType
+BuildTimeMultiplier=1  ; float, multiplier to the time it takes for an object to be built
+```
+
+In `RULES.INI`:
+```ini
+[General]
+LowPowerPenaltyModifier=1              ; float, the "double penalty" or "half penalty". Multiply this by the power units you are short to get the actual penalty to the build speed
+WorstLowPowerBuildRateCoefficient=0.5  ; float, what is the lowest the build rate can get for being low on power?
+BestLowPowerBuildRateCoefficient=0.75  ; float, what is the highest the build rate can get when in a low power condition?
+MultipleFactoryCap=0                   ; integer, the maximum number of factories that can be considered when calculating the multiple factory bonus on an object's build time
+```
+
+```{note}
+`WorstLowPowerBuildRateCoefficient`, and `BestLowPowerBuildRateCoefficient`, albeit present in vanilla `RULES.INI`, were not read. They are not correctly read from `RULES.INI`.
+```
+
+```{warning}
+While the default value for `WorstLowPowerBuildRateCoefficient` is `0.5`, vanilla `RULES.INI` contains a value of `0.3`. To address this, when reading unmodified `RULES.INI`, the value will be changed to `0.5`. For modified `RULES.INI` files, please make sure to adjust the value.
+```
+
 ## Terrain
 
 ### Light Sources

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -190,6 +190,7 @@ New:
 - Allow up to 65535 OverlayTypes in maps using `NewINIFormat=5` (by ZivDero)
 - Implement naval yards (by ZivDero, CCHyper, Rampastring)
 - Implement exclusive factories (by ZivDero)
+- Change the behavior MultipleFactory and implements build speed overrides (by CCHyper)
 
 
 Vanilla fixes:

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -86,7 +86,8 @@ RulesClassExtension::RulesClassExtension(const RulesClass *this_ptr) :
     IsRecheckPrerequisites(false),
     IsMultiMCV(false),
     AINavalYardAdjacency(20),
-    LowPowerPenaltyModifier(1.0f)
+    LowPowerPenaltyModifier(1.0f),
+    MultipleFactoryCap(0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("RulesClassExtension::RulesClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
@@ -651,6 +652,7 @@ bool RulesClassExtension::AudioVisual(CCINIClass &ini)
 {
     //EXT_DEBUG_TRACE("RulesClassExtension::General - 0x%08X\n", (uintptr_t)(This()));
 
+    static char const * const GENERAL = "General";
     static char const * const AUDIOVISUAL = "AudioVisual";
 
     if (!ini.Is_Present(AUDIOVISUAL)) {
@@ -660,6 +662,7 @@ bool RulesClassExtension::AudioVisual(CCINIClass &ini)
     IsShowSuperWeaponTimers = ini.Get_Bool(AUDIOVISUAL, "ShowSuperWeaponTimers", IsShowSuperWeaponTimers);
     WeedPipIndex = ini.Get_Int(AUDIOVISUAL, "WeedPipIndex", WeedPipIndex);
     MaxPips = ini.Get_Integers(AUDIOVISUAL, "MaxPips", MaxPips);
+    MultipleFactoryCap = ini.Get_Int(GENERAL, "MultipleFactoryCap", MultipleFactoryCap);
 
     for (int i = 0; i < MaxPips.Count(); i++)
         DEBUG_INFO("%d", MaxPips[i]);

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -638,6 +638,7 @@ bool RulesClassExtension::General(CCINIClass &ini)
     IsRecheckPrerequisites = ini.Get_Bool(GENERAL, "RecheckPrerequisites", IsRecheckPrerequisites);
     IsMultiMCV = ini.Get_Bool(GENERAL, "MultiMCV", IsMultiMCV);
     LowPowerPenaltyModifier = ini.Get_Float(GENERAL, "LowPowerPenaltyModifier", LowPowerPenaltyModifier);
+    MultipleFactoryCap = ini.Get_Int(GENERAL, "MultipleFactoryCap", MultipleFactoryCap);
 
     return true;
 }
@@ -650,9 +651,8 @@ bool RulesClassExtension::General(CCINIClass &ini)
  */
 bool RulesClassExtension::AudioVisual(CCINIClass &ini)
 {
-    //EXT_DEBUG_TRACE("RulesClassExtension::General - 0x%08X\n", (uintptr_t)(This()));
+    //EXT_DEBUG_TRACE("RulesClassExtension::AudioVisual - 0x%08X\n", (uintptr_t)(This()));
 
-    static char const * const GENERAL = "General";
     static char const * const AUDIOVISUAL = "AudioVisual";
 
     if (!ini.Is_Present(AUDIOVISUAL)) {
@@ -662,7 +662,6 @@ bool RulesClassExtension::AudioVisual(CCINIClass &ini)
     IsShowSuperWeaponTimers = ini.Get_Bool(AUDIOVISUAL, "ShowSuperWeaponTimers", IsShowSuperWeaponTimers);
     WeedPipIndex = ini.Get_Int(AUDIOVISUAL, "WeedPipIndex", WeedPipIndex);
     MaxPips = ini.Get_Integers(AUDIOVISUAL, "MaxPips", MaxPips);
-    MultipleFactoryCap = ini.Get_Int(GENERAL, "MultipleFactoryCap", MultipleFactoryCap);
 
     for (int i = 0; i < MaxPips.Count(); i++)
         DEBUG_INFO("%d", MaxPips[i]);
@@ -945,16 +944,16 @@ void RulesClassExtension::Fixups(CCINIClass &ini)
     /**
      *  Check to see if the ini files have been modified.
      */
-    bool is_rule_unmodified = false;
+    bool rule_unmodified = false;
     if (rule_crc == Unmodified_RuleINI_CRC) {
         DEBUG_INFO("Rules: RuleINI is unmodified (version 2.03).\n");
-        is_rule_unmodified = true;
+        rule_unmodified = true;
     }
     bool fsrule_unmodified = false;
     if (Is_Addon_Available(ADDON_FIRESTORM)) {
         if (fsrule_crc == Unmodified_FSRuleINI_CRC) {
             DEBUG_INFO("Rules: FSRuleINI is unmodified (version 2.03).\n");
-            is_fsrule_unmodified = true;
+            fsrule_unmodified = true;
         }
     }
 

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -85,7 +85,8 @@ RulesClassExtension::RulesClassExtension(const RulesClass *this_ptr) :
     MaxFreeRefineryDistanceBias(16),
     IsRecheckPrerequisites(false),
     IsMultiMCV(false),
-    AINavalYardAdjacency(20)
+    AINavalYardAdjacency(20),
+    LowPowerPenaltyModifier(1.0f)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("RulesClassExtension::RulesClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
@@ -635,6 +636,7 @@ bool RulesClassExtension::General(CCINIClass &ini)
     MaxFreeRefineryDistanceBias = ini.Get_Int(GENERAL, "MaxFreeRefineryDistanceBias", MaxFreeRefineryDistanceBias);
     IsRecheckPrerequisites = ini.Get_Bool(GENERAL, "RecheckPrerequisites", IsRecheckPrerequisites);
     IsMultiMCV = ini.Get_Bool(GENERAL, "MultiMCV", IsMultiMCV);
+    LowPowerPenaltyModifier = ini.Get_Float(GENERAL, "LowPowerPenaltyModifier", LowPowerPenaltyModifier);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -139,4 +139,10 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
          *  units you are short of to get the actual penalty to the build speed.
          */
         float LowPowerPenaltyModifier;
+
+        /**
+         *  The maximum number of factories that can be considered when calculating
+         *  the multiple factory bonus on an object's build time.
+         */
+        int MultipleFactoryCap;
 };

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -133,4 +133,10 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
          *  The distance in cells the computer player can place their Naval Yard from their Construction Yard.
          */
         int AINavalYardAdjacency;
+
+        /**
+         *  The "double penalty" or "half penalty". Multiply this by the power
+         *  units you are short of to get the actual penalty to the build speed.
+         */
+        float LowPowerPenaltyModifier;
 };

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -452,6 +452,15 @@ int TechnoClassExtension::Time_To_Build() const
     time *= This()->House->BuildSpeedBias;
 
     /**
+     *  #issue-657
+     * 
+     *  Implements BuildTimeMultiplier for TechnoTypes.
+     * 
+     *  @author: CCHyper
+     */
+    time *= technotypeext->BuildTimeMultiplier;
+
+    /**
      *  Adjust the time to build based on the power output of the owning house.
      */
     double power = This()->House->Power_Fraction();

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -528,6 +528,20 @@ int TechnoClassExtension::Time_To_Build() const
      *  @author: CCHyper
      */
     if (Rule->MultipleFactory > 0.0 && (divisor-1) > 0) {
+
+        /**
+         *  #issue-659
+         * 
+         *  Implements MultipleFactoryCap for RulesClass.
+         * 
+         *  @author: CCHyper
+         */
+        if (RuleExtension->MultipleFactoryCap > 0) {
+            divisor = RuleExtension->MultipleFactoryCap;
+        }
+
+        divisor = (divisor-1);
+
         while (divisor) {
             time *= Rule->MultipleFactory;
             --divisor;

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -459,11 +459,27 @@ int TechnoClassExtension::Time_To_Build() const
     if (power > 1.0) {
         scale = 1.0;
 
-    } else if (power < 1.0 && power > 0.75) {
-        scale = 0.75;
+    } else if (power < 1.0 && power >= Rule->BestLowPowerBuildRateCoefficient) {
 
-    } else if (power < 0.5) {
-        scale = 0.5;
+        /**
+         *  #issue-658
+         *
+         *  Restores the affect of "BestLowPowerBuildRateCoefficient".
+         *
+         *  @author: CCHyper
+         */
+        scale = Rule->BestLowPowerBuildRateCoefficient; // Was "0.75"
+
+    } else if (power <= Rule->WorstLowPowerBuildRateCoefficient) {
+
+        /**
+         *  #issue-658
+         *
+         *  Restores the affect of "WorstLowPowerBuildRateCoefficient".
+         *
+         *  @author: CCHyper
+         */
+        scale = Rule->WorstLowPowerBuildRateCoefficient; // Was 0.5;
 
     }
     if (power <= Rule->MinProductionSpeed) {

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -34,11 +34,13 @@
 #include "building.h"
 #include "buildingtype.h"
 #include "rules.h"
+#include "rulesext.h"
 #include "voc.h"
 #include "ebolt.h"
 #include "tactical.h"
 #include "tibsun_inline.h"
 #include "tibsun_globals.h"
+#include "extension_globals.h"
 #include "wwcrc.h"
 #include "extension.h"
 #include "asserthandler.h"
@@ -465,6 +467,16 @@ int TechnoClassExtension::Time_To_Build() const
      */
     double power = This()->House->Power_Fraction();
     double scale = 1.0f;
+
+    /**
+     *  #issue-656
+     * 
+     *  Implements LowPowerPenaltyModifier for RulesClass.
+     * 
+     *  @author: CCHyper
+     */
+    scale = 1.0f - (1.0f - power) * RuleExtension->LowPowerPenaltyModifier;
+
     if (power > 1.0) {
         scale = 1.0;
 

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -45,6 +45,7 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "houseext.h"
 #include "saveload.h"
 #include "vinifera_saveload.h"
 #include "storageext.h"
@@ -438,13 +439,13 @@ bool TechnoClassExtension::Can_Passive_Acquire() const
 /**
  *  Determines the time it would take to build this object.
  * 
- *  @author: CCHyper
+ *  @author: CCHyper, ZivDero
  */
 int TechnoClassExtension::Time_To_Build() const
 {
     //EXT_DEBUG_TRACE("TechnoClassExtension::Time_To_Build - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
-    TechnoTypeClassExtension* technotypeext = Extension::Fetch< TechnoTypeClassExtension>(Techno_Type_Class());
+    const TechnoTypeClassExtension* technotypeext = Techno_Type_Class_Ext();
 
     int time = Techno_Type_Class()->Time_To_Build();
 
@@ -511,7 +512,7 @@ int TechnoClassExtension::Time_To_Build() const
     /**
      *  Calculate the bonus based on the current factory count.
      */
-    int divisor = This()->House->Factory_Count(This()->Kind_Of());
+    int divisor = Extension::Fetch(This()->House)->Factory_Count(This()->RTTI, TechnoTypeClassExtension::Get_Production_Flags(This()));
 #if 0
     /**
      *  Original code for "MultipleFactory".

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -475,9 +475,28 @@ int TechnoClassExtension::Time_To_Build() const
      *  Calculate the bonus based on the current factory count.
      */
     int divisor = This()->House->Factory_Count(This()->Kind_Of());
+#if 0
+    /**
+     *  Original code for "MultipleFactory".
+     */
     if (Rule->MultipleFactory > 0.0 && divisor > 1) {
         time = (double)(1.0 / ((double)(divisor-1) * Rule->MultipleFactory) * (double)time);
     }
+#else
+    /**
+     *  #issue-106
+     * 
+     *  "MultipleFactory" calculation back ported from Red Alert 2.
+     * 
+     *  @author: CCHyper
+     */
+    if (Rule->MultipleFactory > 0.0 && (divisor-1) > 0) {
+        while (divisor) {
+            time *= Rule->MultipleFactory;
+            --divisor;
+        }
+    }
+#endif
 
     /**
      *  Walls have a coefficient as they are really cheap.

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -68,6 +68,8 @@ class TechnoClassExtension : public RadioClassExtension
 
         void Put_Storage_Pointers();
 
+        int Time_To_Build() const;
+
     private:
         const TechnoTypeClass *Techno_Type_Class() const;
         const TechnoTypeClassExtension *Techno_Type_Class_Ext() const;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1302,32 +1302,11 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
 /**
  *  Reimplementation of TechnoClass::Time_To_Build.
  *
- *  @author: ZivDero
+ *  @author: CCHyper
  */
 int TechnoClassExt::_Time_To_Build() const
 {
-    int val = Class_Of()->Time_To_Build();
-
-    val *= House->BuildSpeedBias;
-
-    /*
-    **  Adjust the time to build based on the power output of the owning house.
-    */
-    double power = House->Power_Fraction();
-    if (power > 1.0) power = 1.0;
-    if (power < 1.0 && power > 0.75) power = 0.75;
-    if (power < 0.5) power = 0.5;
-    power = std::max(power, Rule->MinProductionSpeed);
-    val /= power;
-
-    int divisor = Extension::Fetch(House)->Factory_Count(RTTI, TechnoTypeClassExtension::Get_Production_Flags(this));
-    if (divisor > 1 && Rule->MultipleFactory > 0) {
-        val *= 1.0 / ((divisor - 1) * Rule->MultipleFactory);
-    }
-    if (RTTI == RTTI_BUILDING && ((BuildingClass*)this)->Class->IsWall) {
-        val *= Rule->WallBuildSpeedCoefficient;
-    }
-    return val;
+    return Extension::Fetch(this)->Time_To_Build();
 }
 
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -104,7 +104,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     JumpjetNoWobbles(false),
     IsNaval(false),
     BuiltAt(),
-    BuildTimeMultiplier(1.0f),
+    BuildTimeMultiplier(1.0f)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -103,7 +103,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     _JumpjetCloakDetectionRadius(std::numeric_limits<int>::min()),
     JumpjetNoWobbles(false),
     IsNaval(false),
-    BuiltAt()
+    BuiltAt(),
+    BuildTimeMultiplier(1.0f),
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -379,6 +380,8 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
 
     IdleRate = ini.Get_Int(ini_name, "IdleRate", IdleRate);
     IdleRate = ArtINI.Get_Int(graphic_name, "IdleRate", IdleRate);
+
+    BuildTimeMultiplier = ini.Get_Float(ini_name, "BuildTimeMultiplier", BuildTimeMultiplier);
 
     /**
      *  Fetch the cameo image surface if it exists.

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -360,4 +360,9 @@ public:
      *  A list of factories that can produce this unit.
      */
     TypeList<BuildingTypeClass*> BuiltAt;
+    
+    /**
+     *  This is an individual control of the build time for this object.
+     */
+    float BuildTimeMultiplier;
 };


### PR DESCRIPTION
Closes #106, Closes #656, Closes #657, Closes #658, Closes #659

This pull request covers multiple related items;

- Changes the effect of the `MultipleFactory` bonus to be the same as Red Alert 2 when calculating an object's build time. Now, this is a straight discount multiplier that is cumulative.

- **`[TechnoTypes]`**
`BuildTimeMultiplier=<float>`
_Multiplier to the time it takes for an object to be built. Defaults to `1.0`._

- **`[General]`** _(`RULES.INI`)_
`LowPowerPenaltyModifier=<float>`
_The "double penalty" or "half penalty". Multiply this by the power units you are short of to get the actual penalty to the build speed. Defaults to `1.0`._

- `WorstLowPowerBuildRateCoefficient` and `BestLowPowerBuildRateCoefficient` now have an effect on the production times when in a low power state. Previously there were not used.

- **`[General]`** _(`RULES.INI`)_
`MultipleFactoryCap=<integer>`
_The maximum number of factories that can be considered when calculating the multiple factory bonus on an object's build time. Defaults to `0` (no limit)._