### PR TITLE
Implements developer commands for instant superweapon recharge.

### DIFF
--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -3112,3 +3112,77 @@ bool RemoveTiberiumCommandClass::Process()
 
     return false;
 }
+
+
+/**
+ *  Toggles the instant recharge cheat for the players super weapons.
+ * 
+ *  @author: CCHyper
+ */
+const char *InstantSuperRechargeCommandClass::Get_Name() const
+{
+    return "InstantSpecialRecharge";
+}
+
+const char *InstantSuperRechargeCommandClass::Get_UI_Name() const
+{
+    return "Instant Special Recharge (Player)";
+}
+
+const char *InstantSuperRechargeCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *InstantSuperRechargeCommandClass::Get_Description() const
+{
+    return "Toggles the instant recharge cheat for the players super weapons.";
+}
+
+bool InstantSuperRechargeCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Vinifera_Developer_InstantSuperRecharge = !Vinifera_Developer_InstantSuperRecharge;
+
+    return true;
+}
+
+
+/**
+ *  Toggles the instant recharge cheat for the AI player super weapons.
+ * 
+ *  @author: CCHyper
+ */
+const char *AIInstantSuperRechargeCommandClass::Get_Name() const
+{
+    return "AIInstantSpecialRecharge";
+}
+
+const char *AIInstantSuperRechargeCommandClass::Get_UI_Name() const
+{
+    return "Instant Special Recharge (AI)";
+}
+
+const char *AIInstantSuperRechargeCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *AIInstantSuperRechargeCommandClass::Get_Description() const
+{
+    return "Toggles the instant recharge cheat for the AI player super weapons.";
+}
+
+bool AIInstantSuperRechargeCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Vinifera_Developer_AIInstantSuperRecharge = !Vinifera_Developer_AIInstantSuperRecharge;
+
+    return true;
+}

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -1141,6 +1141,44 @@ class RemoveTiberiumCommandClass : public ViniferaCommandClass
 };
 
 
+/**
+ *  Toggles the instant recharge cheat for the players super weapons.
+ */
+class InstantSuperRechargeCommandClass : public ViniferaCommandClass
+{
+    public:
+        InstantSuperRechargeCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~InstantSuperRechargeCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
+/**
+ *  Toggles the instant recharge cheat for the AI player super weapons.
+ */
+class AIInstantSuperRechargeCommandClass : public ViniferaCommandClass
+{
+    public:
+        AIInstantSuperRechargeCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~AIInstantSuperRechargeCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
 #ifndef DEBUG
 /**
  *  Based class for all new developer/debug command classes.

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -312,6 +312,12 @@ void Init_Vinifera_Commands()
 
         cmdptr = new RemoveTiberiumCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new InstantSuperRechargeCommandClass;
+        Commands.Add(cmdptr);
+
+        cmdptr = new AIInstantSuperRechargeCommandClass;
+        Commands.Add(cmdptr);
     }
 
 #ifndef NDEBUG

--- a/src/vinifera_globals.cpp
+++ b/src/vinifera_globals.cpp
@@ -37,6 +37,8 @@ char Vinifera_ScreenshotDirectory[PATH_MAX] = { "Screenshots" };
 
 bool Vinifera_Developer_InstantBuild = false;
 bool Vinifera_Developer_AIInstantBuild = false;
+bool Vinifera_Developer_InstantSuperRecharge = false;
+bool Vinifera_Developer_AIInstantSuperRecharge = false;
 bool Vinifera_Developer_BuildCheat = false;
 bool Vinifera_Developer_Unshroud = false;
 bool Vinifera_Developer_ShowCursorPosition = false;

--- a/src/vinifera_globals.h
+++ b/src/vinifera_globals.h
@@ -52,6 +52,8 @@ extern char Vinifera_ScreenshotDirectory[PATH_MAX];
  */
 extern bool Vinifera_Developer_InstantBuild;
 extern bool Vinifera_Developer_AIInstantBuild;
+extern bool Vinifera_Developer_InstantSuperRecharge;
+extern bool Vinifera_Developer_AIInstantSuperRecharge;
 extern bool Vinifera_Developer_BuildCheat;
 extern bool Vinifera_Developer_Unshroud;
 extern bool Vinifera_Developer_ShowCursorPosition;

--- a/src/vinifera_hooks.cpp
+++ b/src/vinifera_hooks.cpp
@@ -284,6 +284,8 @@ DECLARE_PATCH(_Select_Game_Clear_Globals_Patch)
      */
     Vinifera_Developer_AIInstantBuild = false;
     Vinifera_Developer_InstantBuild = false;
+    Vinifera_Developer_InstantSuperRecharge = false;
+    Vinifera_Developer_AIInstantSuperRecharge = false;
     Vinifera_Developer_BuildCheat = false;
     Vinifera_Developer_Unshroud = false;
     Vinifera_Developer_FrameStep = false;


### PR DESCRIPTION
This pull request implements two new developer mode hotkey commands.

**Instant Special Recharge (Player)**
Toggles the instant recharge cheat for the player's superweapons.

**Instant Special Recharge (AI)**
Toggles the instant recharge cheat for the AI player superweapons.