### PR TITLE
Implements CnCNet 4 UDP support. 

### DIFF
--- a/src/cncnet/cncnet4/cncnet4.cpp
+++ b/src/cncnet/cncnet4/cncnet4.cpp
@@ -56,6 +56,7 @@ bool __stdcall CnCNet4::Init()
         CnCNet4::IsEnabled = ini.Get_Bool("CnCNet4", "Enabled", CnCNet4::IsEnabled);
         ini.Get_String("CnCNet4", "Host", CnCNet4::Host, sizeof(CnCNet4::Host));
         CnCNet4::Peer2Peer = ini.Get_Bool("CnCNet4", "P2P", CnCNet4::Peer2Peer);
+        CnCNet4::UseUDP = ini.Get_Bool("CnCNet4", "UDP", CnCNet4::UseUDP);
         CnCNet4::Port = ini.Get_Int("CnCNet4", "Port", CnCNet4::Port);
     }
 

--- a/src/cncnet/cncnet4/cncnet4_globals.cpp
+++ b/src/cncnet/cncnet4/cncnet4_globals.cpp
@@ -47,4 +47,9 @@ bool CnCNet4::Peer2Peer = false;
 
 bool CnCNet4::IsDedicated = false;
 
+/**
+ *  Use the UDP interface instead of IPX?
+ */
+bool CnCNet4::UseUDP = true;
+
 struct sockaddr_in CnCNet4::Server;

--- a/src/cncnet/cncnet4/cncnet4_globals.h
+++ b/src/cncnet/cncnet4/cncnet4_globals.h
@@ -39,6 +39,7 @@ extern char Host[256];
 extern unsigned Port;
 extern bool Peer2Peer;
 extern bool IsDedicated;
+extern bool UseUDP;
 
 extern struct sockaddr_in Server;
 

--- a/src/debug/debug_hooks.cpp
+++ b/src/debug/debug_hooks.cpp
@@ -481,6 +481,13 @@ static void Debug_Print_Patch()
     Patch_Call(0x006A67FF, &Debug_Print_Warning);
     Patch_Call(0x006A6862, &Debug_Print_Warning);
     Patch_Call(0x006A68D5, &Debug_Print_Warning);
+
+    /**
+     *  Changes the RetryDelta message to be more general.
+     *  (original string "IPX Manager: RetryDelta = %d\n")
+     */
+    static const char *Network_Manager_RetryDelta = "RetryDelta = %d\n";
+    Patch_Dword(0x004F05C0+1, (uint32_t)Network_Manager_RetryDelta);
 }
 
 

--- a/src/vinifera/vinifera_hooks.cpp
+++ b/src/vinifera/vinifera_hooks.cpp
@@ -389,6 +389,11 @@ void Vinifera_Hooks()
      *  This patch allows 1 player LAN games for testing various network features.
      */
     Patch_Jump(0x00577029, 0x00577071);
+
+    /**
+     *  Allow up to 7 AI players in LAN games.
+     */
+    Patch_Byte(0x0057C97E+3, 0x07);
 #endif
 
 #ifndef NDEBUG


### PR DESCRIPTION
Closes #504

This pull request adds UDP as a protocol option when using the CnCNet 4 interface.

To enable, add the following to `SUN.INI` _(alongside the other CnCNet 4 options as mentioned in #492)_;
```
[CnCNet4]
UDP=yes
```

_**NOTE:** All players must have UDP enabled otherwise unexpected errors can occur._