### PR TITLE
Implements `IntroMovie` for Campaigns. 

### DIFF
--- a/src/extensions/campaign/campaignext.cpp
+++ b/src/extensions/campaign/campaignext.cpp
@@ -45,7 +45,8 @@ ExtensionMap<CampaignClass, CampaignClassExtension> CampaignClassExtensions;
  */
 CampaignClassExtension::CampaignClassExtension(CampaignClass *this_ptr) :
     Extension(this_ptr),
-    IsDebugOnly(false)
+    IsDebugOnly(false),
+    IntroMovie()
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("CampaignClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -187,5 +188,7 @@ bool CampaignClassExtension::Read_INI(CCINIClass &ini)
         std::snprintf(ThisPtr->Description, sizeof(ThisPtr->Description), "[Debug] - %s", buffer);
     }
     
+    ini.Get_String(ini_name, "IntroMovie", IntroMovie, sizeof(IntroMovie));
+
     return true;
 }

--- a/src/extensions/campaign/campaignext.h
+++ b/src/extensions/campaign/campaignext.h
@@ -56,6 +56,11 @@ class CampaignClassExtension final : public Extension<CampaignClass>
          *  Is this campaign only available in Developer mode?
          */
         bool IsDebugOnly;
+
+        /**
+         *  The movie to play at start of this campaign.
+         */
+        char IntroMovie[64];
 };
 
 


### PR DESCRIPTION
Closes #762

This pull request implements `IntroMovie` for campaigns, allowing customisation of the intro movie that plays before the campaign path starts.

**`[Campaign]`**
`IntroMovie=<string>` - _The intro movie name _(without the .VQA extension)_ to play at the start of the campaign? Defaults to `<none>`._

