### PR TITLE
Implements `CanPassiveAcquire` for TechnoTypes.

### DIFF
--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -312,3 +312,27 @@ void TechnoClassExtension::Response_Harvest()
 
     Sound_Effect(response);
 }
+
+
+/**
+ *  Returns if this object can acquire targets that are within range and attack them automatically.
+ * 
+ *  @author: CCHyper
+ */
+bool TechnoClassExtension::Can_Passive_Acquire() const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension::Can_Passive_Acquire - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    
+    TechnoTypeClass *technotype = ThisPtr->Techno_Type_Class();
+    TechnoTypeClassExtension *technotypeext = TechnoTypeClassExtensions.find(technotype);
+
+    if (technotypeext) {
+        return technotypeext->IsCanPassiveAcquire;
+    }
+
+    /**
+     *  Original behaviour, all units can passive acquire.
+     */
+    return true;
+}

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -56,6 +56,7 @@ class TechnoClassExtension final : public Extension<TechnoClass>
         void Response_Enter();
         void Response_Deploy();
         void Response_Harvest();
+        bool Can_Passive_Acquire() const;
 
     public:
         /**

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -51,6 +51,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     UncloakSound(VOC_NONE),
     IsShakeScreen(false),
     IsImmuneToEMP(false),
+    IsCanPassiveAcquire(true),
     ShakePixelYHi(0),
     ShakePixelYLo(0),
     ShakePixelXHi(0),
@@ -223,6 +224,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     UncloakSound = ini.Get_VocType(ini_name, "UncloakSound", UncloakSound);
     IsShakeScreen = ini.Get_Bool(ini_name, "CanShakeScreen", IsShakeScreen);
     IsImmuneToEMP = ini.Get_Bool(ini_name, "ImmuneToEMP", IsImmuneToEMP);
+    IsCanPassiveAcquire = ini.Get_Bool(ini_name, "CanPassiveAcquire", IsCanPassiveAcquire);
     ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
     ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
     ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -78,6 +78,12 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
         bool IsImmuneToEMP;
 
         /**
+         *  Can this object acquire targets that are within its weapons range
+         *  and attack them automatically?
+         */
+        bool IsCanPassiveAcquire;
+
+        /**
          *  These values are used to shake the screen when the object is destroyed.
          */
         unsigned ShakePixelYHi;


### PR DESCRIPTION
Closes #593

This pull request implements `CanPassiveAcquire` for TechnoTypes from Red Alert 2. 

**`[TechnoType]`**
**`CanPassiveAcquire=<boolean>`**
_Can this object acquire targets that are within its weapons range and attack them automatically? Defaults to `yes`_