### PR TITLE
Adds the "Underground" layer to the tactical display Next and Prev search.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -140,6 +140,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement `StopSound` for `AnimTypes` and `VoxelAnimTypes`.
   - Implement 'OmniFire' for WeaponTypes.
   - Implement MeteorShowerCommandClass and MeteorImpactCommandClass.
+  - Add the "Underground" layer to the tactical display Next and Prev search.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -69,3 +69,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where it was impossible to tell infantry to enter cloaked allied transports.
 - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building.
 - Fix a crash when a Jumpjet infantry is flying or trying to take off just when an Ion Storm starts.
+- Add the "Underground" layer to the tactical display Next and Prev search.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -265,6 +265,7 @@ Vanilla fixes:
 - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building (by ZivDero)
 - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now have the building display Special animations (by ZivDero)
 - Allow customizing "Missile Launched" voice per super weapon (by ZivDero)
+- Add the "Underground" layer to the tactical display Next and Prev search (by CCHyper)
 
 :::
 

--- a/src/extensions/display/displayext_hooks.cpp
+++ b/src/extensions/display/displayext_hooks.cpp
@@ -80,6 +80,14 @@ class DisplayClassExt final : public DisplayClass
 ObjectClass * DisplayClassExt::_Next_Object(ObjectClass * object) const
 {
     static const LayerType _layers[] = {
+        
+        /**
+         *  #issue-785
+         * 
+         *  Adds underground layer to display search.
+         */
+        LAYER_UNDERGROUND,
+
         LAYER_GROUND, LAYER_AIR, LAYER_TOP,
     };
 
@@ -121,6 +129,13 @@ ObjectClass * DisplayClassExt::_Prev_Object(ObjectClass * object)  const
 {
     static const LayerType _layers[] = {
         LAYER_TOP, LAYER_AIR, LAYER_GROUND,
+
+        /**
+         *  #issue-785
+         * 
+         *  Adds underground layer to display search.
+         */
+        LAYER_UNDERGROUND,
     };
 
     ObjectClass * firstobj = nullptr;

--- a/src/extensions/display/displayext_hooks.cpp
+++ b/src/extensions/display/displayext_hooks.cpp
@@ -97,7 +97,7 @@ ObjectClass * DisplayClassExt::_Next_Object(ObjectClass * object) const
     if (object == nullptr) {
         foundmatch = true;
     }
-    for (int index = 0; index < ARRAY_SIZE(_layers); ++index) {
+    for (int index = 0; index < std::size(_layers); ++index) {
         LayerType layer = _layers[index];
 
         for (unsigned uindex = 0; uindex < (unsigned)Layer[layer].Count(); uindex++) {
@@ -144,7 +144,7 @@ ObjectClass * DisplayClassExt::_Prev_Object(ObjectClass * object)  const
     if (object == nullptr) {
         foundmatch = true;
     }
-    for (int index = 0; index < ARRAY_SIZE(_layers); ++index) {
+    for (int index = 0; index < std::size(_layers); ++index) {
         LayerType layer = _layers[index];
 
         for (int uindex = Layer[layer].Count()-1; uindex >= 0; uindex--) {


### PR DESCRIPTION
Closes #785

This pull request adds the Underground layer to the tactical display Next and Prev search, allowing units that are currently underground to be included.

