### PR TITLE
Implements `NumberOfDocks` and `DockingOffset#` for BuildingTypes.

### DIFF
--- a/src/extensions/building/buildingext.cpp
+++ b/src/extensions/building/buildingext.cpp
@@ -29,6 +29,7 @@
 #include "building.h"
 #include "buildingtype.h"
 #include "buildingtypeext.h"
+#include "tibsun_inline.h"
 #include "house.h"
 #include "housetype.h"
 #include "wwcrc.h"
@@ -178,6 +179,7 @@ void BuildingClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(ProduceCashTimer());
 }
 
+
 /**
  *  #issue-26
  * 
@@ -290,4 +292,48 @@ void BuildingClassExtension::Produce_Cash_AI()
 
     }
 
+}
+
+
+/**
+ *  Fetches the coordinate to use for docking.
+ *  
+ *  @author: CCHyper
+ */
+Coordinate BuildingClassExtension::Docking_Coord() const
+{
+    //EXT_DEBUG_TRACE("BuildingClassExtension::Docking_Coord - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    Coordinate coord = This()->Center_Coord();
+
+    /**
+     *  #issue-786
+     * 
+     *  Implements DockingOffset for BuildingTypes (currently limited to Helipads and Refinerys).
+     *  
+     *  @author: CCHyper
+     */
+    BuildingTypeClassExtension *buildingtypeext = Extension::Fetch<BuildingTypeClassExtension>(This()->Class);
+
+    if (buildingtypeext->NumberOfDocks > 0) {
+
+        if (This()->Class->IsRefinery || This()->Class->IsWeeder) {
+            TPoint3D<int> docking_offset = buildingtypeext->DockingOffsets[0];
+            coord.X += docking_offset.X;
+            coord.Y += docking_offset.Y;
+            coord.Z += docking_offset.Z;
+            return coord;
+        }
+
+        if (This()->Class->IsHelipad) {
+            TPoint3D<int> docking_offset = buildingtypeext->DockingOffsets[0];
+            coord.X += docking_offset.X;
+            coord.Y += docking_offset.Y;
+            coord.Z += docking_offset.Z;
+            return coord;
+        }
+
+    }
+
+    return coord;
 }

--- a/src/extensions/building/buildingext.h
+++ b/src/extensions/building/buildingext.h
@@ -66,6 +66,7 @@ BuildingClassExtension final : public TechnoClassExtension
         virtual RTTIType What_Am_I() const override { return RTTI_BUILDING; }
 
         void Produce_Cash_AI();
+        Coordinate Docking_Coord() const;
 
     public:
         /**

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -60,6 +60,32 @@
 
 
 /**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or destructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+class BuildingClassExt final : public BuildingClass
+{
+    public:
+        Coordinate _Docking_Coord() const;
+};
+
+
+/**
+ *  Reimplementation of BuildingClass::Docking_Coord.
+ * 
+ *  @author: CCHyper
+ */
+Coordinate BuildingClassExt::_Docking_Coord() const
+{
+    BuildingClassExtension *buildingext = Extension::Fetch<BuildingClassExtension>(this);
+    return buildingext->Docking_Coord();
+}
+
+
+/**
  *  #issue-204
  * 
  *  Implements ReloadRate for AircraftTypes, allowing each aircraft to have
@@ -514,4 +540,5 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x0042E179, &_BuildingClass_Grand_Opening_ProduceCash_Patch);
     Patch_Jump(0x004325F9, &_BuildingClass_Mission_Repair_ReloadRate_Patch);
     Patch_Jump(0x0043266C, &_BuildingClass_Mission_Repair_ReloadRate_Patch);
+    Patch_Dword(0x006CC3A0, Get_Func_Address(&BuildingClassExt::_Docking_Coord));
 }

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -106,4 +106,14 @@ BuildingTypeClassExtension final : public TechnoTypeClassExtension
          *  Is this building eligible for proximity checks by players who are its owner's allies?
          */
         bool IsEligibleForAllyBuilding;
+
+        /**
+         *  The number of available docking positions this building has.
+         */
+        unsigned NumberOfDocks;
+
+        /**
+         *  The offset(s) from the center of the building for each docking position.
+         */
+        DynamicVectorClass<TPoint3D<int>> DockingOffsets;
 };


### PR DESCRIPTION
Closes #786 

This pull request implements `NumberOfDocks` and `DockingOffset#` for BuildingTypes.

_**NOTE1:** This feature currently only applies to the following BuildingTypes;_
_- Structures with `Helipad=yes`, where `DockingOffset0` adjusts the docking position for aircraft. A `NumberOfDocks` value greater than `1` has no additional effect at this time._
_- Structures with `Refinery=yes` or `Weeder=yes`, where `DockingOffset0` adjusts the docking position for the harvester. A `NumberOfDocks` value greater than `1` has no additional effect._

_**NOTE2:** The default docking coord is offset from the center of the building for the following BuildingTypes;_
_- `Refinery=yes` is offset by 128 leptons on the x-axis._
_- `Weeder=yes` is offset by 512 leptons on the x-axis, and 256 leptons on the y-axis_

****
`[BuildingType]` (`RULES.INI`)
`NumberOfDocks=<integer>` - The number of docking locations this building has. Defaults to `1` for buildings with `Helipad=yes`, and `0` for all other buildings.

`[Image]` (`ART.INI`)
`DockingOffset#=<X,Y,Z>` - The coord offset from the center of the building for the respective docking location. This list must contain the same number of entries as defined by `NumberOfDocks`, with `#` being replaced by the docking position starting from zero. Each entry defaults to `0,0,0`.