### PR TITLE
Implements `StupidHunt` and `CanApproachTarget` for TechnoTypes.

### DIFF
--- a/src/extensions/foot/footext_hooks.cpp
+++ b/src/extensions/foot/footext_hooks.cpp
@@ -27,10 +27,14 @@
  ******************************************************************************/
 #include "footext_hooks.h"
 #include "foot.h"
+#include "tibsun_globals.h"
 #include "technoext.h"
 #include "technotype.h"
 #include "technotypeext.h"
 #include "house.h"
+#include "housetype.h"
+#include "session.h"
+#include "iomap.h"
 #include "extension.h"
 #include "fatal.h"
 #include "asserthandler.h"
@@ -38,6 +42,76 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-680
+ * 
+ *  Implements IsStupidHunt for TechnoTypes.
+ * 
+ *  @author: CCHyper
+ */
+static Coordinate &Foot_Get_Coord(FootClass *this_ptr) { return this_ptr->Get_Coord(); }
+static CellClass *Get_House_Center_Cell(HouseClass *house) { return &Map[PlayerPtr->Center]; }
+DECLARE_PATCH(_FootClass_Mission_Hunt_Stupid_Hunt_Patch)
+{
+    GET_REGISTER_STATIC(FootClass *, this_ptr, esi);
+    static TechnoTypeClassExtension *technotypeext;
+
+    technotypeext = Extension::Fetch<TechnoTypeClassExtension>(this_ptr->Techno_Type_Class());
+
+    /**
+     *  Should this unit just head towards the enemy without picking a target?
+     */
+    if (technotypeext->IsStupidHunt) {
+
+        /**
+         *  Player controlled units don't abid by the "stupid hunt" rule, so
+         *  tell them to randomly animate. Same goes for if this is a multiplayer
+         *  game.
+         */
+        if (this_ptr->House->Is_Player_Control() || Session.Type != GAME_NORMAL) {
+            this_ptr->Random_Animate();
+
+        /**
+         *  AI controlled units in the campaign should head directly towards
+         *  the player, not its current enemy. This ensures the units do not
+         *  head towards a partner house that attacked them last.
+         */
+        } else if (PlayerPtr->Center) {
+            this_ptr->Assign_Destination(Get_House_Center_Cell(PlayerPtr));
+            this_ptr->Assign_Mission(MISSION_MOVE);
+
+        }
+
+        goto mission_return;
+    }
+
+    /**
+     *  Find a fresh target within my range.
+     */
+    if (this_ptr->Target_Something_Nearby(Foot_Get_Coord(this_ptr), THREAT_NORMAL)) {
+        goto target_picked;
+    }
+
+    /**
+     *  Failed to pick a target, random animate and return.
+     */
+random_animate:
+    JMP(0x004A1C03);
+
+    /**
+     *  We picked a target, continue.
+     */
+target_picked:
+    JMP(0x004A1C12);
+
+    /**
+     *  Mission complete!
+     */
+mission_return:
+    JMP(0x004A1D28);
+}
 
 
 /**
@@ -334,4 +408,5 @@ void FootClassExtension_Hooks()
     Patch_Jump(0x004A1AAE, &_FootClass_Mission_Guard_Can_Passive_Acquire_Patch);
     Patch_Jump(0x004A102F, &_FootClass_Mission_Move_Can_Passive_Acquire_Patch);
     Patch_Jump(0x004A1EA8, &_FootClass_Approach_Target_Can_Approach_Patch);
+    Patch_Jump(0x004A1BEB, &_FootClass_Mission_Hunt_Stupid_Hunt_Patch);
 }

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -74,7 +74,8 @@ RulesClassExtension::RulesClassExtension(const RulesClass *this_ptr) :
     IsMPPrePlacedConYards(false),
     IsBuildOffAlly(true),
     IsShowSuperWeaponTimers(true),
-    IceStrength(0)
+    IceStrength(0),
+    ApproachTargetResetMultiplier(1.0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("RulesClassExtension::RulesClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
@@ -432,6 +433,8 @@ bool RulesClassExtension::General(CCINIClass &ini)
      *  @author: CCHyper
      */
     This()->EngineerDamage = ini.Get_Float(GENERAL, "EngineerDamage", This()->EngineerDamage);
+
+    ApproachTargetResetMultiplier = ini.Get_Float(GENERAL, "ApproachTargetResetMultiplier", ApproachTargetResetMultiplier);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -97,4 +97,10 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
          *  to break from a shot.
          */
         int IceStrength;
+
+        /**
+         *  The "approach target" position should be recalculated if the target is
+         *  now more than weapon range times this value.
+         */
+        double ApproachTargetResetMultiplier;
 };

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -54,6 +54,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsCanRetaliate(true),
     IsLegalTargetComputer(true),
     IsCanApproachTarget(true),
+    IsStupidHunt(false),
     ShakePixelYHi(0),
     ShakePixelYLo(0),
     ShakePixelXHi(0),
@@ -252,6 +253,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsCanRetaliate = ini.Get_Bool(ini_name, "CanRetaliate", IsCanRetaliate);
     IsLegalTargetComputer = ini.Get_Bool(ini_name, "AILegalTarget", IsLegalTargetComputer);
     IsCanApproachTarget = ini.Get_Bool(ini_name, "CanApproachTarget", IsCanApproachTarget);
+    IsStupidHunt = ini.Get_Bool(ini_name, "StupidHunt", IsStupidHunt);
     ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
     ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
     ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -53,6 +53,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsCanPassiveAcquire(true),
     IsCanRetaliate(true),
     IsLegalTargetComputer(true),
+    IsCanApproachTarget(true),
     ShakePixelYHi(0),
     ShakePixelYLo(0),
     ShakePixelXHi(0),
@@ -250,6 +251,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsCanPassiveAcquire = ini.Get_Bool(ini_name, "CanPassiveAcquire", IsCanPassiveAcquire);
     IsCanRetaliate = ini.Get_Bool(ini_name, "CanRetaliate", IsCanRetaliate);
     IsLegalTargetComputer = ini.Get_Bool(ini_name, "AILegalTarget", IsLegalTargetComputer);
+    IsCanApproachTarget = ini.Get_Bool(ini_name, "CanApproachTarget", IsCanApproachTarget);
     ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
     ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);
     ShakePixelXHi = ini.Get_Int(ini_name, "ShakeXhi", ShakePixelXHi);

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -108,6 +108,12 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
         bool IsCanApproachTarget;
 
         /**
+         *  Should this unit just head towards the enemy if possible rather than
+         *  assigning itself a nearby target (computer-controlled units only)?
+         */
+        bool IsStupidHunt;
+
+        /**
          *  These values are used to shake the screen when the object is destroyed.
          */
         unsigned ShakePixelYHi;

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -102,6 +102,12 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
         bool IsLegalTargetComputer;
 
         /**
+         *  Can this unit can continually move towards its intended target with
+         *  the intention of gaining more accuracy?
+         */
+        bool IsCanApproachTarget;
+
+        /**
          *  These values are used to shake the screen when the object is destroyed.
          */
         unsigned ShakePixelYHi;


### PR DESCRIPTION
Closes #680 

This pull request implements `StupidHunt` and `CanApproachTarget` for TechnoTypes from Red Alert 2.

**`[TechnoType]`**
`StupidHunt=<boolean>`
_Should this unit just head towards the enemy if possible rather than assigning itself a nearby target (applies to computer-controlled units in the campaign only)? Defaults to `no`_

`CanApproachTarget=<boolean>`
_Should this unit can continually move towards its intended target with the intention of gaining more accuracy? Defaults to `no`_

It also implements a modifier `CanApproachTarget`, also from Red Alert 2;

**`[General]`**
`ApproachTargetResetMultiplier=<float>`
_The "approach target" position should be recalculated if the target is now more than weapon range times this value. Defaults to `1.0`_
