### PR TITLE
Fixes two issues with the HouseType `Nod` in the unmodded Tiberian Sun `RULES.INI` data.

### DIFF
--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -459,6 +459,32 @@ void RulesClassExtension::Fixups()
                 housetype->Name());
         }
 
+        /**
+         *  #issue-903
+         * 
+         *  Workaround because NOD has Prefix=B in unmodded Tiberian Sun.
+         * 
+         *  Match criteria;
+         *   - The HouseType's name is "Nod"
+         *   - HouseType "Nod" is index 1
+         *   - HouseType "Nod" has Prefix=B
+         */
+        if (Wstring(housetype->Name()) == Wstring("Nod")
+            && housetype->Get_Heap_ID() == HOUSE_NOD
+            && housetype->Prefix == 'B') {
+
+            DEBUG_WARNING("Rules: House \"%s\" (%d) has \"Prefix=B\", changing Prefix to \"N\"!\n",
+                housetype->Name(), housetype->Get_Heap_ID());
+
+            /**
+             *  We are pretty sure this house is NOD, force the Prefix to the 'N' character.
+             */
+            housetype->Prefix = 'N';
+
+            DEBUG_WARNING("Rules: Please consider changing House \"%s\" to have \"Side=Nod\"!\n",
+                housetype->Name());
+        }
+
     }
 
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -62,6 +62,7 @@ class RulesClassExtension final : public Extension<RulesClass>
 
     private:
         void Check();
+        void Fixups();
 
     public:
         /**


### PR DESCRIPTION
Closes #903

This pull request fixes two issues with the HouseType `Nod` in the unmodded Tiberian Sun `RULES.INI` data by performing a fixup after the data has been loaded;
- `Prefix` is set to `B` when it should be `N`. This is a hand over from when Nod was referred to as `BADGUY` in Tiberian Dawn.
- `Side` is set to `GDI`. This is most likely a copy-and-paste error.

Fixing these ensures that any future feature that aims to extend the support for new sides works correctly with the unmodded game.
