### PR TITLE
Implements `CanRetaliate` for TechnoTypes.

### DIFF
--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -55,6 +55,42 @@
 
 
 /**
+ *  #issue-594
+ * 
+ *  Implements IsCanRetaliate for TechnoTypes.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_TechnoClass_Is_Allowed_To_Retaliate_Can_Retaliate_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
+    static TechnoTypeClassExtension *technotypeext;
+
+    technotypeext = TechnoTypeClassExtensions.find(this_ptr->Techno_Type_Class());
+
+    /**
+     *  If this unit is flagged as no being allowed to retaliate to attacks, return false.
+     */
+    if (technotypeext && !technotypeext->IsCanRetaliate) {
+        goto return_FALSE;
+    }
+
+    /**
+     *  Stolen bytes/code.
+     */
+    if (this_ptr->House->Is_Player_Control() && this_ptr->TarCom) {
+        goto return_FALSE;
+    }
+
+continue_checks:
+    JMP(0x00636F26);
+
+return_FALSE:
+    JMP(0x006371E7);
+}
+
+
+/**
  *  #issue-357
  * 
  *  Creates an instance of the electric bolt from the firing techno to the target.
@@ -691,4 +727,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00631661, &_TechnoClass_Player_Assign_Mission_Response_Patch);
     Patch_Jump(0x00630390, &_TechnoClass_Fire_At_Suicide_Patch);
     Patch_Jump(0x006312CD, &_TechnoClass_Fire_At_Electric_Bolt_Patch);
+    Patch_Jump(0x00636F09, &_TechnoClass_Is_Allowed_To_Retaliate_Can_Retaliate_Patch);
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -52,6 +52,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     IsShakeScreen(false),
     IsImmuneToEMP(false),
     IsCanPassiveAcquire(true),
+    IsCanRetaliate(true),
     ShakePixelYHi(0),
     ShakePixelYLo(0),
     ShakePixelXHi(0),
@@ -225,6 +226,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsShakeScreen = ini.Get_Bool(ini_name, "CanShakeScreen", IsShakeScreen);
     IsImmuneToEMP = ini.Get_Bool(ini_name, "ImmuneToEMP", IsImmuneToEMP);
     IsCanPassiveAcquire = ini.Get_Bool(ini_name, "CanPassiveAcquire", IsCanPassiveAcquire);
+    IsCanRetaliate = ini.Get_Bool(ini_name, "CanRetaliate", IsCanRetaliate);
     ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
     ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
     ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -84,6 +84,11 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
         bool IsCanPassiveAcquire;
 
         /**
+         *  Can this object retaliate when hit by enemy fire?
+         */
+        bool IsCanRetaliate;
+
+        /**
          *  These values are used to shake the screen when the object is destroyed.
          */
         unsigned ShakePixelYHi;


### PR DESCRIPTION
Closes #594 

This pull request implements `CanRetaliate` for TechnoTypes from Red Alert 2.

**`[TechnoTypes]`**
`CanRetaliate=<boolean>`
_Can this unit retaliate (if general conditions are met) when hit by enemy fire? Defaults to `yes`._