### PR TITLE
Various bug fixes and items related to `NaturalParticleLocation`.

### DIFF
--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -35,6 +35,8 @@
 #include "building.h"
 #include "buildingtype.h"
 #include "buildingtypeext.h"
+#include "techno.h"
+#include "technoext.h"
 #include "technotype.h"
 #include "technotypeext.h"
 #include "house.h"
@@ -54,6 +56,61 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-721
+ * 
+ *  Takes over control of spawning the natural particle system when
+ *  the building is uncloaking.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Cloaking_AI_Spawn_Natural_Particle_System_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, ebp);
+    static TechnoClassExtension *technoext_ptr;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    _asm { mov [ebp+0x0F0], 0 } // this->Cloak = UNCLOAKED;
+
+    /**
+     *  Find the extension instances.
+     */
+    technoext_ptr = TechnoClassExtensions.find(this_ptr);
+    if (technoext_ptr) {
+        technoext_ptr->Spawn_Natural_Particle_System();
+    }
+
+    JMP(0x00438BE4);
+}
+
+
+/**
+ *  #issue-721
+ * 
+ *  Takes over control of spawning the natural particle system when
+ *  the building is unlimbo'd in the game world.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Unlimbo_Spawn_Natural_Particle_System_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, esi);
+    static TechnoClassExtension *technoext_ptr;
+
+    /**
+     *  Find the extension instances.
+     */
+    technoext_ptr = TechnoClassExtensions.find(this_ptr);
+    if (technoext_ptr) {
+        technoext_ptr->Spawn_Natural_Particle_System();
+    }
+
+    JMP(0x0042A80F);
+}
 
 
 /**
@@ -481,4 +538,6 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x00429A96, &_BuildingClass_AI_ProduceCash_Patch);
     Patch_Jump(0x0042F67D, &_BuildingClass_Captured_ProduceCash_Patch);
     Patch_Jump(0x0042E179, &_BuildingClass_Grand_Opening_ProduceCash_Patch);
+    Patch_Jump(0x0042A753, &_BuildingClass_Unlimbo_Spawn_Natural_Particle_System_Patch);
+    Patch_Jump(0x00438B06, &_BuildingClass_Cloaking_AI_Spawn_Natural_Particle_System_Patch);
 }

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -29,10 +29,15 @@
 #include "techno.h"
 #include "technotype.h"
 #include "technotypeext.h"
+#include "tibsun_inline.h"
+#include "tibsun_globals.h"
+#include "particlesys.h"
+#include "particlesystype.h"
 #include "house.h"
 #include "voc.h"
 #include "ebolt.h"
 #include "tactical.h"
+#include "iomap.h"
 #include "tibsun_inline.h"
 #include "wwcrc.h"
 #include "extension.h"
@@ -376,6 +381,44 @@ bool TechnoClassExtension::Can_Passive_Acquire() const
      *  IsCanPassiveAcquire defaults to true to copy original behaviour, so all units can passive acquire unless told otherwise.
      */
     return Techno_Type_Class_Ext()->IsCanPassiveAcquire;
+}
+
+
+/**
+ *  Handles the voice response when given harvest order.
+ * 
+ *  @author: CCHyper
+ */
+void TechnoClassExtension::Spawn_Natural_Particle_System()
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("TechnoClassExtension::Spawn_Natural_Particle_System - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+    
+    Coordinate where;
+
+    TechnoTypeClass *technotype = ThisPtr->Techno_Type_Class();
+    TechnoTypeClassExtension *technotypeext = TechnoTypeClassExtensions.find(technotype);
+
+    /**
+     *  Spawn NaturalParticleSystem.
+     */
+    if (!ThisPtr->ParticleSystems[ATTACHED_PARTICLE_NATURAL] && technotype->NaturalParticleSystem) {
+
+        where = ThisPtr->Get_Coord();
+
+        where.X += technotype->NaturalParticleSystemLocation.X;
+        where.Y += technotype->NaturalParticleSystemLocation.Y;
+
+        /**
+         *  #BUGFIX: The original code did not take into account the Z coord
+         *           of the NaturalParticleSystem location.
+         */
+        where.Z += technotype->NaturalParticleSystemLocation.Z;
+
+        ThisPtr->ParticleSystems[ATTACHED_PARTICLE_NATURAL] = new ParticleSystemClass(
+            technotype->NaturalParticleSystem, where, &Map[ThisPtr->Get_Coord()]
+        );
+    }
 }
 
 

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -98,6 +98,10 @@ HRESULT TechnoClassExtension::Load(IStream *pStm)
     }
 
     ElectricBolt = nullptr;
+
+	for (int index = 0; index < EXT_ATTACHED_PARTICLE_COUNT; ++index) {
+        SWIZZLE_REQUEST_POINTER_REMAP(ParticleSystems[index]);
+    }
     
     return hr;
 }
@@ -417,6 +421,38 @@ void TechnoClassExtension::Spawn_Natural_Particle_System()
 
         ThisPtr->ParticleSystems[ATTACHED_PARTICLE_NATURAL] = new ParticleSystemClass(
             technotype->NaturalParticleSystem, where, &Map[ThisPtr->Get_Coord()]
+        );
+    }
+
+    /**
+     *  Spawn NaturalParticleSystem2.
+     */
+    if (!ParticleSystems[ATTACHED_PARTICLE_NATURAL2] && technotypeext->NaturalParticleSystem2) {
+
+        where = ThisPtr->Get_Coord();
+
+        where.X += technotypeext->NaturalParticleSystemLocation2.X;
+        where.Y += technotypeext->NaturalParticleSystemLocation2.Y;
+        where.Z += technotypeext->NaturalParticleSystemLocation2.Z;
+
+        ParticleSystems[ATTACHED_PARTICLE_NATURAL2] = new ParticleSystemClass(
+            technotypeext->NaturalParticleSystem2, where, &Map[ThisPtr->Get_Coord()]
+        );
+    }
+
+    /**
+     *  Spawn NaturalParticleSystem3.
+     */
+    if (!ParticleSystems[ATTACHED_PARTICLE_NATURAL3] && technotypeext->NaturalParticleSystem3) {
+
+        where = ThisPtr->Get_Coord();
+
+        where.X += technotypeext->NaturalParticleSystemLocation3.X;
+        where.Y += technotypeext->NaturalParticleSystemLocation3.Y;
+        where.Z += technotypeext->NaturalParticleSystemLocation3.Z;
+
+        ParticleSystems[ATTACHED_PARTICLE_NATURAL3] = new ParticleSystemClass(
+            technotypeext->NaturalParticleSystem3, where, &Map[ThisPtr->Get_Coord()]
         );
     }
 }

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -63,6 +63,7 @@ class TechnoClassExtension : public RadioClassExtension
         virtual void Response_Deploy();
         virtual void Response_Harvest();
         virtual bool Can_Passive_Acquire() const;
+        void Spawn_Natural_Particle_System();
 
     private:
         const TechnoTypeClass *Techno_Type_Class() const;

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -74,4 +74,9 @@ class TechnoClassExtension : public RadioClassExtension
          *  The current electric bolt instance fired by this object.
          */
         EBoltClass *ElectricBolt;
+
+        /**
+         *  Additional attached particle system trackers for this object. 
+         */
+        ParticleSystemClass *ParticleSystems[EXT_ATTACHED_PARTICLE_COUNT];
 };

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -65,6 +65,10 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     VoiceDeploy(),
     VoiceHarvest(),
     IdleRate(0),
+    NaturalParticleSystem2(nullptr),
+    NaturalParticleSystemLocation2(0,0,0),
+    NaturalParticleSystem3(nullptr),
+    NaturalParticleSystemLocation3(0,0,0),
     CameoImageSurface(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
@@ -262,6 +266,11 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
 
     IdleRate = ini.Get_Int(ini_name, "IdleRate", IdleRate);
     IdleRate = ArtINI.Get_Int(graphic_name, "IdleRate", IdleRate);
+
+    NaturalParticleSystem2 = ini.Get_ParticleSystem(ini_name, "NaturalParticleSystem2", NaturalParticleSystem2);
+    NaturalParticleSystemLocation2 = ini.Get_Point(ini_name, "NaturalParticleLocation2", NaturalParticleSystemLocation2);
+    NaturalParticleSystem3 = ini.Get_ParticleSystem(ini_name, "NaturalParticleSystem3", NaturalParticleSystem3);
+    NaturalParticleSystemLocation3 = ini.Get_Point(ini_name, "NaturalParticleLocation3", NaturalParticleSystemLocation3);
 
     /**
      *  Fetch the cameo image surface if it exists.

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -30,6 +30,7 @@
 #include "objecttypeext.h"
 #include "technotype.h"
 #include "typelist.h"
+#include "point.h"
 #include "tibsun_defines.h"
 
 
@@ -151,4 +152,13 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
          *  Pointer to the cameo image surface.
          */
         BSurface *CameoImageSurface;
+
+        /**
+         *  These define the additional particle systems to display on the
+         *  building while it is active.
+         */
+        const ParticleSystemTypeClass *NaturalParticleSystem2;
+        TPoint3D<int> NaturalParticleSystemLocation2;
+        const ParticleSystemTypeClass *NaturalParticleSystem3;
+        TPoint3D<int> NaturalParticleSystemLocation3;
 };


### PR DESCRIPTION
Closes #721

This pull request fixes various bugs and related items with `NaturalParticleSystem`.

- Fixes a bug where the Z coordinate of `NaturalParticleLocation` was not considered when spawning `NaturalParticleSystem`.

---

In addition to these bug fixes, two more optional particle systems can be now spawned alongside `NaturalParticleSystem`, with `NaturalParticleSystem3` spawned last.

**`[TechnoType]`** _(Although the Natural particle systems only apply to BuildingTypes)_
`NaturalParticleSystem2=<ParticleSystemType>`
_The secondary particle system to spawn when this building appears in the game world. Defaults to `<none>`._

`NaturalParticleLocation2=<X,Y,Z>`
_The location to spawn the respective particle at (relative to current coordinate). Defaults to `0,0,0`._

`NaturalParticleSystem3=<ParticleSystemType>`
_The third particle system to spawn when this building appears in the game world. Defaults to `<none>`._

`NaturalParticleLocation3=<X,Y Z>`
_The location to spawn the respective particle at (relative to current coordinate). Defaults to `0,0,0`._

