### PR TITLE
Adds `RequiredAddon` to Theme control types.

### DIFF
--- a/src/extensions/ext_hooks.cpp
+++ b/src/extensions/ext_hooks.cpp
@@ -48,6 +48,7 @@
 #include "cdext_hooks.h"
 
 #include "playmovie_hooks.h"
+#include "themeext_hooks.h"
 
 #include "objecttypeext_hooks.h"
 #include "technotypeext_hooks.h"
@@ -163,6 +164,7 @@ void Extension_Hooks()
     CDExtension_Hooks();
 
     PlayMovieExtension_Hooks();
+    ThemeClassExtension_Hooks();
 
     /**
      *  All type class extensions here.

--- a/src/extensions/theme/themeext.cpp
+++ b/src/extensions/theme/themeext.cpp
@@ -44,7 +44,8 @@ ExtensionMap<ThemeClass::ThemeControl, ThemeControlExtension> ThemeControlExtens
  *  @author: CCHyper
  */
 ThemeControlExtension::ThemeControlExtension(ThemeClass::ThemeControl *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+    RequiredAddon(ADDON_NONE)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("ThemeControlExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
@@ -110,6 +111,8 @@ bool ThemeControlExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    RequiredAddon = (AddonType)ini.Get_Int(ini_name, "RequiredAddon", RequiredAddon);
     
     return true;
 }

--- a/src/extensions/theme/themeext.cpp
+++ b/src/extensions/theme/themeext.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          THEMEEXT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended ThemeClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "themeext.h"
+#include "theme.h"
+#include "ccini.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+
+/**
+ *  Provides the map for all ThemeControlClass extension instances.
+ */
+ExtensionMap<ThemeClass::ThemeControl, ThemeControlExtension> ThemeControlExtensions;
+
+
+/**
+ *  Class constructor.
+ *  
+ *  @author: CCHyper
+ */
+ThemeControlExtension::ThemeControlExtension(ThemeClass::ThemeControl *this_ptr) :
+    Extension(this_ptr)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("ThemeControlExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("ThemeControlExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
+
+    IsInitialized = true;
+}
+
+
+/**
+ *  Class no-init constructor.
+ *  
+ *  @author: CCHyper
+ */
+ThemeControlExtension::ThemeControlExtension(const NoInitClass &noinit) :
+    Extension(noinit)
+{
+    IsInitialized = false;
+}
+
+
+/**
+ *  Class destructor.
+ *  
+ *  @author: CCHyper
+ */
+ThemeControlExtension::~ThemeControlExtension()
+{
+    //EXT_DEBUG_TRACE("ThemeControlExtension destructor - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
+    //EXT_DEBUG_WARNING("ThemeControlExtension destructor - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
+
+    IsInitialized = false;
+}
+
+
+/**
+ *  Return the raw size of class data for save/load purposes.
+ *  
+ *  @author: CCHyper
+ */
+int ThemeControlExtension::Size_Of() const
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("ThemeControlExtension::Size_Of - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
+
+    return sizeof(*this);
+}
+
+
+/**
+ *  Fetches the extension data from the INI database.  
+ *  
+ *  @author: CCHyper
+ */
+bool ThemeControlExtension::Read_INI(CCINIClass &ini)
+{
+    ASSERT(ThisPtr != nullptr);
+    //EXT_DEBUG_TRACE("ThemeControlExtension::Read_INI - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
+    EXT_DEBUG_WARNING("ThemeControlExtension::Read_INI - Name: %s (0x%08X)\n", ThisPtr->Name, (uintptr_t)(ThisPtr));
+
+    const char *ini_name = ThisPtr->Name;
+
+    if (!ini.Is_Present(ini_name)) {
+        return false;
+    }
+    
+    return true;
+}

--- a/src/extensions/theme/themeext.h
+++ b/src/extensions/theme/themeext.h
@@ -47,6 +47,10 @@ class ThemeControlExtension final : public Extension<ThemeClass::ThemeControl>
         bool Read_INI(CCINIClass &ini);
 
     public:
+        /**
+         *  The addon required to be active for this theme to be available.
+         */
+        AddonType RequiredAddon;
 };
 
 

--- a/src/extensions/theme/themeext.h
+++ b/src/extensions/theme/themeext.h
@@ -1,0 +1,53 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          THEMEEXT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Extended ThemeClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "extension.h"
+#include "container.h"
+#include "theme.h"
+
+
+class CCINIClass;
+
+
+class ThemeControlExtension final : public Extension<ThemeClass::ThemeControl>
+{
+    public:
+        ThemeControlExtension(ThemeClass::ThemeControl *this_ptr);
+        ThemeControlExtension(const NoInitClass &noinit);
+        ~ThemeControlExtension();
+
+        virtual int Size_Of() const override;
+
+        bool Read_INI(CCINIClass &ini);
+
+    public:
+};
+
+
+extern ExtensionMap<ThemeClass::ThemeControl, ThemeControlExtension> ThemeControlExtensions;

--- a/src/extensions/theme/themeext_hooks.cpp
+++ b/src/extensions/theme/themeext_hooks.cpp
@@ -34,6 +34,7 @@
 #include "housetype.h"
 #include "session.h"
 #include "scenario.h"
+#include "addon.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -81,6 +82,20 @@ bool ThemeClassFake::_Is_Allowed(ThemeType index) const
      */
     if (!Themes[index]->Normal) {
         return false;
+    }
+
+    /**
+     *  #issue-764
+     * 
+     *  If this theme requires an addon, make sure that addon is active.
+     * 
+     *  @author: CCHyper
+     */
+    ThemeControlExtension *themectrlext = ThemeControlExtensions.find(Themes[index]);
+    if (themectrlext && themectrlext->RequiredAddon != ADDON_NONE) {
+        if (!Addon_Enabled(themectrlext->RequiredAddon)) {
+            return false;
+        }
     }
 
     /**

--- a/src/extensions/theme/themeext_hooks.cpp
+++ b/src/extensions/theme/themeext_hooks.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          THEMEEXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended ThemeClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "themeext_hooks.h"
+#include "themeext_init.h"
+#include "themeext.h"
+#include "theme.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void ThemeClassExtension_Hooks()
+{
+    /**
+     *  Initialises the extended class.
+     */
+    ThemeClassExtension_Init();
+}

--- a/src/extensions/theme/themeext_hooks.h
+++ b/src/extensions/theme/themeext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          THEMEEXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended ThemeClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void ThemeClassExtension_Hooks();

--- a/src/extensions/theme/themeext_init.cpp
+++ b/src/extensions/theme/themeext_init.cpp
@@ -1,0 +1,139 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          THEMEEXT_INIT.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended ThemeClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "themeext_hooks.h"
+#include "themeext.h"
+#include "theme.h"
+#include "tibsun_globals.h"
+#include "vinifera_util.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_ThemeClass_ThemeControl_Constructor_Patch)
+{
+    GET_REGISTER_STATIC(ThemeClass::ThemeControl *, this_ptr, eax); // "this" pointer.
+    static ThemeControlExtension *exttype_ptr;
+
+    //EXT_DEBUG_WARNING("Creating ThemeClass_ThemeControlExtension.\n");
+
+    /**
+     *  Find existing or create an extended class instance.
+     */
+    exttype_ptr = ThemeControlExtensions.find_or_create(this_ptr);
+    if (!exttype_ptr) {
+        DEBUG_ERROR("Failed to create ThemeControlExtension instance!\n");
+        ShowCursor(TRUE);
+        MessageBoxA(MainWindow, "Failed to create ThemeControlExtension instance!\n", "Vinifera", MB_OK|MB_ICONEXCLAMATION);
+        Vinifera_Generate_Mini_Dump();
+        Fatal("Failed to create ThemeControlExtension instance!\n");
+        goto original_code; // Keep this for clean code analysis.
+    }
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov eax, this_ptr }
+    _asm { ret }
+}
+
+
+/**
+ *  This patch replaces a inlined copy of the constructor with a call to the constructor.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_ThemeClass_ThemeControl_Inlined_Constructor_Patch)
+{
+    _asm { mov ecx, eax }
+    _asm { mov eax, 0x006439B0 } // ThemeClass::ThemeControl::ThemeControl()
+    _asm { call eax }
+
+    _asm { mov ebp, eax } // ebp = "this".
+
+    JMP(0x00643B7C);
+}
+
+
+/**
+ *  Patch for reading the extended class members from the ini instance.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_ThemeClass_ThemeControl_Read_INI_Patch)
+{
+    GET_REGISTER_STATIC(ThemeClass::ThemeControl *, this_ptr, esi);
+    GET_REGISTER_STATIC(CCINIClass *, ini, edi);
+    static ThemeControlExtension *exttype_ptr;
+
+    /**
+     *  Find the extension instance.
+     */
+    exttype_ptr = ThemeControlExtensions.find(this_ptr);
+    if (!exttype_ptr) {
+        goto original_code;
+    }
+
+    /**
+     *  Read type class ini.
+     */
+    exttype_ptr->Read_INI(*ini);
+
+    /**
+     *  Stolen bytes here.
+     */
+original_code:
+    _asm { mov al, 1 }
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { ret 4 }
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void ThemeClassExtension_Init()
+{
+    Patch_Jump(0x006439E5, &_ThemeClass_ThemeControl_Constructor_Patch);
+    Patch_Jump(0x00643B45, &_ThemeClass_ThemeControl_Inlined_Constructor_Patch);
+    //Patch_Jump(0x, &_ThemeClass_ThemeControl_Destructor_Patch); // No destructor to hook, extension should clean up on exit.
+    Patch_Jump(0x00643AAB, &_ThemeClass_ThemeControl_Read_INI_Patch);
+}

--- a/src/extensions/theme/themeext_init.h
+++ b/src/extensions/theme/themeext_init.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          THEMEEXT_INIT.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for initialising the extended ThemeClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void ThemeClassExtension_Init();


### PR DESCRIPTION
Closes #764

This pull request adds `RequiredAddon` to Theme control types, allowing new and existing themes to be limited to a specific addon _(i.e, Firestorm)_.

**`[ThemeType]`**
`RequiredAddon=<AddonType>` - _The addon required to be active for this theme to be available. Currently, only `1` (Firestorm) is supported. Defaults to `0` (none)._