### PR TITLE
Allow the games Window title, Cursor and Icon to be overridden.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,7 @@ add_library(${PROJECT_NAME} SHARED
 		${GIT_POST_CONFIGURE_FILE}
 		${CMAKE_SOURCE_DIR}/res/resource.h
 		${CMAKE_SOURCE_DIR}/res/dialog.rc
+		${CMAKE_SOURCE_DIR}/res/icon.rc
 )
 target_include_directories(${PROJECT_NAME} BEFORE PUBLIC
 		${VINIFERA_INCLUDE_DIRS}
@@ -574,7 +575,7 @@ add_dependencies(${PROJECT_NAME} TSpp)
 # Ensure the launcher is built with the main project.
 add_dependencies(${PROJECT_NAME} Launch${PROJECT_NAME})
 
-set(REQUIRED_LIBRARIES ws2_32 dbghelp shlwapi version)
+set(REQUIRED_LIBRARIES ws2_32 dbghelp shlwapi version comctl32)
 
 # Link to any required libraries.
 target_link_libraries(${PROJECT_NAME} ${REQUIRED_LIBRARIES})

--- a/res/resource.h
+++ b/res/resource.h
@@ -42,8 +42,8 @@
 /**
  *  Use these defines in code to allow easy updating in all areas used.
  */
-#define MAINICON    IDI_VINIFERA
-#define MAINCURSOR  IDC_ARROW
+#define VINIFERA_MAINICON		 IDI_VINIFERA
+#define VINIFERA_MAINCURSOR		 IDC_ARROW
 
 
 /**

--- a/src/debug/exceptionhandler.cpp
+++ b/src/debug/exceptionhandler.cpp
@@ -371,6 +371,13 @@ static void Dump_Exception_Info(unsigned int e_code, struct _EXCEPTION_POINTERS 
     
     Exception_Printf("\r\n");
 
+    Exception_Printf("Project information:\r\n");
+    if (Vinifera_ProjectName[0] != '\0') {
+        Exception_Printf("Title: %s\r\n", Vinifera_ProjectName);
+        Exception_Printf("Version: %s\r\n", Vinifera_ProjectVersion);
+        Exception_Printf("\r\n");
+    }
+
     Exception_Printf("Application : %s (%s)\r\n", VINIFERA_PROJECT_NAME, VINIFERA_DLL);
     //Exception_Printf("Version : %s\r\n", VerNum.Version_Name());
 

--- a/src/extensions/init/initext_functions.cpp
+++ b/src/extensions/init/initext_functions.cpp
@@ -70,6 +70,7 @@ void Vinifera_Create_Main_Window(HINSTANCE hInstance, int nCmdShow, int width, i
     WNDCLASSEX wc;
     tagRECT rect;
     HICON hIcon = nullptr;
+    HICON hSmIcon = nullptr;
     HCURSOR hCursor = nullptr;
 
     //DEV_DEBUG_INFO("Create_Main_Window() - About to call InitCommonControls()\n");
@@ -90,13 +91,39 @@ void Vinifera_Create_Main_Window(HINSTANCE hInstance, int nCmdShow, int width, i
      *  Load the Vinifera icon and cursor resources, falling back to the GAME.EXE
      *  resources if not available or failed to load.
      */
-    hIcon = LoadIcon((HINSTANCE)DLLInstance, MAKEINTRESOURCE(VINIFERA_MAINICON));
-    if (!hIcon) {
-        hIcon = LoadIcon((HINSTANCE)hInstance, MAKEINTRESOURCE(TS_MAINICON));
+    if (Vinifera_IconName[0] != '\0') {
+        DEBUG_INFO("Loading custom icon \"%s\"\n", Vinifera_IconName);
+        hIcon = (HICON)LoadImage(
+            nullptr,
+            Vinifera_IconName,
+            IMAGE_ICON,
+            0,
+            0,
+            LR_LOADFROMFILE);
+        DEBUG_INFO("Loading custom small icon \"%s\"\n", Vinifera_IconName);
+        hSmIcon = (HICON)LoadImage(
+            nullptr,
+            Vinifera_IconName,
+            IMAGE_ICON,
+            GetSystemMetrics(SM_CXSMICON),
+            GetSystemMetrics(SM_CXSMICON),
+            LR_LOADFROMFILE);
     }
-    hCursor = LoadCursor(nullptr, VINIFERA_MAINCURSOR); // IDC_ARROW is a system resource, does not require module.
+    if (!hIcon) {
+        hIcon = LoadIcon((HINSTANCE)DLLInstance, MAKEINTRESOURCE(VINIFERA_MAINICON));
+        if (!hIcon) {
+            hIcon = LoadIcon((HINSTANCE)hInstance, MAKEINTRESOURCE(TS_MAINICON));
+        }
+    }
+    if (Vinifera_CursorName[0] != '\0') {
+        DEBUG_INFO("Loading custom cursor \"%s\"\n", Vinifera_CursorName);
+        hCursor = LoadCursorFromFile(Vinifera_CursorName);
+    }
     if (!hCursor) {
-        hCursor = LoadCursor((HINSTANCE)hInstance, MAKEINTRESOURCE(TS_MAINCURSOR));
+        hCursor = LoadCursor(nullptr, VINIFERA_MAINCURSOR); // IDC_ARROW is a system resource, does not require module.
+        if (!hCursor) {
+            hCursor = LoadCursor((HINSTANCE)hInstance, MAKEINTRESOURCE(TS_MAINCURSOR));
+        }
     }
 
     //DEV_DEBUG_INFO("Create_Main_Window() - Setting up window class info.\n");
@@ -115,7 +142,7 @@ void Vinifera_Create_Main_Window(HINSTANCE hInstance, int nCmdShow, int width, i
     wc.hbrBackground  = nullptr;
     wc.lpszMenuName   = nullptr;
     wc.lpszClassName  = "Vinifera";
-    wc.hIconSm        = hIcon;
+    wc.hIconSm        = (hSmIcon ? hSmIcon : hIcon);
 
     //DEV_DEBUG_INFO("Create_Main_Window() - About to call RegisterClass()\n");
 

--- a/src/extensions/init/initext_functions.cpp
+++ b/src/extensions/init/initext_functions.cpp
@@ -1,0 +1,241 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          INITEXT_FUNCTIONS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains supporting functions for game init process.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "initext_functions.h"
+#include "vinifera_const.h"
+#include "vinifera_globals.h"
+#include "vinifera_util.h"
+#include "tibsun_globals.h"
+#include "tibsun_functions.h"
+#include "language.h"
+#include "dsaudio.h"
+#include "vinifera_gitinfo.h"
+#include "tspp_gitinfo.h"
+#include "resource.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+#include <Windows.h>
+#include <commctrl.h>
+
+#include "options.h"
+
+
+extern HMODULE DLLInstance;
+
+
+/**
+ *  Tiberian Sun resource constants.
+ */
+#define TS_MAINICON		    93
+#define TS_MAINCURSOR		104
+
+
+/**
+ *  Creates the main window for Tiberian Sun
+ * 
+ *  @author: CCHyper
+ */
+void Vinifera_Create_Main_Window(HINSTANCE hInstance, int nCmdShow, int width, int height)
+{
+    //DEV_DEBUG_INFO("Create_Main_Window(enter)\n");
+
+    MainWindow = nullptr;
+
+    HWND hWnd = nullptr;
+    BOOL rc;
+    WNDCLASSEX wc;
+    tagRECT rect;
+    HICON hIcon = nullptr;
+    HCURSOR hCursor = nullptr;
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - About to call InitCommonControls()\n");
+
+    InitCommonControls();
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - Preparing window name (with version info).\n");
+
+    DWORD dwPid = GetProcessId(GetCurrentProcess());
+    if (!dwPid) {
+        DEBUG_ERROR("Create_Main_Window() - Failed to get the process id!\n");
+        return;
+    }
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - Loading icon and cursor resources.\n");
+
+    /**
+     *  Load the Vinifera icon and cursor resources, falling back to the GAME.EXE
+     *  resources if not available or failed to load.
+     */
+    hIcon = LoadIcon((HINSTANCE)DLLInstance, MAKEINTRESOURCE(VINIFERA_MAINICON));
+    if (!hIcon) {
+        hIcon = LoadIcon((HINSTANCE)hInstance, MAKEINTRESOURCE(TS_MAINICON));
+    }
+    hCursor = LoadCursor(nullptr, VINIFERA_MAINCURSOR); // IDC_ARROW is a system resource, does not require module.
+    if (!hCursor) {
+        hCursor = LoadCursor((HINSTANCE)hInstance, MAKEINTRESOURCE(TS_MAINCURSOR));
+    }
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - Setting up window class info.\n");
+
+    /**
+     *  Register the window class.
+     */
+    wc.cbSize         = sizeof(WNDCLASSEX);
+    wc.style          = CS_HREDRAW|CS_VREDRAW;
+    wc.lpfnWndProc    = Main_Window_Procedure;
+    wc.cbClsExtra     = 0;
+    wc.cbWndExtra     = 0;
+    wc.hInstance      = (HINSTANCE)hInstance;
+    wc.hIcon          = hIcon;
+    wc.hCursor        = hCursor;
+    wc.hbrBackground  = nullptr;
+    wc.lpszMenuName   = nullptr;
+    wc.lpszClassName  = "Vinifera";
+    wc.hIconSm        = hIcon;
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - About to call RegisterClass()\n");
+
+    /**
+     *  Register window class.
+     */
+    rc = RegisterClassEx(&wc);
+    if (!rc) {
+        DEBUG_INFO("Create_Main_Window() - Failed to register window class!\n");
+        return;
+    }
+
+    /**
+     *  Get the dimensions of the primary display.
+     */
+    int display_width = GetSystemMetrics(SM_CXSCREEN);
+    int display_height = GetSystemMetrics(SM_CYSCREEN);
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - Desktop size %d x %d\n", display_width, display_height);
+
+    /**
+     *  Create our main window.
+     */
+    if (Debug_Windowed) {
+
+        DEBUG_INFO("Create_Main_Window() - Creating desktop window (%d x %d).\n", width, height);
+
+        hWnd = CreateWindowEx(
+            WS_EX_LEFT|WS_EX_TOPMOST,
+            "Vinifera",
+            Vinifera_Get_Window_Title(dwPid),
+            WS_SYSMENU|WS_MINIMIZEBOX|WS_CLIPCHILDREN|WS_CAPTION,
+            0, 0, 0, 0,
+            nullptr,
+            nullptr,
+            (HINSTANCE)hInstance,
+            nullptr);
+
+        SetRect(&rect, 0, 0, width, height);
+
+        AdjustWindowRectEx(&rect,
+            GetWindowLong(hWnd, GWL_STYLE),
+            GetMenu(hWnd) != nullptr,
+            GetWindowLong(hWnd, GWL_EXSTYLE));
+
+        /**
+         *  #BUGFIX:
+         * 
+         *  Fetch the desktop size, calculate the screen center position the window and move it.
+         */
+        RECT workarea;
+        SystemParametersInfo(SPI_GETWORKAREA, 0, &workarea, 0);
+
+        int x_pos = (display_width - width) / 2;
+        int y_pos = (((display_height - height) / 2) - (display_height - workarea.bottom));
+        
+        DEBUG_INFO("Create_Main_Window() - Moving window (%d,%d,%d,%d).\n",
+            x_pos, y_pos, (rect.right - rect.left), (rect.bottom - rect.top));
+
+        MoveWindow(hWnd, x_pos, y_pos, (rect.right - rect.left), (rect.bottom - rect.top), TRUE);
+
+    } else {
+
+        DEBUG_INFO("Create_Main_Window() - Creating fullscreen window.\n");
+
+        hWnd = CreateWindowEx(
+            WS_EX_TOPMOST,
+            "Vinifera",
+            Vinifera_Get_Window_Title(dwPid),
+            WS_POPUP|WS_CLIPCHILDREN,
+            0, 0,
+            display_width,
+            display_height,
+            nullptr,
+            nullptr,
+            (HINSTANCE)hInstance,
+            nullptr);
+    }
+
+    if (!hWnd) {
+        DEBUG_INFO("Create_Main_Window() - Failed to create window!\n");
+        return;
+    }
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - About to call ShowWindow()\n");
+
+    ShowWindow(hWnd, SW_SHOWNORMAL);
+    ShowCommand = nCmdShow;
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - About to call UpdateWindow()\n");
+
+    UpdateWindow(hWnd);
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - About to call SetFocus()\n");
+
+    SetFocus(hWnd);
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - About to call RegisterHotKey()\n");
+
+    RegisterHotKey(hWnd, 1, MOD_ALT|MOD_CONTROL|MOD_SHIFT, VK_M);
+
+    //DEV_DEBUG_INFO("Create_Main_Window() - About to call SetCursor()\n");
+
+    SetCursor(hCursor);
+
+    Audio.AudioFocusLossFunction = &Focus_Loss;
+
+    /**
+     *  Save the handle to our main window.
+     */
+    MainWindow = hWnd;
+    ProgramInstance = hInstance;
+
+    /**
+     *  #NOTE:
+     *  This had been added to resolved a issue where the game gets stuck in a
+     *  focus checking loop, this could be because the DLL now creates the 
+     *  window in its thread.
+     */
+    GameInFocus = true;
+
+    //DEV_DEBUG_INFO("Create_Main_Window(exit)\n");
+}

--- a/src/extensions/init/initext_functions.h
+++ b/src/extensions/init/initext_functions.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          VINIFERA_UTIL.H
+ *  @file          INITEXT_FUNCTIONS.H
  *
- *  @authors       CCHyper
+ *  @author        CCHyper
  *
- *  @brief         Various utility functions.
+ *  @brief         Contains supporting functions for game init process.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -30,17 +30,5 @@
 #include "always.h"
 
 
-class XSurface;
+void Vinifera_Create_Main_Window(HINSTANCE hInstance, int nCmdShow, int width, int height);
 
-
-const char *Vinifera_Version_String();
-const char *TSpp_Version_String();
-
-void Vinifera_Draw_Version_Text(XSurface *surface, bool pre_init = false);
-
-bool Vinifera_Generate_Mini_Dump();
-
-int Vinifera_Do_WWMessageBox(const char *msg, const char *btn1, const char *btn2 = nullptr, const char *btn3 = nullptr);
-void Vinifera_DeveloperMode_Warning_WWMessageBox(const char *msg, ...);
-
-const char *Vinifera_Get_Window_Title(DWORD dwPid);

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -26,6 +26,7 @@
  *
  ******************************************************************************/
 #include "initext_hooks.h"
+#include "initext_functions.h"
 #include "vinifera_globals.h"
 #include "tibsun_globals.h"
 #include "special.h"
@@ -530,6 +531,7 @@ void GameInit_Hooks()
     Patch_Jump(0x004E0461, &_Init_CDROM_Access_Local_Files_Patch);
     Patch_Jump(0x004E3D20, &Vinifera_Init_Bootstrap_Mixfiles);
     Patch_Jump(0x004E4120, &Vinifera_Init_Secondary_Mixfiles);
+    Patch_Jump(0x00686190, &Vinifera_Create_Main_Window);
 
     /**
      *  #issue-110

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -246,6 +246,14 @@ bool Vinifera_Startup()
         DEBUG_WARNING("Failed to load VINIFERA.INI!\n");
     }
 
+    if (Vinifera_ProjectName[0] != '\0') {
+        DEBUG_INFO("\n");
+        DEBUG_INFO("Project information:\n");
+        DEBUG_INFO("  Title: %s\n", Vinifera_ProjectName);
+        DEBUG_INFO("  Version: %s\n", Vinifera_ProjectVersion);
+        DEBUG_INFO("\n");
+    }
+
     /**
      *  Initialise the CnCNet4 system.
      */

--- a/src/vinifera_functions.cpp
+++ b/src/vinifera_functions.cpp
@@ -33,10 +33,41 @@
 #include "cncnet5_globals.h"
 #include "rulesext.h"
 #include "ccfile.h"
+#include "ccini.h"
 #include "cd.h"
 #include "ebolt.h"
 #include "debughandler.h"
 #include <string>
+
+
+/**
+ *  Load any Vinifera settings that provide overrides.
+ * 
+ *  @author: CCHyper
+ */
+bool Vinifera_Load_INI()
+{
+    CCFileClass file("VINIFERA.INI");
+    INIClass ini;
+
+    if (!file.Is_Available()) {
+        return false;
+    }
+
+    ini.Load(file);
+
+    ini.Get_String("General", "ProjectName", Vinifera_ProjectName, sizeof(Vinifera_ProjectName));
+    ini.Get_String("General", "ProjectVersion", "Not Set", Vinifera_ProjectVersion, sizeof(Vinifera_ProjectVersion));
+    ini.Get_String("General", "IconFile", Vinifera_IconName, sizeof(Vinifera_IconName));
+    ini.Get_String("General", "CursorFile", Vinifera_CursorName, sizeof(Vinifera_CursorName));
+
+    Vinifera_ProjectName[sizeof(Vinifera_ProjectName)-1] = '\0';
+    Vinifera_ProjectVersion[sizeof(Vinifera_ProjectVersion)-1] = '\0';
+    Vinifera_IconName[sizeof(Vinifera_IconName)-1] = '\0';
+    Vinifera_CursorName[sizeof(Vinifera_CursorName)-1] = '\0';
+
+    return true;
+}
 
 
 /**
@@ -208,6 +239,13 @@ bool Vinifera_Parse_Command_Line(int argc, char *argv[])
  */
 bool Vinifera_Startup()
 {
+    /**
+     *  Load Vinifera settings and overrides.
+     */
+    if (!Vinifera_Load_INI()) {
+        DEBUG_WARNING("Failed to load VINIFERA.INI!\n");
+    }
+
     /**
      *  Initialise the CnCNet4 system.
      */

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -36,6 +36,7 @@ char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
 char Vinifera_ScreenshotDirectory[PATH_MAX] = { "Screenshots" };
 
 char Vinifera_ProjectName[64] = { '\0' };
+char Vinifera_ProjectVersion[64] = { '\0' };
 char Vinifera_IconName[64] = { '\0' };
 char Vinifera_CursorName[64] = { '\0' };
 

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -35,6 +35,8 @@ bool Vinifera_DeveloperMode = false;
 char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
 char Vinifera_ScreenshotDirectory[PATH_MAX] = { "Screenshots" };
 
+char Vinifera_ProjectName[64] = { '\0' };
+
 bool Vinifera_Developer_InstantBuild = false;
 bool Vinifera_Developer_AIInstantBuild = false;
 bool Vinifera_Developer_InstantSuperRecharge = false;

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -36,6 +36,8 @@ char Vinifera_DebugDirectory[PATH_MAX] = { "Debug" };
 char Vinifera_ScreenshotDirectory[PATH_MAX] = { "Screenshots" };
 
 char Vinifera_ProjectName[64] = { '\0' };
+char Vinifera_IconName[64] = { '\0' };
+char Vinifera_CursorName[64] = { '\0' };
 
 bool Vinifera_Developer_InstantBuild = false;
 bool Vinifera_Developer_AIInstantBuild = false;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -41,6 +41,8 @@ extern char Vinifera_DebugDirectory[PATH_MAX];
 extern char Vinifera_ScreenshotDirectory[PATH_MAX];
 
 extern char Vinifera_ProjectName[64];
+extern char Vinifera_IconName[64];
+extern char Vinifera_CursorName[64];
 
 
 /**

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -41,6 +41,7 @@ extern char Vinifera_DebugDirectory[PATH_MAX];
 extern char Vinifera_ScreenshotDirectory[PATH_MAX];
 
 extern char Vinifera_ProjectName[64];
+extern char Vinifera_ProjectVersion[64];
 extern char Vinifera_IconName[64];
 extern char Vinifera_CursorName[64];
 

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -40,6 +40,8 @@ extern bool Vinifera_DeveloperMode;
 extern char Vinifera_DebugDirectory[PATH_MAX];
 extern char Vinifera_ScreenshotDirectory[PATH_MAX];
 
+extern char Vinifera_ProjectName[64];
+
 
 /**
  *  Defines and constants.

--- a/src/vinifera_util.cpp
+++ b/src/vinifera_util.cpp
@@ -379,3 +379,42 @@ void Vinifera_DeveloperMode_Warning_WWMessageBox(const char *msg, ...)
         WWMessageBox().Process(buffer, 0, "OK");
     }
 }
+
+
+/**
+ *  Build the window title name.
+ * 
+ *  @author: CCHyper
+ */
+const char *Vinifera_Get_Window_Title(DWORD dwPid)
+{
+    static char _window_name[512];
+
+    if (_window_name[0] != '\0') {
+        return _window_name;
+    }
+
+    char title_buff[32];
+    std::strncpy(title_buff, Text_String(TXT_SHORT_TITLE), sizeof(title_buff));
+
+#ifndef NDEBUG
+    std::snprintf(_window_name, sizeof(_window_name),
+        "%s (PID:%d) - [Vinifera (Dev)] (%s %s%s %s)",
+        title_buff,
+        dwPid,
+        Vinifera_Git_Branch(),
+        Vinifera_Git_Uncommitted_Changes() ? "~" : "",
+        Vinifera_Git_Hash_Short(),
+        Vinifera_Git_DateTime());
+#else
+    if (!Vinifera_DeveloperMode) {
+        std::snprintf(_window_name, sizeof(_window_name),
+            "%s (PID:%d) (Developer Mode)", title_buff, dwPid);
+    } else {
+        std::snprintf(_window_name, sizeof(_window_name),
+            "%s", title_buff);
+    }
+#endif
+
+    return _window_name;
+}

--- a/src/vinifera_util.cpp
+++ b/src/vinifera_util.cpp
@@ -395,7 +395,12 @@ const char *Vinifera_Get_Window_Title(DWORD dwPid)
     }
 
     char title_buff[32];
-    std::strncpy(title_buff, Text_String(TXT_SHORT_TITLE), sizeof(title_buff));
+    if (Vinifera_ProjectName[0] != '\0') {
+        std::strncpy(title_buff, Vinifera_ProjectName, sizeof(title_buff));
+    } else {
+        std::strncpy(title_buff, Text_String(TXT_SHORT_TITLE), sizeof(title_buff));
+    }
+    title_buff[sizeof(title_buff)-1] = '\0';
 
 #ifndef NDEBUG
     std::snprintf(_window_name, sizeof(_window_name),


### PR DESCRIPTION
Closes #669 

This pull request adds control for overriding the games Window title, Cursor and Icon. These controls are loaded from a new INI file, `VINIFERA.INI`.

_**NOTE:** While this is INI file is optional, it is recommended the `ProjectName` and `ProjectVersion` are set by the mod developer as this information is printed into debug logs and crash dumps to aid in the troubleshooting process._

**`[General]`**
`ProjectName=<string>`
_The project's title name string. Limited to 64 characters._

`ProjectVersion=<string>`
_The project's version string. Limited to 64 characters._

_**NOTE:** The following filenames also support subdirectories._

`IconFile=<string>`
_The name of the icon file (including the `.ICO` extension) to use for the games window. Limited to 64 characters._

`CursorFile=<string>`
_The name of the cursor file (including the `.CUR` extension) to use for the game's cursor. Limited to 64 characters._
