### PR TITLE
Implements `CanApproachTarget` and `CanRecalcApproachTarget` for TechnoTypes and `ApproachTargetResetMultiplier` for Rules.

### DIFF
--- a/src/extensions/foot/footext_hooks.cpp
+++ b/src/extensions/foot/footext_hooks.cpp
@@ -30,13 +30,76 @@
 #include "technoext.h"
 #include "technotype.h"
 #include "technotypeext.h"
+#include "tibsun_inline.h"
 #include "house.h"
+#include "rules.h"
+#include "rulesext.h"
+#include "target.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-595
+ * 
+ *  Implements IsCanRecalcApproachTarget for TechnoTypes.
+ * 
+ *  @author: CCHyper
+ */
+static short NavCom_TarCom_Distance(FootClass *this_ptr) { return Distance(this_ptr->NavCom->Center_Coord(), this_ptr->TarCom->Center_Coord()); }
+static int Multiply_Integer(int a, double b) { return (a * b); }
+DECLARE_PATCH(_FootClass_Approach_Target_Can_Recalc_Approach_Target_Patch)
+{
+    GET_REGISTER_STATIC(FootClass *, this_ptr, ebp);
+    GET_REGISTER_STATIC(bool, in_range, bl);
+    GET_STACK_STATIC(int, maxrange, esp, 0x34);
+    static TechnoTypeClassExtension *technotypeext;
+
+    if (Target_Legal(this_ptr->NavCom)) {
+
+        if (Target_Legal(this_ptr->TarCom)) {
+
+            technotypeext = TechnoTypeClassExtensions.find(this_ptr->Techno_Type_Class());
+            if (technotypeext && technotypeext->IsCanRecalcApproachTarget) {
+
+                //DEV_DEBUG_INFO("Approach_Target: CanRecalcApproachTarget branch.\n");
+
+                if (!in_range) {
+
+                    static double reset_multiplier = 1.0;
+                    if (RulesExtension) {
+                        reset_multiplier = RulesExtension->ApproachTargetResetMultiplier;
+                    }
+
+                    if (NavCom_TarCom_Distance(this_ptr) > Multiply_Integer(maxrange, reset_multiplier)) {
+                        DEV_DEBUG_INFO("Approach_Target: Clearing NavCom.\n");
+                        this_ptr->NavCom = nullptr;
+                    }
+
+                }
+
+            }
+
+        }
+
+        if (Target_Legal(this_ptr->NavCom)) {
+            if (!this_ptr->In_Air()) {
+                goto function_return;
+            }
+        }
+    }
+
+    _asm { mov bl, byte ptr [in_range] }    // restore BL register.
+
+    JMP(0x004A2004);
+
+function_return:
+    JMP(0x004A2813);
+}
 
 
 /**
@@ -335,4 +398,5 @@ void FootClassExtension_Hooks()
     Patch_Jump(0x004A1AAE, &_FootClass_Mission_Guard_Can_Passive_Acquire_Patch);
     Patch_Jump(0x004A102F, &_FootClass_Mission_Move_Can_Passive_Acquire_Patch);
     Patch_Jump(0x004A1EA8, &_FootClass_Approach_Target_Can_Approach_Patch);
+    Patch_Jump(0x004A1FEA, &_FootClass_Approach_Target_Can_Recalc_Approach_Target_Patch);
 }

--- a/src/extensions/foot/footext_hooks.cpp
+++ b/src/extensions/foot/footext_hooks.cpp
@@ -30,12 +30,62 @@
 #include "technoext.h"
 #include "technotype.h"
 #include "technotypeext.h"
+#include "house.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-595
+ * 
+ *  Implements IsCanApproachTarget for TechnoTypes.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_FootClass_Approach_Target_Can_Approach_Patch)
+{
+    GET_REGISTER_STATIC(FootClass *, this_ptr, ebp);
+    static TechnoTypeClassExtension *technotypeext;
+
+    technotypeext = TechnoTypeClassExtensions.find(this_ptr->Techno_Type_Class());
+
+    /**
+     *  Stolen bytes/code.
+     */
+    if (this_ptr->Mission == MISSION_STICKY) {
+        goto assign_null_target_return;
+    }
+
+    /**
+     *  
+     */
+    if (technotypeext && !technotypeext->IsCanApproachTarget) {
+
+        static bool force_approach;
+        force_approach = false;
+
+        if (this_ptr->Mission == MISSION_ATTACK) {
+            force_approach = true;
+        }
+        if (this_ptr->Mission == MISSION_GUARD_AREA && this_ptr->House->Is_Player_Control()) {
+            force_approach = true;
+        }
+        if ((this_ptr->Mission != MISSION_HUNT || this_ptr->House->Is_Player_Control()) && !force_approach) {
+            goto assign_null_target_return;
+        }
+
+    }
+
+continue_checks:
+    JMP(0x004A1ED2);
+
+assign_null_target_return:
+    JMP(0x004A1EAE);
+}
 
 
 /**
@@ -284,4 +334,5 @@ void FootClassExtension_Hooks()
     Patch_Jump(0x004A2BE7, &_FootClass_Mission_Guard_Area_Can_Passive_Acquire_Patch);
     Patch_Jump(0x004A1AAE, &_FootClass_Mission_Guard_Can_Passive_Acquire_Patch);
     Patch_Jump(0x004A102F, &_FootClass_Mission_Move_Can_Passive_Acquire_Patch);
+    Patch_Jump(0x004A1EA8, &_FootClass_Approach_Target_Can_Approach_Patch);
 }

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -48,7 +48,8 @@ RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
     IsMPAutoDeployMCV(false),
     IsMPPrePlacedConYards(false),
     IsBuildOffAlly(true),
-    IsShowSuperWeaponTimers(true)
+    IsShowSuperWeaponTimers(true),
+    ApproachTargetResetMultiplier(1.0)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("RulesClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -290,6 +291,8 @@ bool RulesClassExtension::General(CCINIClass &ini)
     if (!ini.Is_Present(GENERAL)) {
         return false;
     }
+
+    ApproachTargetResetMultiplier = ini.Get_Float(GENERAL, "ApproachTargetResetMultiplier", ApproachTargetResetMultiplier);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -110,6 +110,12 @@ class RulesClassExtension final : public Extension<RulesClass>
          *  on the tactical view?
          */
         bool IsShowSuperWeaponTimers;
+
+        /**
+         *  The "approach target" position should be recalculated if the target is
+         *  now more than weapon range times this value.
+         */
+        double ApproachTargetResetMultiplier;
 };
 
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -58,6 +58,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     IsCanPassiveAcquire(true),
     IsCanRetaliate(true),
     IsCanApproachTarget(true),
+    IsCanRecalcApproachTarget(true),
     ShakePixelYHi(0),
     ShakePixelYLo(0),
     ShakePixelXHi(0),
@@ -261,6 +262,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsCanPassiveAcquire = ini.Get_Bool(ini_name, "CanPassiveAcquire", IsCanPassiveAcquire);
     IsCanRetaliate = ini.Get_Bool(ini_name, "CanRetaliate", IsCanRetaliate);
     IsCanApproachTarget = ini.Get_Bool(ini_name, "CanApproachTarget", IsCanApproachTarget);
+    IsCanRecalcApproachTarget = ini.Get_Bool(ini_name, "CanRecalcApproachTarget", IsCanRecalcApproachTarget);
     ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
     ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
     ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -57,6 +57,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     IsImmuneToEMP(false),
     IsCanPassiveAcquire(true),
     IsCanRetaliate(true),
+    IsCanApproachTarget(true),
     ShakePixelYHi(0),
     ShakePixelYLo(0),
     ShakePixelXHi(0),
@@ -259,6 +260,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsImmuneToEMP = ini.Get_Bool(ini_name, "ImmuneToEMP", IsImmuneToEMP);
     IsCanPassiveAcquire = ini.Get_Bool(ini_name, "CanPassiveAcquire", IsCanPassiveAcquire);
     IsCanRetaliate = ini.Get_Bool(ini_name, "CanRetaliate", IsCanRetaliate);
+    IsCanApproachTarget = ini.Get_Bool(ini_name, "CanApproachTarget", IsCanApproachTarget);
     ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
     ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
     ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -96,6 +96,12 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
         bool IsCanApproachTarget;
 
         /**
+         *  Can this unit recalculate what its next target will be when conducting
+         *  its threat scan if its current target is out of range?
+         */
+        bool IsCanRecalcApproachTarget;
+
+        /**
          *  These values are used to shake the screen when the object is destroyed.
          */
         unsigned ShakePixelYHi;

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -90,6 +90,12 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
         bool IsCanRetaliate;
 
         /**
+         *  Can this unit can continually move towards its intended target with
+         *  the intention of gaining more accuracy?
+         */
+        bool IsCanApproachTarget;
+
+        /**
          *  These values are used to shake the screen when the object is destroyed.
          */
         unsigned ShakePixelYHi;


### PR DESCRIPTION
Closes #595

This pull request implements `CanApproachTarget` and `CanRecalcApproachTarget` for TechnoTypes, and `ApproachTargetResetMultiplier` for the rules `[General]` section from Red Alert 2. 

**`[TechnoType]`**
**`CanApproachTarget=<boolean>`**
_Can this unit can continually move towards its intended target with the intention of gaining more accuracy? Defaults to `yes`_

**`CanRecalcApproachTarget=<boolean>`**
_Can this unit recalculate what its next target will be when conducting its threat scan if its current target is out of range? Defaults to `yes`_

**`[General]`**
**`ApproachTargetResetMultiplier=<float>`**
_The "approach target" position should be recalculated if the target is now more than weapon range times this value. Defaults to `1.0`_
_**NOTE:** This value does not apply to units with `CanRecalcApproachTarget=no`._
