### PR TITLE
Improves the harvester AI.

### DIFF
--- a/src/extensions/foot/footext_functions.cpp
+++ b/src/extensions/foot/footext_functions.cpp
@@ -1,0 +1,149 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          FOOTEXT_FUNCTIONS.CPP
+ *
+ *  @author        Rampastring
+ *
+ *  @brief         Contains the supporting functions for the extended FootClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "footext_functions.h"
+#include "unitext_functions.h"
+#include "unit.h"
+#include "unittype.h"
+#include "unitext.h"
+#include "building.h"
+#include "buildingtype.h"
+#include "cell.h"
+#include "map.h"
+#include "mouse.h"
+#include "house.h"
+#include "technotype.h"
+#include "rulesext.h"
+#include "session.h"
+#include "tibsun_inline.h"
+#include "vinifera_globals.h"
+#include "tibsun_globals.h"
+#include "tibsun_functions.h"
+#include "tibsun_defines.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+
+
+void _Vinifera_FootClass_Search_For_Tiberium_Check_Tiberium_Value_Of_Cell(FootClass* this_ptr, Cell& cell_coords, Cell* besttiberiumcell, int* besttiberiumvalue, UnitClassExtension* unitext)
+{
+    if (this_ptr->Tiberium_Check(cell_coords)) {
+
+        CellClass* cell = &Map[cell_coords];
+        int tiberiumvalue = cell->Get_Tiberium_Value();
+
+        /**
+        *  #issue-203
+        *
+        *  Consider distance to refinery when selecting the next tiberium patch to harvest.
+        *  Prefer the most resourceful tiberium patch, but if there's a tie, prefer one that's
+        *  closer to our refinery.
+        *
+        *  @author: Rampastring
+        */
+        if (unitext && unitext->LastDockedBuilding && unitext->LastDockedBuilding->IsActive && !unitext->LastDockedBuilding->IsInLimbo) {
+            tiberiumvalue *= 100;
+            tiberiumvalue -= ::Distance(cell_coords, unitext->LastDockedBuilding->Get_Cell());
+        }
+
+        if (tiberiumvalue > * besttiberiumvalue)
+        {
+            *besttiberiumvalue = tiberiumvalue;
+            *besttiberiumcell = cell_coords;
+        }
+    }
+}
+
+
+/**
+ *  Smarter replacement for the Search_For_Tiberium method.
+ *  Makes harvesters consider the distance to their refinery when
+ *  looking for the cell of tiberium to harvest.
+ *
+ *  @author: Rampastring
+ */
+Cell Vinifera_FootClass_Search_For_Tiberium(FootClass* this_ptr, int rad, bool a2)
+{
+    if (!this_ptr->Owning_House()->Is_Human_Control() &&
+        this_ptr->What_Am_I() == RTTI_UNIT &&
+        ((UnitClass*)this_ptr)->Class->IsToHarvest &&
+        a2 &&
+        Session.Type != GAME_NORMAL)
+    {
+        /**
+         *  Use weighted tiberium-seeking algorithm for AI in multiplayer.
+         */
+
+        return this_ptr->Search_For_Tiberium_Weighted(rad);
+    }
+
+    Coordinate center_coord = this_ptr->Center_Coord();
+    Cell cell_coords = Coord_Cell(center_coord);
+    Cell unit_cell_coords = cell_coords;
+
+    if (Map[unit_cell_coords].Land_Type() == LAND_TIBERIUM) {
+
+        /**
+         *  If we're already standing on tiberium, then we don't need to move anywhere.
+         */
+
+        return unit_cell_coords;
+    }
+
+    int besttiberiumvalue = -1;
+    Cell besttiberiumcell = Cell(0, 0);
+
+    UnitClassExtension* unitext = nullptr;
+    if (this_ptr->What_Am_I() == RTTI_UNIT) {
+        unitext = UnitClassExtensions.find((UnitClass*)this_ptr);
+    }
+
+    /**
+     *  Perform a ring search outward from the center.
+     */
+    for (int radius = 1; radius < rad; radius++) {
+        for (int x = -radius; x <= radius; x++) {
+
+            cell_coords = Cell(unit_cell_coords.X + x, unit_cell_coords.Y - radius);
+            _Vinifera_FootClass_Search_For_Tiberium_Check_Tiberium_Value_Of_Cell(this_ptr, cell_coords, &besttiberiumcell, &besttiberiumvalue, unitext);
+
+            cell_coords = Cell(unit_cell_coords.X + x, unit_cell_coords.Y + radius);
+            _Vinifera_FootClass_Search_For_Tiberium_Check_Tiberium_Value_Of_Cell(this_ptr, cell_coords, &besttiberiumcell, &besttiberiumvalue, unitext);
+
+            cell_coords = Cell(unit_cell_coords.X - radius, unit_cell_coords.Y + x);
+            _Vinifera_FootClass_Search_For_Tiberium_Check_Tiberium_Value_Of_Cell(this_ptr, cell_coords, &besttiberiumcell, &besttiberiumvalue, unitext);
+
+            cell_coords = Cell(unit_cell_coords.X + radius, unit_cell_coords.Y + x);
+            _Vinifera_FootClass_Search_For_Tiberium_Check_Tiberium_Value_Of_Cell(this_ptr, cell_coords, &besttiberiumcell, &besttiberiumvalue, unitext);
+        }
+
+        if (besttiberiumvalue != -1)
+            break;
+    }
+
+    return besttiberiumcell;
+}

--- a/src/extensions/foot/footext_functions.h
+++ b/src/extensions/foot/footext_functions.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          UNITEXT.H
+ *  @file          FOOTEXT_FUNCTIONS.H
  *
- *  @author        CCHyper
+ *  @author        Rampastring
  *
- *  @brief         Extended UnitClass class.
+ *  @brief         Contains the supporting functions for the extended UnitClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,39 +27,10 @@
  ******************************************************************************/
 #pragma once
 
-#include "extension.h"
-#include "container.h"
+#include "always.h"
+#include "foot.h"
+#include "tibsun_defines.h"
 
+class FootClass;
 
-class UnitClass;
-class HouseClass;
-
-
-class UnitClassExtension final : public Extension<UnitClass>
-{
-    public:
-        UnitClassExtension(UnitClass *this_ptr);
-        UnitClassExtension(const NoInitClass &noinit);
-        ~UnitClassExtension();
-
-        virtual HRESULT Load(IStream *pStm) override;
-        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
-        virtual int Size_Of() const override;
-
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
-
-    public:
-
-        /**
-         *  #issue-203
-         *
-         *  The building that this unit last docked with.
-         *  Used by harvesters for considering the distance to their last refinery
-         *  when picking a tiberium cell to harvest from.
-         */
-        BuildingClass* LastDockedBuilding;
-};
-
-
-extern ExtensionMap<UnitClass, UnitClassExtension> UnitClassExtensions;
+Cell Vinifera_FootClass_Search_For_Tiberium(FootClass* this_ptr, int rad, bool a2);

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -48,7 +48,9 @@ RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
     IsMPAutoDeployMCV(false),
     IsMPPrePlacedConYards(false),
     IsBuildOffAlly(true),
-    IsShowSuperWeaponTimers(true)
+    IsShowSuperWeaponTimers(true),
+    MaxFreeRefineryDistanceBias(16),
+    MinHarvesterQueueJumpDistance(7)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("RulesClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -186,6 +188,8 @@ void RulesClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(IsMPPrePlacedConYards);
     crc(IsBuildOffAlly);
     crc(IsShowSuperWeaponTimers);
+    crc(MaxFreeRefineryDistanceBias);
+    crc(MinHarvesterQueueJumpDistance);
 }
 
 
@@ -290,6 +294,9 @@ bool RulesClassExtension::General(CCINIClass &ini)
     if (!ini.Is_Present(GENERAL)) {
         return false;
     }
+
+    MaxFreeRefineryDistanceBias = ini.Get_Int(GENERAL, "MaxFreeRefineryDistanceBias", MaxFreeRefineryDistanceBias);
+    MinHarvesterQueueJumpDistance = ini.Get_Int(GENERAL, "MinHarvesterQueueJumpDistance", MinHarvesterQueueJumpDistance);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -110,6 +110,21 @@ class RulesClassExtension final : public Extension<RulesClass>
          *  on the tactical view?
          */
         bool IsShowSuperWeaponTimers;
+
+        /**
+         *  When looking for refineries, harvesters will prefer a distant free
+         *  refinery over a closer occupied refinery if the refineries' distance
+         *  difference in cells is less than this.
+         */
+        int MaxFreeRefineryDistanceBias;
+
+        /**
+         *  If a refinery is already occupied by a returning harvester and another
+         *  harvester is also looking to dock, allow the new harvester to take over
+         *  the refinery if the difference in distance to the refinery between
+         *  the existing harvester and the new harvester is at least this many cells.
+         */
+        int MinHarvesterQueueJumpDistance;
 };
 
 

--- a/src/extensions/unit/unitext.cpp
+++ b/src/extensions/unit/unitext.cpp
@@ -27,6 +27,7 @@
  ******************************************************************************/
 #include "unitext.h"
 #include "unit.h"
+#include "building.h"
 #include "wwcrc.h"
 #include "asserthandler.h"
 #include "debughandler.h"
@@ -44,7 +45,9 @@ ExtensionMap<UnitClass, UnitClassExtension> UnitClassExtensions;
  *  @author: CCHyper
  */
 UnitClassExtension::UnitClassExtension(UnitClass *this_ptr) :
-    Extension(this_ptr)
+    Extension(this_ptr),
+
+    LastDockedBuilding(nullptr)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("UnitClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -97,6 +100,8 @@ HRESULT UnitClassExtension::Load(IStream *pStm)
 
     new (this) UnitClassExtension(NoInitClass());
     
+    SWIZZLE_REQUEST_POINTER_REMAP(LastDockedBuilding);
+
     return hr;
 }
 
@@ -155,4 +160,6 @@ void UnitClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("UnitClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
+
+    crc(LastDockedBuilding != nullptr ? LastDockedBuilding->Fetch_ID() : 0);
 }

--- a/src/extensions/unit/unitext_functions.cpp
+++ b/src/extensions/unit/unitext_functions.cpp
@@ -1,0 +1,81 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          UNITEXT_FUNCTIONS.CPP
+ *
+ *  @author        Rampastring
+ *
+ *  @brief         Contains the supporting functions for the extended UnitClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "unitext_functions.h"
+#include "unit.h"
+#include "unittype.h"
+#include "building.h"
+#include "buildingtype.h"
+#include "technotype.h"
+#include "rulesext.h"
+#include "tibsun_inline.h"
+#include "vinifera_globals.h"
+#include "tibsun_globals.h"
+#include "tibsun_functions.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+
+ /**
+  *  Finds the nearest docking bay for a specific unit.
+  *
+  *  @author: Rampastring
+  */
+void UnitClassExtension_Find_Nearest_Refinery(UnitClass* this_ptr, BuildingClass** building_addr, int* distance_addr, bool include_reserved)
+{
+    int nearest_refinery_distance = INT_MAX;
+    BuildingClass* nearest_refinery = nullptr;
+
+    /**
+     *  Find_Docking_Bay looks also through occupied docking bays if ScenarioInit is set
+     */
+    if (include_reserved) {
+        ScenarioInit++;
+    }
+
+    for (int i = 0; i < this_ptr->Class->Dock.Count(); i++) {
+        BuildingTypeClass* dockbuildingtype = this_ptr->Class->Dock[i];
+
+        BuildingClass* dockbuilding = this_ptr->Find_Docking_Bay(dockbuildingtype, false, false);
+        if (dockbuilding == nullptr)
+            continue;
+
+        int distance = this_ptr->Distance(dockbuilding);
+
+        if (distance < nearest_refinery_distance) {
+            nearest_refinery_distance = distance;
+            nearest_refinery = dockbuilding;
+        }
+    }
+
+    if (include_reserved) {
+        ScenarioInit--;
+    }
+
+    *building_addr = nearest_refinery;
+    *distance_addr = nearest_refinery_distance;
+}

--- a/src/extensions/unit/unitext_functions.h
+++ b/src/extensions/unit/unitext_functions.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          UNITEXT.H
+ *  @file          UNITEXT_FUNCTIONS.H
  *
- *  @author        CCHyper
+ *  @author        Rampastring
  *
- *  @brief         Extended UnitClass class.
+ *  @brief         Contains the supporting functions for the extended UnitClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,39 +27,11 @@
  ******************************************************************************/
 #pragma once
 
-#include "extension.h"
-#include "container.h"
+#include "always.h"
+#include "building.h"
 
 
 class UnitClass;
-class HouseClass;
 
 
-class UnitClassExtension final : public Extension<UnitClass>
-{
-    public:
-        UnitClassExtension(UnitClass *this_ptr);
-        UnitClassExtension(const NoInitClass &noinit);
-        ~UnitClassExtension();
-
-        virtual HRESULT Load(IStream *pStm) override;
-        virtual HRESULT Save(IStream *pStm, BOOL fClearDirty) override;
-        virtual int Size_Of() const override;
-
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
-
-    public:
-
-        /**
-         *  #issue-203
-         *
-         *  The building that this unit last docked with.
-         *  Used by harvesters for considering the distance to their last refinery
-         *  when picking a tiberium cell to harvest from.
-         */
-        BuildingClass* LastDockedBuilding;
-};
-
-
-extern ExtensionMap<UnitClass, UnitClassExtension> UnitClassExtensions;
+void UnitClassExtension_Find_Nearest_Refinery(UnitClass* this_ptr, BuildingClass** building_addr, int* distance_addr, bool include_reserved = false);


### PR DESCRIPTION
Closes #201, Closes #202, Closes #203

**NOTE** This implementation has been noted to cause sync errors when manually ordering harvesters to enter refineries. I'll fix the implementation later.

This pull request implements 3 features to significantly improve the harvester AI:

- The harvester's refinery-seeking algorithm now considers both free refineries and occupied refineries when figuring out which refinery to unload at. If the closest occupied refinery is much closer to the harvester than the closest free refinery, the harvester queues for the occipied refinery instead of going for the free refinery.

- If a refinery is reserved for a harvester that is far away and a nearby harvester is seeking for a refinery to unload to, the nearby harvester takes the far-away harvester's place in the refinery queue. This feature is also known as "queue jumping" as coined by cfehunter in his mod for TD Remastered that he has since taken down.

- In vanilla TS, harvesters always go for the northernmost tiberium patch if there is one. This means that on some starting locations, harvesters tend to move just further and further away from your refinery as they harvest, because on each cycle they just go further and further to the north. On other starting locations this behaviour, on the other hand, is usually beneficial (if your refineries are to the north of a tiberium field). This creates a bad imbalance for most maps. Instead of having fixed preferred directions for the tiberium-seeking algorithm, harvesters now pick the most valuable patch that's also closest to their last refinery. This keeps the resources flowing faster, keeps your harvesters safe and levels the playing field between different starting locations.

These features are also explained in the following issues:

https://github.com/Vinifera-Developers/Vinifera/issues/201
https://github.com/Vinifera-Developers/Vinifera/issues/202
https://github.com/Vinifera-Developers/Vinifera/issues/203

### Rules.ini settings

To allow customizing the behaviour of these features, this PR adds the following Rules.ini keys, section `[General]`:

```ini
; When looking for refineries, harvesters will prefer a distant free
; refinery over a closer occupied refinery if the refineries' distance
; difference in cells is less than this.
MaxFreeRefineryDistanceBias=<int> ; defaults to 16

; If a refinery is already occupied by a returning harvester and another
; harvester is also looking to dock, allow the new harvester to take over
; the refinery if the difference in distance to the refinery between
; the existing harvester and the new harvester is at least this many cells.
MinHarvesterQueueJumpDistance=<int> ; defaults to 7
```