### PR TITLE
Implements `RadarColor` for TerrainTypes.

### DIFF
--- a/src/extensions/terraintype/terraintypeext.cpp
+++ b/src/extensions/terraintype/terraintypeext.cpp
@@ -188,6 +188,13 @@ bool TerrainTypeClassExtension::Read_INI(CCINIClass &ini)
 
     const char *ini_name = Name();
 
+    /**
+     *  #issue-570
+     * 
+     *  Implements RadarColor reading support to TerrainTypes.
+     */
+    ThisPtr->RadarColor = ini.Get_RGB(ini_name, "RadarColor", ThisPtr->RadarColor);
+
     IsLightEnabled = ini.Get_Bool(ini_name, "IsLightEnabled", IsLightEnabled);
     LightVisibility = ini.Get_Int(ini_name, "LightVisibility", LightVisibility);
     LightIntensity = ini.Get_Double(ini_name, "LightIntensity", (LightIntensity / 1000)) * 1000.0 + 0.1;


### PR DESCRIPTION
Closes #570 

This pull request implements `RadarColor` for TerrainTypes.

The game already has a system in place the override the radar colour, which is initialised to the color value from the shapefile itself, but did not have the required INI loading code for the override to work.

**`[TerrainType]`**
`RadarColor=<R,G,B>`
_The pixel color that represents this terrain object on the radar. Defaults to the value defined in the shape file frame header._