### PR TITLE
Implements `WaterClass` for UnitTypes.

### DIFF
--- a/src/extensions/unit/unitext.cpp
+++ b/src/extensions/unit/unitext.cpp
@@ -28,7 +28,9 @@
 #include "unitext.h"
 #include "unit.h"
 #include "wwcrc.h"
+#include "swizzle.h"
 #include "extension.h"
+#include "vinifera_saveload.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -39,7 +41,8 @@
  *  @author: CCHyper
  */
 UnitClassExtension::UnitClassExtension(const UnitClass *this_ptr) :
-    FootClassExtension(this_ptr)
+    FootClassExtension(this_ptr),
+    OriginalClass(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("UnitClassExtension::UnitClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -106,6 +109,8 @@ HRESULT UnitClassExtension::Load(IStream *pStm)
     }
 
     new (this) UnitClassExtension(NoInitClass());
+
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(OriginalClass, "OriginalClass");
     
     return hr;
 }

--- a/src/extensions/unit/unitext.h
+++ b/src/extensions/unit/unitext.h
@@ -31,6 +31,9 @@
 #include "unit.h"
 
 
+class UnitTypeClass;
+
+
 class DECLSPEC_UUID(UUID_UNIT_EXTENSION)
 UnitClassExtension final : public FootClassExtension
 {
@@ -60,4 +63,9 @@ UnitClassExtension final : public FootClassExtension
         virtual RTTIType What_Am_I() const override { return RTTI_UNIT; }
 
     public:
+        /**
+         *  Pointer to the original class for this unit. This allows us to
+         *  switch and restore the class in various situations.
+         */
+        const UnitTypeClass *OriginalClass;
 };

--- a/src/extensions/unittype/unittypeext.cpp
+++ b/src/extensions/unittype/unittypeext.cpp
@@ -45,7 +45,8 @@ UnitTypeClassExtension::UnitTypeClassExtension(const UnitTypeClass *this_ptr) :
     StartTurretFrame(-1),
     TurretFacings(32),		// Must default to 32 as all Tiberian Sun units have 32 facings for turrets.,
     StartIdleFrame(0),
-    IdleFrames(0)
+    IdleFrames(0),
+    WaterClass(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("UnitTypeClassExtension::UnitTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -191,6 +192,7 @@ bool UnitTypeClassExtension::Read_INI(CCINIClass &ini)
     //}
 
     IsTotable = ini.Get_Bool(ini_name, "Totable", IsTotable);
+    WaterClass = ini.Get_Unit(ini_name, "WaterClass", WaterClass);
 
     StartTurretFrame = ArtINI.Get_Int(graphic_name, "StartTurretFrame", StartTurretFrame);
     TurretFacings = ArtINI.Get_Int(graphic_name, "TurretFacings", TurretFacings);

--- a/src/extensions/unittype/unittypeext.h
+++ b/src/extensions/unittype/unittypeext.h
@@ -86,4 +86,9 @@ UnitTypeClassExtension final : public TechnoTypeClassExtension
          *  The number of image frames for each of the idle animation sequences.
          */
         unsigned IdleFrames;
+
+        /**
+         *  The graphic class to switch to when this unit enters water.
+         */
+        const UnitTypeClass *WaterClass;
 };


### PR DESCRIPTION
Closes #64 

This pull request implements a new key for UnitTypes to control their image when they enter any land with water properties.

**`[UnitType]`**
`WaterClass=<UnitType>`
_The graphic class to switch to when this unit enters water. Defaults to `<none>`._

**NOTE:** The original logic for the **GDI Amphibious APC**'s graphic switching is retained if the unit's name matches `APC` and does not have `WaterClass` set.
