### PR TITLE
Implements option to display the super weapon recharge timer on the tactical view.

### DIFF
--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -672,6 +672,43 @@ bool JumpCameraSouthCommandClass::Process()
 
 
 /**
+ *  Toggles the visibility of the special weapon timers on the tactical view.
+ * 
+ *  @author: CCHyper
+ */
+const char *ToggleSuperTimersCommandClass::Get_Name() const
+{
+    return "ToggleSuperTimers";
+}
+
+const char *ToggleSuperTimersCommandClass::Get_UI_Name() const
+{
+    return "Toggle Special Timers";
+}
+
+const char *ToggleSuperTimersCommandClass::Get_Category() const
+{
+    return Text_String(TXT_INTERFACE);
+}
+
+const char *ToggleSuperTimersCommandClass::Get_Description() const
+{
+    return "Toggles the visibility of the special weapon timers on the tactical view.";
+}
+
+bool ToggleSuperTimersCommandClass::Process()
+{
+    if (Session.Type == GAME_NORMAL) {
+        return false;
+    }
+
+    Vinifera_ShowSuperWeaponTimers = !Vinifera_ShowSuperWeaponTimers;
+
+    return true;
+}
+
+
+/**
  *  Produces a memory dump on request.
  * 
  *  @author: CCHyper

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -284,6 +284,25 @@ class JumpCameraSouthCommandClass : public ViniferaCommandClass
 
 
 /**
+ *  Toggles the visibility of the super weapon timers on the tactical view.
+ */
+class ToggleSuperTimersCommandClass : public ViniferaCommandClass
+{
+    public:
+        ToggleSuperTimersCommandClass() : ViniferaCommandClass() { IsDeveloper = false; }
+        virtual ~ToggleSuperTimersCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
+/**
  *  Produces a memory dump on request.
  */
 class MemoryDumpCommandClass : public ViniferaCommandClass

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -172,6 +172,9 @@ void Init_Vinifera_Commands()
     cmdptr = new JumpCameraSouthCommandClass;
     Commands.Add(cmdptr);
 
+    cmdptr = new ToggleSuperTimersCommandClass;
+    Commands.Add(cmdptr);
+
     /**
      *  Next, initialised any new commands here if the developer mode is enabled.
      */

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -47,7 +47,8 @@ RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
     Extension(this_ptr),
     IsMPAutoDeployMCV(false),
     IsMPPrePlacedConYards(false),
-    IsBuildOffAlly(true)
+    IsBuildOffAlly(true),
+    IsShowSuperWeaponTimers(true)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("RulesClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -184,6 +185,7 @@ void RulesClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(IsMPAutoDeployMCV);
     crc(IsMPPrePlacedConYards);
     crc(IsBuildOffAlly);
+    crc(IsShowSuperWeaponTimers);
 }
 
 
@@ -251,6 +253,7 @@ void RulesClassExtension::Process(CCINIClass &ini)
      */
     General(ini);
     MPlayer(ini);
+    AudioVisual(ini);
 
     /**
      *  Run some checks to ensure certain values are as expected.
@@ -287,6 +290,28 @@ bool RulesClassExtension::General(CCINIClass &ini)
     if (!ini.Is_Present(GENERAL)) {
         return false;
     }
+
+    return true;
+}
+
+
+/**
+ *  Process the audio/visual game settings.
+ *  
+ *  @author: CCHyper
+ */
+bool RulesClassExtension::AudioVisual(CCINIClass &ini)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("RulesClassExtension::General - 0x%08X\n", (uintptr_t)(ThisPtr));
+
+    static char const * const AUDIOVISUAL = "AudioVisual";
+
+    if (!ini.Is_Present(AUDIOVISUAL)) {
+        return false;
+    }
+
+    IsShowSuperWeaponTimers = ini.Get_Bool(AUDIOVISUAL, "ShowSuperWeaponTimers", IsShowSuperWeaponTimers);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -57,6 +57,7 @@ class RulesClassExtension final : public Extension<RulesClass>
 
         bool General(CCINIClass &ini);
         bool MPlayer(CCINIClass &ini);
+        bool AudioVisual(CCINIClass &ini);
         bool Weapons(CCINIClass &ini);
 
         static bool Read_UI_INI();
@@ -103,6 +104,12 @@ class RulesClassExtension final : public Extension<RulesClass>
          *  Can players build their own structures adjacent to structures owned by their allies?
          */
         bool IsBuildOffAlly;
+
+        /**
+         *  Should active super weapons show their recharge timer display
+         *  on the tactical view?
+         */
+        bool IsShowSuperWeaponTimers;
 };
 
 

--- a/src/extensions/super/superext.cpp
+++ b/src/extensions/super/superext.cpp
@@ -44,7 +44,9 @@ ExtensionMap<SuperClass, SuperClassExtension> SuperClassExtensions;
  *  @author: CCHyper
  */
 SuperClassExtension::SuperClassExtension(SuperClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    FlashTimeEnd(0),
+    TimerFlashState(false)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("SuperClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));

--- a/src/extensions/super/superext.h
+++ b/src/extensions/super/superext.h
@@ -50,6 +50,15 @@ class SuperClassExtension final : public Extension<SuperClass>
         virtual void Compute_CRC(WWCRCEngine &crc) const override;
 
     public:
+        /**
+         *  The time at which the flash mode should return to normal.
+         */
+        unsigned long FlashTimeEnd;
+
+        /**
+         *  The current flash state of the timer printed on the tactical view.
+         */
+        bool TimerFlashState;
 };
 
 

--- a/src/extensions/supertype/supertypeext.cpp
+++ b/src/extensions/supertype/supertypeext.cpp
@@ -44,7 +44,8 @@ ExtensionMap<SuperWeaponTypeClass, SuperWeaponTypeClassExtension> SuperWeaponTyp
  *  @author: CCHyper
  */
 SuperWeaponTypeClassExtension::SuperWeaponTypeClassExtension(SuperWeaponTypeClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    IsShowTimer(false)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("SuperWeaponTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -174,6 +175,8 @@ bool SuperWeaponTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    IsShowTimer = ini.Get_Bool(ini_name, "ShowTimer", IsShowTimer);
     
     return true;
 }

--- a/src/extensions/supertype/supertypeext.h
+++ b/src/extensions/supertype/supertypeext.h
@@ -52,7 +52,11 @@ class SuperWeaponTypeClassExtension final : public Extension<SuperWeaponTypeClas
         bool Read_INI(CCINIClass &ini);
 
     public:
-
+        /**
+         *  When this super weapon is active, does its recharge timer display
+         *  on the tactical view?
+         */
+        bool IsShowTimer;
 };
 
 

--- a/src/extensions/tactical/tacticalext.cpp
+++ b/src/extensions/tactical/tacticalext.cpp
@@ -45,6 +45,8 @@
 #include "superext.h"
 #include "supertype.h"
 #include "supertypeext.h"
+#include "rules.h"
+#include "rulesext.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -655,6 +657,13 @@ void TacticalMapExtension::Draw_Super_Timers()
         return;
     }
 #endif
+
+    /**
+     *  Does the game rules state that the super weapon timers should be shown?
+     */
+    if (!RulesExtension->IsShowSuperWeaponTimers) {
+        return;
+    }
 
     /**
      *  Has the user toggled the visibility of the super weapon timers?

--- a/src/extensions/tactical/tacticalext.h
+++ b/src/extensions/tactical/tacticalext.h
@@ -68,10 +68,16 @@ class TacticalMapExtension final : public Extension<Tactical>
         void Draw_FrameStep_Overlay();
 
         void Draw_Information_Text();
+        void Draw_Super_Timers();
+
+        void Render_Post();
 
 #ifndef NDEBUG
         bool Debug_Draw_Facings();
 #endif
+
+    private:
+        void Super_Draw_Timer(int row_index, ColorScheme *color, int time, const char *name, unsigned long *flash_time, bool *flash_state);
 
     public:
         /**

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -258,9 +258,9 @@ DECLARE_PATCH(_Tactical_Render_Post_Effects_Patch)
     /**
      *  Draw any new post effects here.
      */
-    //DEV_DEBUG_INFO("Before EBoltClass::Draw_All\n");
-    EBoltClass::Draw_All();
-    //DEV_DEBUG_INFO("After EBoltClass::Draw_All\n");
+    if (TacticalExtension) {
+        TacticalExtension->Render_Post();
+    }
 
     JMP(0x00611AFE);
 }

--- a/src/vinifera/vinifera_globals.cpp
+++ b/src/vinifera/vinifera_globals.cpp
@@ -59,6 +59,8 @@ bool Vinifera_Developer_AIControl = false;
 bool Vinifera_SkipWWLogoMovie = false;
 bool Vinifera_SkipStartupMovies = false;
 
+bool Vinifera_ShowSuperWeaponTimers = true;
+
 DynamicVectorClass<MFCC *> ViniferaMapsMixes;
 DynamicVectorClass<MFCC *> ViniferaMoviesMixes;
 

--- a/src/vinifera/vinifera_globals.h
+++ b/src/vinifera/vinifera_globals.h
@@ -79,6 +79,8 @@ extern bool Vinifera_Developer_AIControl;
 extern bool Vinifera_SkipWWLogoMovie;
 extern bool Vinifera_SkipStartupMovies;
 
+extern bool Vinifera_ShowSuperWeaponTimers;
+
 extern DynamicVectorClass<MFCC *> ViniferaMapsMixes;
 extern DynamicVectorClass<MFCC *> ViniferaMoviesMixes;
 

--- a/src/vinifera/vinifera_hooks.cpp
+++ b/src/vinifera/vinifera_hooks.cpp
@@ -306,6 +306,11 @@ DECLARE_PATCH(_Select_Game_Clear_Globals_Patch)
     Vinifera_Developer_AIControl = false;
 
     /**
+     *  Reset any globals.
+     */
+    Vinifera_ShowSuperWeaponTimers = true;
+
+    /**
      *  Stolen bytes/code.
      */
     Map.Set_Default_Mouse(MOUSE_NORMAL);


### PR DESCRIPTION
Closes #102

This pull request implements the system from Red Alert 2 that shows all active superweapon timers on the tactical view. This is disabled by default and each relevant SuperWeaponType must have it enabled. Superweapons that are offline due to low power or are disabled via other purposes will not show.

In addition to this, a new keyboard command has been added to allow the user to toggle the visibility of these timers. You can find this under the **"Interface"** category as **"Toggle Special Timers"**.

**`[SuperWeaponType]`**
`ShowTimer=<boolean>`
_When this superweapon is active, does its recharge timer display on the tactical view? Defaults to `no`._