### PR TITLE
Implements naval factory and unit support.

### DIFF
--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -58,6 +58,45 @@
 /**
  *  #issue-531
  * 
+ *  This patch allows buildings with the IsNavalYard property to be assigned
+ *  as "Primary" seperate from other UnitType factories.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_BuildingClass_Toggle_Primary_NavalYard_Check_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(BuildingClass *, building, eax);
+    static BuildingTypeClassExtension *this_buildingtypeext;
+    static BuildingTypeClassExtension *i_buildingtypeext;
+
+    /**
+     *  Find the type class extension instance.
+     */
+    this_buildingtypeext = BuildingTypeClassExtensions.find(this_ptr->Class);
+    i_buildingtypeext = BuildingTypeClassExtensions.find(building->Class);
+
+    /**
+     *  If we found another naval yard, remove its leadership status so we can
+     *  assign it to ourself.
+     */
+    if (this_buildingtypeext && i_buildingtypeext
+     && this_buildingtypeext->IsNavalYard && i_buildingtypeext->IsNavalYard) {
+
+        building->IsLeader = false;
+
+    } else {
+        building->IsLeader = false;
+    }
+
+continue_loop:
+    JMP(0x0042F61A);
+}
+
+
+/**
+ *  #issue-531
+ * 
  *  This patch allows buildings with the IsNavalYard property to place rally
  *  points on water rather than on land.
  * 
@@ -552,4 +591,5 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x0042F67D, &_BuildingClass_Captured_ProduceCash_Patch);
     Patch_Jump(0x0042E179, &_BuildingClass_Grand_Opening_ProduceCash_Patch);
     Patch_Jump(0x0042C37F, &_BuildingClass_Set_Rally_To_Point_NavalYard_Check_Patch);
+    Patch_Jump(0x0042F614, &_BuildingClass_Toggle_Primary_NavalYard_Check_Patch);
 }

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -54,7 +54,8 @@ BuildingTypeClassExtension::BuildingTypeClassExtension(BuildingTypeClass *this_p
     ProduceCashBudget(0),
     IsStartupCashOneTime(false),
     IsResetBudgetOnCapture(false),
-    IsEligibleForAllyBuilding(false)
+    IsEligibleForAllyBuilding(false),
+    IsNavalYard(false)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("BuildingTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -167,6 +168,7 @@ void BuildingTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     //EXT_DEBUG_TRACE("BuildingTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
 
     crc(IsEligibleForAllyBuilding);
+    crc(IsNavalYard);
 }
 
 
@@ -200,5 +202,7 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
     IsEligibleForAllyBuilding = ini.Get_Bool(ini_name, "EligibleForAllyBuilding",
                                                     ThisPtr->IsConstructionYard ? true : IsEligibleForAllyBuilding);
     
+    IsNavalYard = ini.Get_Bool(ini_name, "Shipyard", IsNavalYard);
+
     return true;
 }

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -83,7 +83,7 @@ class BuildingTypeClassExtension final : public Extension<BuildingTypeClass>
         unsigned ProduceCashBudget;
         
         /**
-         *  Is the capture bonus a "one one" special (further captures will not get the bonus)?
+         *  Is the capture bonus a "one off" special (further captures will not get the bonus)?
          */
         bool IsStartupCashOneTime;
         
@@ -96,6 +96,15 @@ class BuildingTypeClassExtension final : public Extension<BuildingTypeClass>
          *  Is this building eligible for proximity checks by players who are its owner's allies?
          */
         bool IsEligibleForAllyBuilding;
+
+        /**
+         *  Is this building a factory that is placed on water and produces vessels (i.e. ships)?
+         * 
+         *  #NOTE: This is a temporary property that is used to enforce special rules to
+         *         allow better naval and shipyard support until a full Vessel class is hooked
+         *         up and implemented.
+         */
+        bool IsNavalYard;
 };
 
 

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -50,7 +50,8 @@ RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
     IsMPPrePlacedConYards(false),
     IsBuildOffAlly(true),
     IsShowSuperWeaponTimers(true),
-    BuildNavalYard()
+    BuildNavalYard(),
+    AINavalYardAdjacency(20)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("RulesClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -180,6 +181,9 @@ void RulesClassExtension::Detach(TARGET target, bool all)
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("RulesClassExtension::Size_Of - 0x%08X\n", (uintptr_t)(ThisPtr));
 
+    if (target->What_Am_I() == RTTI_BUILDINGTYPE) {
+        BuildNavalYard.Delete(reinterpret_cast<BuildingTypeClass *>(target));
+    }
 }
 
 
@@ -198,6 +202,7 @@ void RulesClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(IsBuildOffAlly);
     crc(IsShowSuperWeaponTimers);
     crc(BuildNavalYard.Count());
+    crc(AINavalYardAdjacency);
 }
 
 
@@ -304,6 +309,8 @@ bool RulesClassExtension::General(CCINIClass &ini)
     }
 
     BuildNavalYard = ini.Get_Buildings(GENERAL, "BuildNavalYard", BuildNavalYard);
+
+    AINavalYardAdjacency = ini.Get_Int(GENERAL, "AINavalYardAdjacency", AINavalYardAdjacency);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -30,6 +30,7 @@
 #include "rules.h"
 #include "tiberium.h"
 #include "weapontype.h"
+#include "vinifera_globals.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -48,7 +49,8 @@ RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
     IsMPAutoDeployMCV(false),
     IsMPPrePlacedConYards(false),
     IsBuildOffAlly(true),
-    IsShowSuperWeaponTimers(true)
+    IsShowSuperWeaponTimers(true),
+    BuildNavalYard()
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("RulesClassExtension constructor - 0x%08X\n", (uintptr_t)(ThisPtr));
@@ -64,7 +66,8 @@ RulesClassExtension::RulesClassExtension(RulesClass *this_ptr) :
  *  @author: CCHyper
  */
 RulesClassExtension::RulesClassExtension(const NoInitClass &noinit) :
-    Extension(noinit)
+    Extension(noinit),
+    BuildNavalYard()
 {
     IsInitialized = false;
 }
@@ -114,7 +117,13 @@ HRESULT RulesClassExtension::Load(IStream *pStm)
         return E_FAIL;
     }
 
+    BuildNavalYard.Clear();
+
     new (this) RulesClassExtension(NoInitClass());
+
+    BuildNavalYard.Load(pStm);
+
+    SWIZZLE_REQUEST_POINTER_REMAP_LIST("BuildNavalYard", BuildNavalYard);
 
     SWIZZLE_REGISTER_POINTER(id, this);
 
@@ -140,6 +149,8 @@ HRESULT RulesClassExtension::Save(IStream *pStm, BOOL fClearDirty)
     if (FAILED(hr)) {
         return hr;
     }
+
+    BuildNavalYard.Save(pStm);
 
     return hr;
 }
@@ -186,6 +197,7 @@ void RulesClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(IsMPPrePlacedConYards);
     crc(IsBuildOffAlly);
     crc(IsShowSuperWeaponTimers);
+    crc(BuildNavalYard.Count());
 }
 
 
@@ -290,6 +302,8 @@ bool RulesClassExtension::General(CCINIClass &ini)
     if (!ini.Is_Present(GENERAL)) {
         return false;
     }
+
+    BuildNavalYard = ini.Get_Buildings(GENERAL, "BuildNavalYard", BuildNavalYard);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -116,6 +116,11 @@ class RulesClassExtension final : public Extension<RulesClass>
          *  from when building its base.
          */
         TypeList<BuildingTypeClass *> BuildNavalYard;
+
+        /**
+         *  The distance in cells the computer player can place their Naval Yard from their Construction Yard.
+         */
+        unsigned AINavalYardAdjacency;
 };
 
 

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -29,7 +29,7 @@
 
 #include "extension.h"
 #include "container.h"
-
+#include "typelist.h"
 #include "noinit.h"
 #include "tpoint.h"
 
@@ -110,6 +110,12 @@ class RulesClassExtension final : public Extension<RulesClass>
          *  on the tactical view?
          */
         bool IsShowSuperWeaponTimers;
+
+        /**
+         *  A list of buildings considered Naval Yard's for the computer to choose
+         *  from when building its base.
+         */
+        TypeList<BuildingTypeClass *> BuildNavalYard;
 };
 
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -70,7 +70,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(TechnoTypeClass *this_ptr) :
     VoiceDeploy(),
     VoiceHarvest(),
     IdleRate(0),
-    CameoImageSurface(nullptr)
+    CameoImageSurface(nullptr),
+    IsNaval(false)
 {
     ASSERT(ThisPtr != nullptr);
     //EXT_DEBUG_TRACE("TechnoTypeClassExtension constructor - Name: %s (0x%08X)\n", ThisPtr->Name(), (uintptr_t)(ThisPtr));
@@ -218,6 +219,7 @@ void TechnoTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(ShakePixelXHi);
     crc(ShakePixelXLo);
     crc(SoylentValue);
+    crc(IsNaval);
 }
 
 
@@ -282,6 +284,8 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     if (imagesurface) {
         CameoImageSurface = imagesurface;
     }
+
+    IsNaval = ini.Get_Bool(ini_name, "Naval", IsNaval);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -146,6 +146,15 @@ class TechnoTypeClassExtension final : public Extension<TechnoTypeClass>
          *  Pointer to the cameo image surface.
          */
         BSurface *CameoImageSurface;
+
+        /**
+         *  Is this object considered a water based vehicle (i.e. ship, submarine, etc)?
+         * 
+         *  #NOTE: This is a temporary property that is used to enforce special rules to
+         *         allow better naval and shipyard support until a full Vessel class is hooked
+         *         up and implemented.
+         */
+        bool IsNaval;
 };
 
 


### PR DESCRIPTION
Closes #531

This pull request implements various features for naval factory and unit support.

**NOTE:** Until a VesselClass is fully implemented, The following keys will act as a separation between vessel factories and water-based UnitTypes _(VesselTypes)_, with the aim of providing basic naval feature support.

_At this time;_
- Rules: `[General]` -> `BuildNavalYard=<BuildingType list>`
    - A list of BuildingTypes that are considered a NavalYard for AI production purposes.
    
- Rules: `[General]` -> `AINavalYardAdjacency=<integer: cell distance>`
    - The distance in cells the computer player can place a Naval Yard _(as set by `BuildNavalYard`)_ from their Construction Yard.

- `[BuildingType]` -> `NavalYard=yes`
  - An initial random rally point will be set at a distance of 2 cells away when the structure is placed.
  - Will allow the player to set rally points on water rather than land.
  - Allow the building to be assigned as "Primary" alongside a normal UnitType factory.
  
- `[UnitType]` -> `Naval=yes` currently has no effect, but it is recommended that you define this on all water-based UnitTypes to ensure an easy transition when this feature is extended.