### PR TITLE
Implements `DebugOnly` for Campaigns.

### DIFF
--- a/src/extensions/campaign/campaignext.cpp
+++ b/src/extensions/campaign/campaignext.cpp
@@ -44,7 +44,8 @@ ExtensionMap<CampaignClass, CampaignClassExtension> CampaignClassExtensions;
  *  @author: CCHyper
  */
 CampaignClassExtension::CampaignClassExtension(CampaignClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    IsDebugOnly(false)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("CampaignClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -173,6 +174,17 @@ bool CampaignClassExtension::Read_INI(CCINIClass &ini)
 
     if (!ini.Is_Present(ini_name)) {
         return false;
+    }
+
+    IsDebugOnly = ini.Get_Bool(ini_name, "DebugOnly", IsDebugOnly);
+
+    /**
+     *  Reload the campaign description so we can prepend the debug string.
+     */
+    if (IsDebugOnly) {
+        char buffer[128];
+        std::strncpy(buffer, ThisPtr->Description, sizeof(buffer));
+        std::snprintf(ThisPtr->Description, sizeof(ThisPtr->Description), "[Debug] - %s", buffer);
     }
     
     return true;

--- a/src/extensions/campaign/campaignext.h
+++ b/src/extensions/campaign/campaignext.h
@@ -52,7 +52,10 @@ class CampaignClassExtension final : public Extension<CampaignClass>
         bool Read_INI(CCINIClass &ini);
 
     public:
-
+        /**
+         *  Is this campaign only available in Developer mode?
+         */
+        bool IsDebugOnly;
 };
 
 

--- a/src/extensions/campaign/campaignext_init.cpp
+++ b/src/extensions/campaign/campaignext_init.cpp
@@ -201,6 +201,11 @@ DECLARE_PATCH(_CampaignClass_Read_INI_Patch)
     static CampaignClassExtension *exttype_ptr;
 
     /**
+     *  Stolen bytes here.
+     */
+    this_ptr->RequiredAddon = (AddonType)required_addon;
+
+    /**
      *  Find the extension instance.
      */
     exttype_ptr = CampaignClassExtensions.find(this_ptr);
@@ -213,12 +218,7 @@ DECLARE_PATCH(_CampaignClass_Read_INI_Patch)
      */
     exttype_ptr->Read_INI(*ini);
 
-    /**
-     *  Stolen bytes here.
-     */
 original_code:
-    this_ptr->RequiredAddon = (AddonType)required_addon;
-
     _asm { mov al, 1 }
     _asm { pop edi }
     _asm { pop ebp }


### PR DESCRIPTION
Closes #723

This pull request implements `DebugOnly` for campaigns from Red Alert 2, which adds the prefix of **"[Debug]"** to the campaign description. In addition to this, it also makes the campaign only available Developer mode.

**`[Campaign]`**
`DebugOnly=<boolean>` - _Is this campaign only available in Developer mode? Defaults to `no`._

For testing, debugging versions of the Tiberian Sun and Firestorm campaigns, download [BATTLE_DEBUG_CAMPAIGN.INI](https://github.com/Vinifera-Developers/Vinifera-Files/blob/master/files/BATTLE_DEBUG_CAMPAIGN.INI) and place it in your game install directory.
