### PR TITLE
Add support for more than two sides for Sidebar, Speech and Loading Screens.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -167,6 +167,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement the Torpedo logic from Red Alert 1 for BulletTypes.
   - Add `BuildTimeCost`.
   - Allow scenarios to have custom score screen bar colors.
+  - Add support for more than 2 sides' loading screens, sidebars and speeches.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:
@@ -207,4 +208,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement the multiplayer spawner.
   - Extend `BaseUnit` to accept a list of vehicles.
   - Allow `BuildConst`, `BuildRefinery`, `BuildWeapons` and `HarvesterUnit` to properly have multiple entries.
-
+  - Port Rampastring's trigger actions from TS-Patches.
+  - Allow manually aiming AA buildings.
+  - Add support for more than 2 sides' loading screens, sidebars and speeches.
+  - Disallow loading campaign saves from other playthoughs, as well as from skirmish.

--- a/docs/Mapping.md
+++ b/docs/Mapping.md
@@ -11,14 +11,32 @@ This page describes all mapping-related additions and changes introduced by Vini
 
 ## Campaign Settings
 
+### Campaign Side
+
+- `Side` can now be set for campaigns, allowing the customisation of which **HOUSE**'s loading screens this campaign should use.
+
+In `BATTLE.INI`:
+```ini
+[SOMECAMPAIGN]  ; Campaign
+Side=0          ; integer, the index of the house whose loading screens will be used for this campaign.
+```
+
+```{note}
+To preserve compatibility, the campaign's `Side` defaults to `0` if its scenario names contains `GDI`, to `1` if it contains `NOD`, and to 0 otherwise.
+```
+
+```{note}
+This setting only affects the loading screen graphics used.
+```
+
 ### Intro Movie
 
 - `IntroMovie` can now be set for campaigns, allowing the customisation of the intro movie that plays before the campaign path starts.
 
 In `BATTLE.INI`:
 ```ini
-[Campaign]
-IntroMovie=<none>  ; string, the intro movie name (without the .VQA extension) to play at the start of the campaign.
+[SOMECAMPAIGN]  ; Campaign
+IntroMovie=     ; string, the intro movie name (without the .VQA extension) to play at the start of the campaign.
 ```
 
 ### DebugOnly
@@ -27,12 +45,27 @@ IntroMovie=<none>  ; string, the intro movie name (without the .VQA extension) t
 
 In `BATTLE.INI`:
 ```ini
-[Campaign]
-DebugOnly=no  ; boolean, is this campaign only available in Developer mode?
+[SOMECAMPAIGN]  ; Campaign
+DebugOnly=no    ; boolean, is this campaign only available in Developer mode?
 ```
 For testing/debugging versions of the Tiberian Sun and Firestorm campaigns, download [BATTLE_DEBUG_CAMPAIGN.INI](https://github.com/Vinifera-Developers/Vinifera-Files/blob/master/files/BATTLE_DEBUG_CAMPAIGN.INI) and place it in your game install directory.
 
 ## Scenario Settings
+
+### Custom Loading Screen
+
+- The scenario file can now specify which loading screen to use.
+
+In a scenario file:
+```ini
+[Basic]
+LoadingScreen400=         ; string, the name of the loading screen to use with this resolution.
+LoadingScreen480=         ; string, the name of the loading screen to use with this resolution.
+LoadingScreen600=         ; string, the name of the loading screen to use with this resolution.
+LoadingScreen400TextPos=  ; Point2D, a custom offset for the loading screen text and bars. 
+LoadingScreen480TextPos=  ; Point2D, a custom offset for the loading screen text and bars. 
+LoadingScreen600TextPos=  ; Point2D, a custom offset for the loading screen text and bars. 
+```
 
 ### Ice Destruction
 
@@ -60,3 +93,47 @@ ScoreEnemyColor=250,28,28    ; color in R,G,B, color of the enemy's score bars
 ## Script Actions
 
 ## Trigger Actions
+
+### `106` Give Credits
+
+- Give `P3` credits to House `P2`.
+
+### `107` Enable Short Game
+
+- Enable Short Game.
+
+### `108` Disable Short Game
+
+- Disable Short Game.
+
+### `106` Print Difficulty
+
+- Print the current difficulty level as a message.
+
+### `106` Blow Up House
+
+- Blow up all units and structures of House `P2`.
+
+### `106` Make Elite
+
+- Make all attached objects elite.
+
+### `106` Enable AllyReveal
+
+- Enable `AllyReveal`.
+
+### `106` Disable AllyReveal
+
+- Disable `AllyReveal`.
+
+### `106` Create Auto-Save
+
+- Schedule the creation of an auto-save at the end of this frame. Works in MP and SP.
+
+### `106` Delete Object
+
+- Silently delete all attached objects from the map.
+
+### `106` Assign Mission to All
+
+- Assign Mission `P2` to all attached objects.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -153,6 +153,18 @@ PrePlacedConYards=no  ; boolean, should pre-place construction yards instead of 
                       ; NOTE: This option has priority over AutoDeployMCV.
 ```
 
+## Auto-Saves
+
+- When playing campaigns, Vinifera will now make auto-saves for the player at equal intervals. The number of auto-saves to keep, as well as the interval, can be customized.
+
+In `SUN.INI`:
+```ini
+[Options]
+AutoSaveCount=5        ; integer, the number of auto-saves to keep simultaneously. Setting to 0 will disable auto-saves.
+AutoSaveInterval=7200  ; integer, the interval between auto-saves, in frames.
+```
+
+
 ## Multi-Engineer
 
 - Vinifera fixes `EngineerDamage` and `EngineerCaptureLevel` to be considered by the game, like they were in Tiberian Dawn and Red Alert.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -93,12 +93,37 @@ It is not recommended to set `EngineerChance=100`, as this may put the game into
 - In the original game, harvesters always prefer free refineries over occupied ones, even if the free refinery was much farther away than the occupied refinery. Vinifera fixes this so that harvesters now prefer queueing to occupied refineries if they are much closer than free refineries. The distance for this preference is customizable.
 
 In `RULES.INI`:
-```
+```ini
 [General]
 ; When looking for refineries, harvesters will prefer a distant free
 ; refinery over a closer occupied refinery if the refineries' distance
 ; difference in cells is less than this.
 MaxFreeRefineryDistanceBias=16
+```
+
+## Houses
+
+- Loading screens can now be customized per house.
+
+In `RULES.INI`:
+```ini
+[SOMEHOUSE]         ; HouseType
+LoadingScreens400=  ; list of strings, loading screens to be used by this house with a screen resolution of at least 400x600.
+LoadingScreens480=  ; list of strings, loading screens to be used by this house with a screen resolution of at least 480x600.
+LoadingScreens600=  ; list of strings, loading screens to be used by this house with a screen resolution of at least 600x800.
+```
+
+- The defaults for loading screens are as follows:
+```ini
+LoadingScreens000=LOAD000C,LOAD000D ; House 0 - GDI
+LoadingScreens000=LOAD000A,LOAD000B ; House 1 - Nod
+LoadingScreens000=LOAD000E,LOAD000F ; House 2
+```
+
+- `000` is replaced with the loading screen's height, starting from house 2 letters are incremented (so house 2 uses `E` and `F`, house 3 uses letters `G` and `H`, etc.). After house 12 the letters loop around to `A` and `B`.
+
+```{note}
+Loading screen names should not contain the `.PCX` extension.
 ```
 
 ## Ice

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -209,7 +209,7 @@ Vanilla fixes:
 - Fix an issue where losers were not marked as defeated in multiplayer when using TACTION_WIN or TACTION_LOSE to end the game (by Rampastring)
 - Fix a bug where under some circumstances, the player could hear "New Construction Options", even though no new construction options were available (by ZivDero)
 - Fix a bug where attempting to start construction when low funds would put the queue on hold (by ZivDero)
-- Port the fix for the (Whiteboy bug)[https://modenc.renegadeprojects.com/Whiteboy-Bug] (by ZivDero)
+- Port the fix for the [Whiteboy bug](https://modenc.renegadeprojects.com/Whiteboy-Bug) (by ZivDero)
 - Fix a bug where the objects would sometimes receive a minimum of 1 damage even if MinDamage was set to 0 (by ZivDero)
 - Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air (by Rampastring)
 - Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action (by Rampastring)
@@ -226,6 +226,10 @@ Vanilla fixes:
 - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed (by ZivDero)
 - Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying (by ZivDero)
 - Fix a bug where if the player loaded a saved game, the score screen timer would report the time since the saved game was loaded, instead of since when the scenario was first started (by ZivDero)
+- Port trigger actions from TS-Patches (by ZivDero, Rampastring)
+- Allow manually aiming AA buildings (by ZivDero)
+- Add support for more than 2 sides' loading screens, sidebars and speeches (by CCHyper/tomsons26, ZivDero)
+- Disallow loading campaign saves from other playthoughs, as well as from skirmish (by ZivDero)
 
 </details>
 

--- a/src/extensions/campaign/campaignext.cpp
+++ b/src/extensions/campaign/campaignext.cpp
@@ -41,7 +41,8 @@
 CampaignClassExtension::CampaignClassExtension(const CampaignClass *this_ptr) :
     AbstractTypeClassExtension(this_ptr),
     IsDebugOnly(false),
-    IntroMovie()
+    IntroMovie(),
+    House(HOUSE_GDI)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("CampaignClassExtension::CampaignClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -173,13 +174,30 @@ void CampaignClassExtension::Compute_CRC(WWCRCEngine &crc) const
  */
 bool CampaignClassExtension::Read_INI(CCINIClass &ini)
 {
+    const char* ini_name = Name();
+
+    if (!IsInitialized) {
+
+        /**
+         *  Select vanilla campaigns's house based on their name
+         */
+        HousesType side = HOUSE_GDI;
+
+        if (std::strstr(This()->Scenario, "GDI")) {
+            side = HOUSE_GDI;
+        }
+        else if (std::strstr(This()->Scenario, "NOD")) {
+            side = HOUSE_NOD;
+        }
+
+        House = side;
+    }
+
     //EXT_DEBUG_TRACE("CampaignClassExtension::Read_INI - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
     if (!AbstractTypeClassExtension::Read_INI(ini)) {
         return false;
     }
-
-    const char *ini_name = Name();
 
     IsDebugOnly = ini.Get_Bool(ini_name, "DebugOnly", IsDebugOnly);
 
@@ -193,6 +211,10 @@ bool CampaignClassExtension::Read_INI(CCINIClass &ini)
     }
     
     ini.Get_String(ini_name, "IntroMovie", IntroMovie, sizeof(IntroMovie));
+
+    House = static_cast<HousesType>(ini.Get_Int(ini_name, "Side", House));
+
+    IsInitialized = true;
 
     return true;
 }

--- a/src/extensions/campaign/campaignext.h
+++ b/src/extensions/campaign/campaignext.h
@@ -71,4 +71,9 @@ CampaignClassExtension final : public AbstractTypeClassExtension
          *  The movie to play at start of this campaign.
          */
         char IntroMovie[64];
+
+        /**
+         *  The HOUSE (not side!) this campaign is played as.
+         */
+        HousesType House;
 };

--- a/src/extensions/event/eventext_hooks.cpp
+++ b/src/extensions/event/eventext_hooks.cpp
@@ -539,7 +539,7 @@ void EventClassExt::_Event_RemovePlayer()
     DEBUG_INFO("Executing REMOVEPLAYER event. Frame is %d\n", Frame);
     HouseClass* house = Houses[Data.General.Value];
 
-    if ((Session.Type == GAME_INTERNET && TournamentGameType) || (Spawner::Active && Session.Type == GAME_IPX && Spawner::Get_Config()->AutoSurrender)) {
+    if ((Session.Type == GAME_INTERNET && PlanetWestwoodTournament) || (Spawner::Active && Session.Type == GAME_IPX && Spawner::Get_Config()->AutoSurrender)) {
         house->Flag_To_Die();
     }
     else if (house->Is_Human_Control()) {

--- a/src/extensions/housetype/housetypeext.h
+++ b/src/extensions/housetype/housetypeext.h
@@ -29,37 +29,40 @@
 
 #include "abstracttypeext.h"
 #include "housetype.h"
+#include "wstring.h"
 
 
 class DECLSPEC_UUID(UUID_HOUSETYPE_EXTENSION)
 HouseTypeClassExtension final : public AbstractTypeClassExtension
 {
-    public:
-        /**
-         *  IPersist
-         */
-        IFACEMETHOD(GetClassID)(CLSID *pClassID);
+public:
+    /**
+     *  IPersist
+     */
+    IFACEMETHOD(GetClassID)(CLSID *pClassID);
 
-        /**
-         *  IPersistStream
-         */
-        IFACEMETHOD(Load)(IStream *pStm);
-        IFACEMETHOD(Save)(IStream *pStm, BOOL fClearDirty);
+    /**
+     *  IPersistStream
+     */
+    IFACEMETHOD(Load)(IStream *pStm);
+    IFACEMETHOD(Save)(IStream *pStm, BOOL fClearDirty);
 
-    public:
-        HouseTypeClassExtension(const HouseTypeClass *this_ptr = nullptr);
-        HouseTypeClassExtension(const NoInitClass &noinit);
-        virtual ~HouseTypeClassExtension();
+public:
+    HouseTypeClassExtension(const HouseTypeClass *this_ptr = nullptr);
+    HouseTypeClassExtension(const NoInitClass &noinit);
+    virtual ~HouseTypeClassExtension();
 
-        virtual int Size_Of() const override;
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
-        
-        virtual HouseTypeClass *This() const override { return reinterpret_cast<HouseTypeClass *>(AbstractTypeClassExtension::This()); }
-        virtual const HouseTypeClass *This_Const() const override { return reinterpret_cast<const HouseTypeClass *>(AbstractTypeClassExtension::This_Const()); }
-        virtual RTTIType What_Am_I() const override { return RTTI_HOUSETYPE; }
+    virtual int Size_Of() const override;
+    virtual void Detach(TARGET target, bool all = true) override;
+    virtual void Compute_CRC(WWCRCEngine &crc) const override;
+    
+    virtual HouseTypeClass *This() const override { return reinterpret_cast<HouseTypeClass *>(AbstractTypeClassExtension::This()); }
+    virtual const HouseTypeClass *This_Const() const override { return reinterpret_cast<const HouseTypeClass *>(AbstractTypeClassExtension::This_Const()); }
+    virtual RTTIType What_Am_I() const override { return RTTI_HOUSETYPE; }
 
-        virtual bool Read_INI(CCINIClass &ini) override;
+    virtual bool Read_INI(CCINIClass &ini) override;
 
-    public:
+public:
+
+    DynamicVectorClass<Wstring> LoadingScreens[3];
 };

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -596,6 +596,8 @@ bool Vinifera_Prep_For_Side(SideType side)
             return false;
         }
         DEBUG_INFO(" %s\n", buffer);
+    } else {
+        DEBUG_WARNING("  Failed to find %s!\n", buffer);
     }
 
     std::snprintf(buffer, sizeof(buffer), "SIDENC%02d.MIX", sidenum);
@@ -607,6 +609,8 @@ bool Vinifera_Prep_For_Side(SideType side)
             //return false; // #issue-193: Unable to load side mix files is no longer a fatal error.
         }
         DEBUG_INFO(" %s\n", buffer);
+    } else {
+        DEBUG_WARNING("  Failed to find %s!\n", buffer);
     }
 
     if (Session.Type == GAME_NORMAL) {
@@ -623,6 +627,8 @@ bool Vinifera_Prep_For_Side(SideType side)
                 //return false; // #issue-193: Unable to load side mix files is no longer a fatal error.
             }
             DEBUG_INFO(" %s\n", buffer);
+        } else {
+            DEBUG_WARNING("  Failed to find %s!\n", buffer);
         }
     }
 

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -532,12 +532,12 @@ void Vinifera_Create_Main_Window(HINSTANCE hInstance, int nCmdShow, int width, i
  */
 bool Vinifera_Prep_For_Side(SideType side)
 {
-    DEBUG_INFO("Preparing Mixfiles for Side %02d.\n", side);
+    int sidenum = (side+1); // Logical side number.
+
+    DEBUG_INFO("Preparing Mixfiles for Side %02d (logical %02d).\n", side, sidenum);
 
     MFCC *mix = nullptr;
     char buffer[16];
-
-    int sidenum = (side+1); // Logical side number.
 
     if (SideCachedMix) {
         DEBUG_INFO("  Releasing %s\n", SideCachedMix->Filename);

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -371,6 +371,7 @@ void RulesClassExtension::Initialize(CCINIClass &ini)
 {
     //EXT_DEBUG_TRACE("RulesClassExtension::Initialize - 0x%08X\n", (uintptr_t)(This()));
 
+    ArmorTypeClass::One_Time();
 }
 
 

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -966,9 +966,9 @@ void RulesClassExtension::Fixups(CCINIClass &ini)
      *  Workaround because NOD has Side=GDI and Prefix=B in unmodded Tiberian Sun.
      *
      *  Match criteria;
-     *   - Are we currently processing RuleINI?
+     *   - Are we currently processing one of the unmodified rule INI's?
      */
-    if (is_ruleini) {
+    if (rule_unmodified || fsrule_unmodified) {
 
         /**
          *  Ensure at least two HouseTypes are defined before performing this fixup case.

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -70,9 +70,10 @@ public:
     bool Rockets(CCINIClass &ini);
     bool Tiberiums(CCINIClass &ini);
 
-private:
-    void Check();
-    void Fixups(CCINIClass &ini);
+        void Fixups(CCINIClass &ini);
+
+    private:
+        void Check();
 
 public:
     /**

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -70,10 +70,10 @@ public:
     bool Rockets(CCINIClass &ini);
     bool Tiberiums(CCINIClass &ini);
 
-        void Fixups(CCINIClass &ini);
+    void Fixups(CCINIClass &ini);
 
-    private:
-        void Check();
+private:
+    void Check();
 
 public:
     /**

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -85,10 +85,20 @@ ScenarioClassExtension::ScenarioClassExtension(const ScenarioClass *this_ptr) :
     GlobalExtensionClass(this_ptr),
     Waypoint(NEW_WAYPOINT_COUNT),
     IsIceDestruction(true),
-    SidebarSide(SIDE_NONE)
+    SidebarSide(SIDE_NONE),
+    LoadingScreen400BackgroundName(),
+    LoadingScreen480BackgroundName(),
+    LoadingScreen600BackgroundName(),
+    LoadingScreen400Loc(0,0),
+    LoadingScreen480Loc(0,0),
+    LoadingScreen600Loc(0,0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("ScenarioClassExtension::ScenarioClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
+    LoadingScreen400BackgroundName[0] = '\0';
+    LoadingScreen480BackgroundName[0] = '\0';
+    LoadingScreen600BackgroundName[0] = '\0';
+    
     /**
      *  This copies the behavior of the games ScenarioClass.
      */
@@ -217,6 +227,13 @@ void ScenarioClassExtension::Init_Clear()
 
     //EXT_DEBUG_TRACE("ScenarioClassExtension::Init_Clear - 0x%08X\n", (uintptr_t)(This()));
 
+    LoadingScreen400BackgroundName[0] = '\0';
+    LoadingScreen480BackgroundName[0] = '\0';
+    LoadingScreen600BackgroundName[0] = '\0';
+    LoadingScreen400Loc = TPoint2D<int>(0,0);
+    LoadingScreen480Loc = TPoint2D<int>(0,0);
+    LoadingScreen600Loc = TPoint2D<int>(0,0);
+
     {
         /**
          *  Clear the any previously loaded tutorial messages in preperation for
@@ -268,6 +285,78 @@ bool ScenarioClassExtension::Read_INI(CCINIClass &ini)
      *  Fetch additional tutorial message data (if present) from the scenario.
      */
     Read_Tutorial_INI(ini, true);
+
+    return true;
+}
+
+
+/**
+ *  Read the loading screen overrides from the scenario INI.
+ *
+ *  @author: CCHyper
+ */
+bool ScenarioClassExtension::Read_Scenario_INI(CCINIClass &ini)
+{
+    //EXT_DEBUG_TRACE("ScenarioClassExtension::Read_Scenario_INI - 0x%08X\n", (uintptr_t)(This()));
+
+    return true;
+}
+
+
+/**
+ *  Read the loading screen overrides from the scenario INI.
+ *
+ *  @author: CCHyper
+ */
+bool ScenarioClassExtension::Read_Loading_Screen_INI(const char *filename)
+{
+    //EXT_DEBUG_TRACE("ScenarioClassExtension::Read_Loading_Screen_INI - 0x%08X\n", (uintptr_t)(This()));
+
+    static const char * const BASIC = "Basic";
+
+    CCFileClass file(filename);
+    CCINIClass ini(file);
+
+    if (!ini.Is_Loaded()) {
+        return false;
+    }
+
+    ScenExtension->LoadingScreen400BackgroundName[0] = '\0';
+    ScenExtension->LoadingScreen480BackgroundName[0] = '\0';
+    ScenExtension->LoadingScreen400BackgroundName[0] = '\0';
+    ScenExtension->LoadingScreen400Loc = TPoint2D<int>(0, 0);
+    ScenExtension->LoadingScreen480Loc = TPoint2D<int>(0, 0);
+    ScenExtension->LoadingScreen600Loc = TPoint2D<int>(0, 0);
+
+    if (Session.Type == GAME_NORMAL) {
+
+        if (ini.Is_Present(BASIC, "LS400BkgdName")) {
+            ini.Get_String(BASIC, "LS400BkgdName", ScenExtension->LoadingScreen400BackgroundName, sizeof(ScenExtension->LoadingScreen400BackgroundName));
+            ASSERT(std::strlen(ScenExtension->LoadingScreen400BackgroundName) > 0);
+        }
+        if (ini.Is_Present(BASIC, "LS480BkgdName")) {
+            ini.Get_String(BASIC, "LS480BkgdName", ScenExtension->LoadingScreen480BackgroundName, sizeof(ScenExtension->LoadingScreen480BackgroundName));
+            ASSERT(std::strlen(ScenExtension->LoadingScreen480BackgroundName) > 0);
+        }
+        if (ini.Is_Present(BASIC, "LS600BkgdName")) {
+            ini.Get_String(BASIC, "LS600BkgdName", ScenExtension->LoadingScreen600BackgroundName, sizeof(ScenExtension->LoadingScreen600BackgroundName));
+            ASSERT(std::strlen(ScenExtension->LoadingScreen600BackgroundName) > 0);
+        }
+
+        if (ini.Is_Present(BASIC, "LS400TextLoc")) {
+            ScenExtension->LoadingScreen400Loc = ini.Get_Point(BASIC, "LS400TextLoc", ScenExtension->LoadingScreen400Loc);
+            ASSERT(ScenExtension->LoadingScreen400Loc.Is_Valid());
+        }
+        if (ini.Is_Present(BASIC, "LS480TextLoc")) {
+            ScenExtension->LoadingScreen480Loc = ini.Get_Point(BASIC, "LS480TextLoc", ScenExtension->LoadingScreen480Loc);
+            ASSERT(ScenExtension->LoadingScreen480Loc.Is_Valid());
+        }
+        if (ini.Is_Present(BASIC, "LS600TextLoc")) {
+            ScenExtension->LoadingScreen600Loc = ini.Get_Point(BASIC, "LS600TextLoc", ScenExtension->LoadingScreen600Loc);
+            ASSERT(ScenExtension->LoadingScreen600Loc.Is_Valid());
+        }
+
+    }
 
     return true;
 }

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -84,7 +84,8 @@
 ScenarioClassExtension::ScenarioClassExtension(const ScenarioClass *this_ptr) :
     GlobalExtensionClass(this_ptr),
     Waypoint(NEW_WAYPOINT_COUNT),
-    IsIceDestruction(true)
+    IsIceDestruction(true),
+    SidebarSide(SIDE_NONE)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("ScenarioClassExtension::ScenarioClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -86,19 +86,10 @@ ScenarioClassExtension::ScenarioClassExtension(const ScenarioClass *this_ptr) :
     Waypoint(NEW_WAYPOINT_COUNT),
     IsIceDestruction(true),
     SidebarSide(SIDE_NONE),
-    LoadingScreen400BackgroundName(),
-    LoadingScreen480BackgroundName(),
-    LoadingScreen600BackgroundName(),
-    LoadingScreen400Loc(0,0),
-    LoadingScreen480Loc(0,0),
-    LoadingScreen600Loc(0,0)
+    LoadingScreens{ { "", {} }, { "", {} } , { "", {} } }
 {
     //if (this_ptr) EXT_DEBUG_TRACE("ScenarioClassExtension::ScenarioClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
-    LoadingScreen400BackgroundName[0] = '\0';
-    LoadingScreen480BackgroundName[0] = '\0';
-    LoadingScreen600BackgroundName[0] = '\0';
-    
     /**
      *  This copies the behavior of the games ScenarioClass.
      */
@@ -227,12 +218,12 @@ void ScenarioClassExtension::Init_Clear()
 
     //EXT_DEBUG_TRACE("ScenarioClassExtension::Init_Clear - 0x%08X\n", (uintptr_t)(This()));
 
-    LoadingScreen400BackgroundName[0] = '\0';
-    LoadingScreen480BackgroundName[0] = '\0';
-    LoadingScreen600BackgroundName[0] = '\0';
-    LoadingScreen400Loc = TPoint2D<int>(0,0);
-    LoadingScreen480Loc = TPoint2D<int>(0,0);
-    LoadingScreen600Loc = TPoint2D<int>(0,0);
+    LoadingScreens[0].Filename = "";
+    LoadingScreens[1].Filename = "";
+    LoadingScreens[2].Filename = "";
+    LoadingScreens[0].Position = TPoint2D<int>(0,0);
+    LoadingScreens[1].Position = TPoint2D<int>(0,0);
+    LoadingScreens[2].Position = TPoint2D<int>(0,0);
 
     {
         /**
@@ -295,19 +286,6 @@ bool ScenarioClassExtension::Read_INI(CCINIClass &ini)
  *
  *  @author: CCHyper
  */
-bool ScenarioClassExtension::Read_Scenario_INI(CCINIClass &ini)
-{
-    //EXT_DEBUG_TRACE("ScenarioClassExtension::Read_Scenario_INI - 0x%08X\n", (uintptr_t)(This()));
-
-    return true;
-}
-
-
-/**
- *  Read the loading screen overrides from the scenario INI.
- *
- *  @author: CCHyper
- */
 bool ScenarioClassExtension::Read_Loading_Screen_INI(const char *filename)
 {
     //EXT_DEBUG_TRACE("ScenarioClassExtension::Read_Loading_Screen_INI - 0x%08X\n", (uintptr_t)(This()));
@@ -321,41 +299,22 @@ bool ScenarioClassExtension::Read_Loading_Screen_INI(const char *filename)
         return false;
     }
 
-    ScenExtension->LoadingScreen400BackgroundName[0] = '\0';
-    ScenExtension->LoadingScreen480BackgroundName[0] = '\0';
-    ScenExtension->LoadingScreen400BackgroundName[0] = '\0';
-    ScenExtension->LoadingScreen400Loc = TPoint2D<int>(0, 0);
-    ScenExtension->LoadingScreen480Loc = TPoint2D<int>(0, 0);
-    ScenExtension->LoadingScreen600Loc = TPoint2D<int>(0, 0);
-
     if (Session.Type == GAME_NORMAL) {
 
-        if (ini.Is_Present(BASIC, "LS400BkgdName")) {
-            ini.Get_String(BASIC, "LS400BkgdName", ScenExtension->LoadingScreen400BackgroundName, sizeof(ScenExtension->LoadingScreen400BackgroundName));
-            ASSERT(std::strlen(ScenExtension->LoadingScreen400BackgroundName) > 0);
-        }
-        if (ini.Is_Present(BASIC, "LS480BkgdName")) {
-            ini.Get_String(BASIC, "LS480BkgdName", ScenExtension->LoadingScreen480BackgroundName, sizeof(ScenExtension->LoadingScreen480BackgroundName));
-            ASSERT(std::strlen(ScenExtension->LoadingScreen480BackgroundName) > 0);
-        }
-        if (ini.Is_Present(BASIC, "LS600BkgdName")) {
-            ini.Get_String(BASIC, "LS600BkgdName", ScenExtension->LoadingScreen600BackgroundName, sizeof(ScenExtension->LoadingScreen600BackgroundName));
-            ASSERT(std::strlen(ScenExtension->LoadingScreen600BackgroundName) > 0);
-        }
+        char buffer[32];
 
-        if (ini.Is_Present(BASIC, "LS400TextLoc")) {
-            ScenExtension->LoadingScreen400Loc = ini.Get_Point(BASIC, "LS400TextLoc", ScenExtension->LoadingScreen400Loc);
-            ASSERT(ScenExtension->LoadingScreen400Loc.Is_Valid());
-        }
-        if (ini.Is_Present(BASIC, "LS480TextLoc")) {
-            ScenExtension->LoadingScreen480Loc = ini.Get_Point(BASIC, "LS480TextLoc", ScenExtension->LoadingScreen480Loc);
-            ASSERT(ScenExtension->LoadingScreen480Loc.Is_Valid());
-        }
-        if (ini.Is_Present(BASIC, "LS600TextLoc")) {
-            ScenExtension->LoadingScreen600Loc = ini.Get_Point(BASIC, "LS600TextLoc", ScenExtension->LoadingScreen600Loc);
-            ASSERT(ScenExtension->LoadingScreen600Loc.Is_Valid());
-        }
+        ini.Get_String(BASIC, "LoadingScreen400", buffer, sizeof(buffer));
+        ScenExtension->LoadingScreens[0].Filename = buffer;
 
+        ini.Get_String(BASIC, "LoadingScreen480", buffer, sizeof(buffer));
+        ScenExtension->LoadingScreens[1].Filename = buffer;
+
+        ini.Get_String(BASIC, "LoadingScreen600", buffer, sizeof(buffer));
+        ScenExtension->LoadingScreens[2].Filename = buffer;
+
+        ScenExtension->LoadingScreens[0].Position = ini.Get_Point(BASIC, "LoadingScreen400TextPos", ScenExtension->LoadingScreens[0].Position);
+        ScenExtension->LoadingScreens[1].Position = ini.Get_Point(BASIC, "LoadingScreen460TextPos", ScenExtension->LoadingScreens[1].Position);
+        ScenExtension->LoadingScreens[2].Position = ini.Get_Point(BASIC, "LoadingScreen600TextPos", ScenExtension->LoadingScreens[2].Position);
     }
 
     return true;
@@ -857,138 +816,169 @@ bool ScenarioClassExtension::Load_Scenario(CCINIClass& ini, bool random)
      */
     Scen->Theater = ini.Get_TheaterType(MAP, "Theater", THEATER_FIRST);
     Init_Theater(Scen->Theater);
+    Session.Loading_Callback(8);
+
+    /**
+     *  Load the main rules file.
+     */
+    DEBUG_INFO("Initializing Rules\n");
+    RuleExtension->Initialize(*RuleINI);
+    Rule->Initialize(*RuleINI);
+
+    Session.Loading_Callback(15);
+    Call_Back();
+
+    /**
+     *  Read the rules into ScenarioClass.
+     */
+    DEBUG_INFO("Calling Scen->Read_Global_INI(*RuleINI);\n");
+    Scen->Read_Global_INI(*RuleINI);
+
+    Call_Back();
+
+    /**
+     *  #issue-#671
+     *
+     *  Add loading of MPLAYER.INI to override Rules data for multiplayer games.
+     *
+     *  @author: CCHyper
+     */
+    if (Session.Type != GAME_NORMAL && Session.Type != GAME_WDT) {
+
+        /**
+         *  Process the multiplayer ini overrides.
+         */
+        Rule_Addition("MPLAYER.INI");
+        if (Is_Addon_Enabled(ADDON_FIRESTORM)) {
+            Rule_Addition("MPLAYERFS.INI");
+        }
+
+    }
+
     Session.Loading_Callback(30);
 
+    Call_Back();
+
     /**
-     *  Determine the player's side.
+     *  Read scenario overrides into our Rules.
+     */
+    DEBUG_INFO("Calling Rule->Addition() with scenario overrides\n");
+    Rule->Addition(ini);
+    DEBUG_INFO("Finished Rule->Addition() with scenario overrides\n");
+
+    Session.Loading_Callback(45);
+
+    /**
+     *  Init the Scenario CRC value
+     */
+    ScenarioCRC = 0;
+
+    /**
+     *  Read in the specific information for each of the house types. This creates
+     *  the houses of different types.
      */
     if (Session.Type == GAME_NORMAL) {
-        ini.Get_String(BASIC, "Player", "GDI", buffer, 32);
-        Scen->IsGDI = std::strcmp(buffer, "GDI") == 0;
-        Scen->SpeechSide = Scen->IsGDI ? SIDE_GDI : SIDE_NOD;
-    }
-    else {
-        Scen->IsGDI = Session.IsGDI;
-        Scen->SpeechSide = Session.IsGDI ? SIDE_GDI : SIDE_NOD;
+        DEBUG_INFO("Reading in scenario house types\n");
+        HouseClass::Read_Scenario_INI(ini);
     }
 
     /**
-     *  Init side-specific data.
+     *  Outside of campaign, the spawner may request that we read base nodes for
+     *  Spawn houses. Do that if necessary.
      */
-    DEBUG_INFO("Calling Prep_For_Side()\n");
-    if (Prep_For_Side(Scen->IsGDI ? SIDE_GDI : SIDE_NOD)) {
-        ArmorTypeClass::One_Time();
+    if (Session.Type != GAME_NORMAL && Spawner::Active && Spawner::Get_Config()->UseMPAIBaseNodes) {
+        for (int i = 0; i < Session.Players.Count() + Session.Options.AIPlayers; i++) {
+
+            /**
+             *  Skip observers, they don't need base nodes.
+             */
+            if (Houses[i]->IsDefeated) {
+                continue;
+            }
+
+            /**
+             *  Read base nodes for this house.
+             */
+            std::snprintf(buffer, std::size(buffer), "Spawn%d", ScenExtension->StartingPositions[i]);
+            Houses[i]->Base.Read_INI(ini, buffer);
+        }
+    }
+
+    Session.Loading_Callback(50);
+
+    /**
+     *  Read scneario data from the scenario INI.
+     */
+    if (Scen->Read_INI(ini)) {
 
         /**
-         *  Load the main rules file.
-         */
-        DEBUG_INFO("Initializing Rules\n");
-        Rule->Initialize(*RuleINI);
-
-        Session.Loading_Callback(35);
-        Call_Back();
-
-        /**
-         *  In single player, the speech side can be overridden by the scenario.
+         *  Determine the player's side.
          */
         if (Session.Type == GAME_NORMAL) {
-            Scen->SpeechSide = ini.Get_SideType("Basic", "SpeechSide", Scen->SpeechSide);
+            ini.Get_String(BASIC, "Player", "GDI", buffer, 32);
+            /**
+             *  Fetch the house's side and use this to decide which assets to load.
+             */
+            const auto housetype = HouseTypeClass::As_Pointer(buffer);
+
+            Scen->IsGDI = static_cast<unsigned char>(housetype->Side & 0xFF);
+            Scen->SpeechSide = housetype->Side;
+            ScenExtension->SidebarSide = housetype->Side;
+        }
+        else {
+            Scen->IsGDI = static_cast<unsigned char>(Session.IsGDI);
+            Scen->SpeechSide = static_cast<SideType>(Session.IsGDI);
+            ScenExtension->SidebarSide = static_cast<SideType>(Session.IsGDI);
         }
 
         /**
-         *  Init the speech for the side.
+         *  Init side-specific data.
          */
-        DEBUG_INFO("Calling Prep_Speech_For_Side()\n");
-        if (Prep_Speech_For_Side(Scen->SpeechSide)) {
-            /**
-             *  Read the rules into ScenarioClass.
-             */
-            DEBUG_INFO("Calling Scen->Read_Global_INI(*RuleINI);\n");
-            Scen->Read_Global_INI(*RuleINI);
+        DEBUG_INFO("Calling Prep_For_Side()\n");
+        if (Prep_For_Side(ScenExtension->SidebarSide)) {
 
             Call_Back();
 
             /**
-             *  #issue-#671
-             *
-             *  Add loading of MPLAYER.INI to override Rules data for multiplayer games.
-             *
-             *  @author: CCHyper
+             *  Unfortunately, since we now load rules before prepping for side,
+             *  we have to reload cameos for Technos, as they can be side-specific.
              */
-            if (Session.Type != GAME_NORMAL && Session.Type != GAME_WDT) {
 
-                /**
-                 *  Process the multiplayer ini overrides.
-                 */
-                Rule_Addition("MPLAYER.INI");
-                if (Is_Addon_Enabled(ADDON_FIRESTORM)) {
-                    Rule_Addition("MPLAYERFS.INI");
+            for (int index = 0; index < TechnoTypes.Count(); ++index) {
+
+                TechnoTypeClass* ttype = TechnoTypes[index];
+                std::snprintf(buffer, sizeof(buffer), "%s.SHP", ttype->CameoFilename);
+
+                const ShapeFileStruct* cameodata = MFCC::RetrieveT<const ShapeFileStruct>(buffer);
+
+                if (cameodata != nullptr) {
+                    ttype->CameoData = cameodata;
                 }
-
             }
-
-            Session.Loading_Callback(42);
 
             Call_Back();
 
             /**
-             *  Read scenario overrides into our Rules.
+             *  In single player, the speech and sidebar side can be overridden by the scenario.
              */
-            DEBUG_INFO("Calling Rule->Addition() with scenario overrides\n");
-            Rule->Addition(ini);
-            DEBUG_INFO("Finished Rule->Addition() with scenario overrides\n");
-
-            Session.Loading_Callback(45);
-
-            /**
-             *  Init the Scenario CRC value
-             */
-            ScenarioCRC = 0;
-
-            /**
-             *  Read in the specific information for each of the house types. This creates
-             *  the houses of different types.
-             */
-            if (Session.Type == GAME_NORMAL) {
-                DEBUG_INFO("Reading in scenario house types\n");
-                HouseClass::Read_Scenario_INI(ini);
+            if (Session.Type == GAME_NORMAL)  {
+                Scen->SpeechSide = ini.Get_SideType("Basic", "SpeechSide", Scen->SpeechSide);
+                ScenExtension->SidebarSide = ini.Get_SideType("Basic", "SidebarSide", ScenExtension->SidebarSide);
             }
 
             /**
-             *  Outside of campaign, the spawner may request that we read base nodes for
-             *  Spawn houses. Do that if necessary.
+             *  Init the speech for the side.
              */
-            if (Session.Type != GAME_NORMAL && Spawner::Active && Spawner::Get_Config()->UseMPAIBaseNodes) {
-                for (int i = 0; i < Session.Players.Count() + Session.Options.AIPlayers; i++) {
-
-                    /**
-                     *  Skip observers, they don't need base nodes.
-                     */
-                    if (Houses[i]->IsDefeated) {
-                        continue;
-                    }
-
-                    /**
-                     *  Read base nodes for this house.
-                     */
-                    std::snprintf(buffer, std::size(buffer), "Spawn%d", ScenExtension->StartingPositions[i]);
-                    Houses[i]->Base.Read_INI(ini, buffer);
-                }
-            }
-
-            Session.Loading_Callback(50);
-
-            /**
-             *  Read scneario data from the scenario INI.
-             */
-            if (Scen->Read_INI(ini)) {
+            DEBUG_INFO("Calling Prep_Speech_For_Side()\n");
+            if (Prep_Speech_For_Side(Scen->SpeechSide)) {
 
                 Session.Loading_Callback(58);
 
                 /**
-                 *  Usually this happens in Map.Read_INI(), but we need to read waypoints earlier to assign them to players.
+                 *  Read in the map control values. This includes dimensions
+                 *  as well as theater information.
                  */
-                Scen->Read_Waypoint_INI(ini);
+                Map.Read_INI(ini);
 
                 /**
                  *  Outside of campaign, assign houses their starting positions.
@@ -1057,12 +1047,6 @@ bool ScenarioClassExtension::Load_Scenario(CCINIClass& ini, bool random)
                 AITriggerTypeClass::Read_Scenario_INI(ini, 0);
 
                 Session.Loading_Callback(60);
-
-                /**
-                 *  Read in the map control values. This includes dimensions
-                 *  as well as theater information.
-                 */
-                Map.Read_INI(ini);
 
                 Call_Back();
 
@@ -1301,6 +1285,13 @@ bool ScenarioClassExtension::Load_Scenario(CCINIClass& ini, bool random)
                  */
                 Vinifera_NextAutosaveFrame = Frame;
                 Vinifera_NextAutosaveFrame += Spawner::Active && Session.Type == GAME_IPX ? Spawner::Get_Config()->AutoSaveInterval : OptionsExtension->AutoSaveInterval;
+
+                /**
+                 *  Set the skip score bool.
+                 */
+                if (Spawner::Active) {
+                    Scen->IsSkipScore = Spawner::Get_Config()->SkipScoreScreen;
+                }
 
                 /**
                  *  Return with flag saying that the scenario file was read.

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -301,7 +301,7 @@ bool ScenarioClassExtension::Read_Loading_Screen_INI(const char *filename)
 
     if (Session.Type == GAME_NORMAL) {
 
-        char buffer[32];
+        char buffer[MAX_PATH];
 
         ini.Get_String(BASIC, "LoadingScreen400", buffer, sizeof(buffer));
         ScenExtension->LoadingScreens[0].Filename = buffer;
@@ -907,7 +907,7 @@ bool ScenarioClassExtension::Load_Scenario(CCINIClass& ini, bool random)
     Session.Loading_Callback(50);
 
     /**
-     *  Read scneario data from the scenario INI.
+     *  Read scenario data from the scenario INI.
      */
     if (Scen->Read_INI(ini)) {
 
@@ -1617,9 +1617,8 @@ void ScenarioClassExtension::Assign_Houses()
         housep->IsHuman = true;
 
         housep->Control.TechLevel = BuildLevel;
-        housep->Init_Data((PlayerColorType)node.Player.Color,
-            node.Player.House, Session.Options.Credits);
-        housep->RemapColor = Session.Player_Color_To_Scheme_Color((PlayerColorType)node.Player.Color);
+        housep->Init_Data(node.Player.Color, node.Player.House, Session.Options.Credits);
+        housep->RemapColor = Session.Player_Color_To_Scheme_Color(node.Player.Color);
         housep->Init_Remap_Color();
 
         /**
@@ -1652,22 +1651,11 @@ void ScenarioClassExtension::Assign_Houses()
 
         if (!Spawner::Active)
         {
-#if 0
-            if (Percent_Chance(50)) {
-                pref_house = HOUSE_GDI;
-            }
-            else {
-                pref_house = HOUSE_NOD;
-    }
-#endif
-
             /**
              *  #issue-7
              *
-             *  Replaces code from above.
-             *
              *  Fixes a limitation where the AI would only be able to choose
-             *  between the houses GDI (0) and NOD (1). Now, all houses that
+             *  between the houses GDI (0) and Nod (1). Now, all houses that
              *  have "IsMultiplay" true will be considered for sellection.
              */
             while (true) {

--- a/src/extensions/scenario/scenarioext.h
+++ b/src/extensions/scenario/scenarioext.h
@@ -30,6 +30,7 @@
 #include "always.h"
 #include "extension.h"
 #include "scenario.h"
+#include "wstring.h"
 
 
 class ScenarioClassExtension final : public GlobalExtensionClass<ScenarioClass>
@@ -79,6 +80,7 @@ public:
     void Assign_Starting_Positions(bool official);
     static void Assign_Houses();
     static void Create_Units(bool official);
+    bool Read_Loading_Screen_INI(const char* filename);
 
 public:
     /**
@@ -106,24 +108,19 @@ public:
     int StartingPositions[MAX_PLAYERS];
     Cell StartingPositionCells[MAX_PLAYERS];
 
-        /**
-         *  The side to use for the sidebar assets (singleplayer only).
-         */
-        SideType SidebarSide;
+    /**
+     *  The side to use for the sidebar assets (singleplayer only).
+     */
+    SideType SidebarSide;
 
-        /**
-         *  Scenarios can override the loading screen with a custom variant, these
-         *  define the filename to load.
-         */
-        char LoadingScreen400BackgroundName[32];
-        char LoadingScreen480BackgroundName[32];
-        char LoadingScreen600BackgroundName[32];
+    /**
+     *  Scenarios can override the loading screen with a custom variant, these
+     *  define the filename to load and position overrides.
+     */
+    struct LoadingScreenData {
+        Wstring Filename;
+        TPoint2D<int> Position;
+    };
 
-        /**
-         *  These are the custom text positions for each of the loading screen
-         *  overrides.
-         */
-        TPoint2D<int> LoadingScreen400Loc;
-        TPoint2D<int> LoadingScreen480Loc;
-        TPoint2D<int> LoadingScreen600Loc;
+    LoadingScreenData LoadingScreens[3];
 };

--- a/src/extensions/scenario/scenarioext.h
+++ b/src/extensions/scenario/scenarioext.h
@@ -110,4 +110,20 @@ public:
          *  The side to use for the sidebar assets (singleplayer only).
          */
         SideType SidebarSide;
+
+        /**
+         *  Scenarios can override the loading screen with a custom variant, these
+         *  define the filename to load.
+         */
+        char LoadingScreen400BackgroundName[32];
+        char LoadingScreen480BackgroundName[32];
+        char LoadingScreen600BackgroundName[32];
+
+        /**
+         *  These are the custom text positions for each of the loading screen
+         *  overrides.
+         */
+        TPoint2D<int> LoadingScreen400Loc;
+        TPoint2D<int> LoadingScreen480Loc;
+        TPoint2D<int> LoadingScreen600Loc;
 };

--- a/src/extensions/scenario/scenarioext.h
+++ b/src/extensions/scenario/scenarioext.h
@@ -105,4 +105,9 @@ public:
      */
     int StartingPositions[MAX_PLAYERS];
     Cell StartingPositionCells[MAX_PLAYERS];
+
+        /**
+         *  The side to use for the sidebar assets (singleplayer only).
+         */
+        SideType SidebarSide;
 };

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -408,7 +408,7 @@ static void Init_Loading_Screen(const char* filename)
     char gamenamebuffer[128];
     const char* gamename = nullptr;
 
-    if (Session.Type == GAME_INTERNET && TournamentGameType == WOL::TOURNAMENT_0) {
+    if (Session.Type == GAME_INTERNET && PlanetWestwoodTournament == WOL::TOURNAMENT_0) {
         std::snprintf(gamenamebuffer, sizeof(gamenamebuffer), Text_String(TXT_GAME_ID), PlanetWestwoodGameID);
         gamename = gamenamebuffer;
     }

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -58,6 +58,8 @@
 #include "language.h"
 #include "wsproto.h"
 #include "rulesext.h"
+#include "ownrdraw.h"
+#include "spritecollection.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -748,6 +750,24 @@ static bool Read_Scenario_INI_Prep_For_Side()
             return false;
         }
     }
+
+    Call_Back();
+
+    /**
+     *  #issue-913
+     * 
+     *  Clear the sprite collection database and reload the owner draw graphics.
+     * 
+     *  #NOTE: This is really, really bad voodoo, but we don't have any easy
+     *         way to clean a Dictionary class yet, so this will have to do.
+     */
+    {
+    SpriteCollection.SpriteCollectionClass::~SpriteCollectionClass();
+    SpriteCollection.SpriteCollectionClass::SpriteCollectionClass();
+    OwnerDraw::Load_Graphics();
+    }
+
+    Call_Back();
 
     return true;
 }

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -44,6 +44,13 @@
 #include "ccini.h"
 #include "endgame.h"
 #include "addon.h"
+#include "house.h"
+#include "housetype.h"
+#include "side.h"
+#include "infantrytype.h"
+#include "unittype.h"
+#include "aircrafttype.h"
+#include "buildingtype.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -211,6 +218,346 @@ int _Waypoint_From_Name(char* wp)
 
 
 /**
+ *  This is a real kludge to work around the fact that in Tiberian Sun, each
+ *  of the side asset mix files contain their own versions of cameo artwork
+ *  for the opposing side.
+ * 
+ *  We call Call_Back() after each iteration to ensure the network connection
+ *  does not drop between clients in multiplayer games.
+ * 
+ *  @author: CCHyper
+ */
+static bool Read_Scenario_INI_Reload_Cameo_For_Side()
+{
+    char buffer[32];
+
+    DEBUG_INFO("Reloading TechnoType cameos.\n");
+
+    Call_Back();
+
+    for (int index = 0; index < TechnoTypes.Count(); ++index) {
+
+        TechnoTypeClass *ttype = TechnoTypes[index];
+        std::snprintf(buffer, sizeof(buffer), "%s.SHP", ttype->CameoFilename);
+
+        const ShapeFileStruct *cameodata = MFCC::RetrieveT<const ShapeFileStruct>(buffer);
+
+        if (cameodata == nullptr) continue;
+
+        if (ttype->CameoData != nullptr && cameodata == ttype->CameoData) continue;
+
+        DEBUG_INFO("  Reloaded cameo for %s \"%s\" (%s).\n", Name_From_RTTI(RTTIType(ttype->What_Am_I())), ttype->Name(), buffer);
+        ttype->CameoData = cameodata;
+    }
+
+    DEBUG_INFO("Finished reloading TechnoType cameos.\n");
+
+    Call_Back();
+
+    return true;
+}
+
+
+/**
+ *  Process the rules and scenario rules overrides.
+ *
+ *  @author: CCHyper
+ */
+static bool Read_Scenario_INI_Rules_Process(CCINIClass &ini)
+{
+    /**
+     *  Initialise and process rules.
+     */
+    DEBUG_INFO("Initializeing Rules\n");
+    Rule->Initialize(*RuleINI);
+
+    Session.Loading_Callback(35);
+
+    Call_Back();
+
+    /**
+     *  Read global variables from rules.
+     */
+    DEBUG_INFO("Calling Scen->Read_Global_INI(*RuleINI)...\n");
+    Scen->Read_Global_INI(*RuleINI);
+
+    Call_Back();
+
+    /**
+     *  Process rules scenario overrides.
+     */
+    DEBUG_INFO("Calling Rule->Addition() with scenario overrides.\n");
+    Rule->Addition(ini);
+    DEBUG_INFO("Finished Rule->Addition() with scenario overrides.\n");
+
+    Session.Loading_Callback(45);
+
+    /**
+     *  Read in scenario house types.
+     */
+    if (Session.Type == GAME_NORMAL) {
+        DEBUG_INFO("Calling HouseClass::Read_Scenario_INI()...\n");
+        HouseClass::Read_Scenario_INI(ini);
+    }
+
+    Session.Loading_Callback(50);
+
+    /**
+     *  Read scenario basic.
+     */
+    DEBUG_INFO("Calling Scen->Read_INI()...\n");
+    if (!Scen->Read_INI(ini)) {
+        return false;
+    }
+
+    return true;
+}
+
+
+/**
+ *  Initialise the player value which is later used to load the side assets.
+ *
+ *  @author: CCHyper
+ */
+static bool Read_Scenario_INI_Init_Side(CCINIClass &ini)
+{
+    HouseTypeClass *housetype = nullptr;
+
+    /**
+     *  If this is a campaign session, load the house from the "Player" value.
+     */
+    if (Session.Type == GAME_NORMAL) {
+
+        char buffer[32];
+        ini.Get_String("Basic", "Player", "GDI", buffer, sizeof(buffer));
+
+#if 0
+        /**
+         *  Original game code.
+         */
+        bool is_gdi = strcmpi(buffer, "GDI") == 0;
+        Scen->IsGDI = is_gdi;
+        Scen->SpeechSide = is_gdi ? SIDE_GDI : SIDE_NOD;
+#endif
+
+        /**
+         *  Fetch the houses side type and use this to decide which assets to load.
+         */
+        housetype = (HouseTypeClass *)HouseTypeClass::As_Pointer(buffer);
+
+        Scen->IsGDI = (unsigned char)housetype->Side & 0xFF;
+        Scen->SpeechSide = housetype->Side;
+
+        ASSERT_FATAL_PRINT(housetype != nullptr, "Invalid \"Player\" value in [Basic] section!");
+
+        /**
+         *  Read speech side override.
+         */
+        Scen->SpeechSide = ini.Get_SideType("Basic", "SpeechSide", Scen->SpeechSide);
+
+        ASSERT_FATAL_PRINT(Scen->SpeechSide != SIDE_NONE && Scen->SpeechSide < Sides.Count(), "Invalid \"SpeechSide\" value in [Basic] section!");
+
+    } else {
+
+#if 0
+        /**
+         *  Original game code.
+         */
+        Scen->IsGDI = Session.IsGDI;
+        Scen->SpeechSide = Session.IsGDI ? SIDE_GDI : SIDE_NOD;
+#endif
+
+        /**
+         *  Fetch the houses side type and use this to decide which assets to load.
+         */
+        housetype = (HouseTypeClass *)HouseTypeClass::As_Pointer(HousesType(PlayerPtr->Class->House));
+        ASSERT_FATAL_PRINT(housetype != nullptr, "Invalid multiplayer house!");
+
+        Scen->IsGDI = (unsigned char)housetype->Side & 0xFF;
+        Scen->SpeechSide = housetype->Side;
+
+    }
+
+    return true;
+}
+
+
+/**
+ *  Initialise the player side assets (sidebar, speech, etc).
+ *
+ *  @author: CCHyper
+ */
+static bool Read_Scenario_INI_Prep_For_Side()
+{
+    /**
+     *  Fetch the houses side type and use this to decide which assets to load.
+     */
+    HouseTypeClass *housetype = (HouseTypeClass *)HouseTypeClass::As_Pointer(HousesType(Scen->IsGDI));
+
+#ifndef NDEBUG
+    DEV_DEBUG_INFO("About to prepare for...\n");
+    DEV_DEBUG_INFO("  House \"%s\" (%d) with Side \"%s\" (%d)\n",
+        housetype->Name(), housetype->Get_Heap_ID(),
+        Sides[housetype->Side]->Name(), Sides[housetype->Side]->Get_Heap_ID());
+
+    DEV_DEBUG_INFO("Side info:\n");
+    for (int i = 0; i < Sides.Count(); ++i) {
+        SideClass *side = Sides[i];
+        DEV_DEBUG_INFO("  Side \"%s\" (%d), Houses.Count %d\n", side->IniName, i, side->Houses.Count());
+        for (int i = 0; i < side->Houses.Count(); ++i) {
+            DEV_DEBUG_INFO("    Houses %d = %s (%d)\n", i, HouseTypes[side->Houses[i]]->Name(), side->Houses[i]);
+        }
+    }
+#endif
+
+    DEBUG_INFO("Calling Prep_For_Side()...\n");
+    if (!Prep_For_Side(housetype->Side)) {
+
+        DEBUG_WARNING("Prep_For_Side(%d) failed! Trying with side 0...\n", housetype->Side);
+
+        /**
+         *  Try once again but with the Side 0 (GDI) assets.
+         */
+        if (!Prep_For_Side(SIDE_GDI)) {
+            DEBUG_ERROR("Prep_For_Side() failed!\n");
+            return false;
+        }
+    }
+
+    DEBUG_INFO("Calling Prep_Speech_For_Side()...\n");
+    if (!Prep_Speech_For_Side(Scen->SpeechSide)) {
+
+        DEBUG_WARNING("Prep_Speech_For_Side(%d) failed! Trying with side 0...\n", Scen->SpeechSide);
+
+        /**
+         *  Try once again but with the Side 0 (GDI) assets.
+         */
+        if (!Prep_Speech_For_Side(SIDE_GDI)) {
+            DEBUG_ERROR("Prep_Speech_For_Side() failed!\n");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+/**
+ *  #issue-218
+ *
+ *  This patch replaces a fairly large chunk of code in Read_Scenario_INI that
+ *  read/initialised the player house, loaded the side assets, then processed the
+ *  rules data and scenario overrides.
+ * 
+ *  Because we now abuse ScenarioClass::IsGDI and SessionClass::IsGDI to store
+ *  the player house, we need to reorder this chunk of code to we are reading
+ *  the house types before we load the side assets, this allows us to use the
+ *  Side member of HouseTypeClass to pick the correct assets.
+ * 
+ *  There is an additional chunk of code that has been added to reload the object
+ *  cameos a second time, this is because the loading of the side assets is now
+ *  before the rules initialisation, and as a result, the rules data is being
+ *  processed before the side assets are declared to the mix file system.
+ */
+DECLARE_PATCH(_Read_Scenario_INI_Init_Side_Patch)
+{
+    GET_REGISTER_STATIC(CCINIClass *, ini, ebp);
+
+    /**
+     *  The original code flow was;
+     *    Read [Basic] -> Player=
+     *    Prep_For_Side
+     *    Process Rules.
+     * 
+     *  To support assets for new sides, be now need to move
+     *  the rules processing to before the side and asset loading.
+     */
+
+    if (!Read_Scenario_INI_Rules_Process(*ini)) {
+        goto return_false;
+    }
+
+    if (!Read_Scenario_INI_Init_Side(*ini)) {
+        goto return_false;
+    }
+
+    if (!Read_Scenario_INI_Prep_For_Side()) {
+        goto return_false;
+    }
+
+    if (!Read_Scenario_INI_Reload_Cameo_For_Side()) {
+        goto return_false;
+    }
+
+    JMP(0x005DD956);
+
+return_false:
+    _asm{ xor al, al }
+    JMP_REG(ecx, 0x005DD7AB);
+}
+
+
+/**
+ *  Process additions to the Rules data from the input file.
+ * 
+ *  @author: CCHyper
+ */
+static bool Rule_Addition(const char *fname, bool with_digest = false)
+{
+    CCFileClass file(fname);
+    if (!file.Is_Available()) {
+        return false;
+    }
+
+    CCINIClass ini;
+    if (!ini.Load(file, with_digest)) {
+        return false;
+    }
+
+    DEBUG_INFO("Calling Rule->Addition() with \"%s\" overrides.\n", fname);
+
+    Rule->Addition(ini);
+
+    return true;
+}
+
+
+/**
+ *  #issue-#671
+ * 
+ *  Add loading of MPLAYER.INI to override Rules data for multiplayer games.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_Read_Scenario_INI_MPlayer_INI_Patch)
+{
+    if (Session.Type != GAME_NORMAL && Session.Type != GAME_WDT) {
+
+        /**
+         *  Process the multiplayer ini overrides.
+         */
+        Rule_Addition("MPLAYER.INI");
+        if (Addon_Enabled(ADDON_FIRESTORM)) { 
+            Rule_Addition("MPLAYERFS.INI");
+        }
+
+    }
+
+    /**
+     *  Update the progress screen bars.
+     */
+    Session.Loading_Callback(42);
+
+    /**
+     *  Stolen bytes/code.
+     */
+    Call_Back();
+
+    JMP(0x005DD8DA);
+}
+
+
+/**
  *  #issue-522
  * 
  *  These patches make the multiplayer score screen to honour the value of
@@ -294,4 +641,13 @@ void ScenarioClassExtension_Hooks()
     Patch_Jump(0x00673330, &_Waypoint_From_Name);
     Patch_Jump(0x006732B0, &_Waypoint_To_Name);
     // 0047A96C
+
+    /**
+     *  #issue-218
+     * 
+     *  Changes the default value of ScenarioClass 0x1D91 (IsGDI) from "1" to "0". This is
+     *  because we now use it as a HouseType index, and need it to default to the first index.
+     */
+    Patch_Byte(0x005DAFD0+6, 0x00); // +6 skips the opcode.
+    Patch_Jump(0x005DD6FB, &_Read_Scenario_INI_Init_Side_Patch);
 }

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -274,8 +274,21 @@ static void Init_Loading_Screen(const char *filename)
     if (side == SIDE_GDI) {
         prefix = Percent_Chance(50) ? 'C' : 'D';
 
+    } else if (side == SIDE_NOD) {
+        prefix = Percent_Chance(50) ? 'A' : 'B';
+
+    /**
+     *  #issue-665
+     *
+     *  The remaining characters can be used in standard order for new sides.
+     *  This gives us support for 11 new sides before this system breaks.
+     */
     } else {
         prefix = Percent_Chance(50) ? 'A' : 'B';
+        prefix += char(2*side); // Offset the character based on the side index.
+        if (prefix > 'Z') {
+            prefix = 'Z';
+        }
     }
 
     Point2D textpos(0,0);
@@ -309,9 +322,16 @@ static void Init_Loading_Screen(const char *filename)
             textpos.X = solo ? 435 : 435;
             textpos.Y = solo ? 157 : 157;
 
-        } else {
+        } else if (side == SIDE_NOD) {
             textpos.X = solo ? 436 : 436;
             textpos.Y = solo ? 161 : 161;
+
+        /**
+         *  All other sides (uses the GDI offsets).
+         */
+        } else {
+            textpos.X = solo ? 435 : 435;
+            textpos.Y = solo ? 157 : 157;
         }
 
         image_width = 640;
@@ -345,9 +365,16 @@ static void Init_Loading_Screen(const char *filename)
             textpos.X = solo ? 435 : 435;
             textpos.Y = solo ? 195 : 195;
 
-        } else {
+        } else if (side == SIDE_NOD) {
             textpos.X = solo ? 436 : 436;
             textpos.Y = solo ? 200 : 200;
+
+        /**
+         *  All other sides (uses the GDI offsets).
+         */
+        } else {
+            textpos.X = solo ? 435 : 435;
+            textpos.Y = solo ? 195 : 195;
         }
 
         image_width = 640;
@@ -381,9 +408,16 @@ static void Init_Loading_Screen(const char *filename)
             textpos.X = solo ? 563 : 563;
             textpos.Y = solo ? 252 : 252;
 
-        } else {
+        } else if (side == SIDE_NOD) {
             textpos.X = solo ? 565 : 565;
             textpos.Y = solo ? 258 : 258;
+
+        /**
+         *  All other sides (uses the GDI offsets).
+         */
+        } else {
+            textpos.X = solo ? 563 : 563;
+            textpos.Y = solo ? 252 : 252;
         }
 
         image_width = 800;
@@ -413,6 +447,14 @@ static void Init_Loading_Screen(const char *filename)
      */
     char loadname[16];
     std::snprintf(loadname, sizeof(loadname), "LOAD%d%c.PCX", load_filename_height, prefix);
+
+    /**
+     *  Check to make sure the loading screen file can be found, if not, then
+     *  default to the GDI loading screen image set.
+     */
+    if (!CCFileClass(loadname).Is_Available()) {
+        std::snprintf(loadname, sizeof(loadname), "LOAD%d%c.PCX", load_filename_height, Sim_Percent_Chance(50) ? 'C' : 'D');
+    }
 
     DEV_DEBUG_INFO("Loading Screen: \"%s\"\n", loadname);
 

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -658,6 +658,15 @@ static bool Read_Scenario_INI_Init_Side(CCINIClass &ini)
 
         ASSERT_FATAL_PRINT(Scen->SpeechSide != SIDE_NONE && Scen->SpeechSide < Sides.Count(), "Invalid \"SpeechSide\" value in [Basic] section!");
 
+        /**
+         *  #issue-309
+         * 
+         *  Read sidebar side override.
+         */
+        ScenExtension->SidebarSide = ini.Get_SideType("Basic", "SidebarSide", housetype->Side);
+
+        ASSERT_FATAL_PRINT(ScenExtension->SidebarSide != SIDE_NONE && ScenExtension->SidebarSide < Sides.Count(), "Invalid \"SidebarSide\" value in [Basic] section!");
+
     } else {
 
 #if 0
@@ -676,6 +685,7 @@ static bool Read_Scenario_INI_Init_Side(CCINIClass &ini)
 
         Scen->IsGDI = (unsigned char)housetype->Side & 0xFF;
         Scen->SpeechSide = housetype->Side;
+        ScenExtension->SidebarSide = housetype->Side;
 
     }
 
@@ -712,9 +722,9 @@ static bool Read_Scenario_INI_Prep_For_Side()
 #endif
 
     DEBUG_INFO("Calling Prep_For_Side()...\n");
-    if (!Prep_For_Side(housetype->Side)) {
+    if (!Prep_For_Side(ScenExtension->SidebarSide)) {
 
-        DEBUG_WARNING("Prep_For_Side(%d) failed! Trying with side 0...\n", housetype->Side);
+        DEBUG_WARNING("Prep_For_Side(%d) failed! Trying with side 0...\n", ScenExtension->SidebarSide);
 
         /**
          *  Try once again but with the Side 0 (GDI) assets.

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -255,13 +255,23 @@ static void Init_Loading_Screen(const char *filename)
     }
 
     /**
-     *  For the campaign, we abuse the required CD to get the desired Side.
+     *  For the campaign, we check to see if the scenario name contains either
+     *  "GDI" or "NOD", and then set the side to those respectively.
      */
     SideType side = SIDE_GDI;
     if (Session.Type == GAME_NORMAL) {
 
         if (Scen->CampaignID != CAMPAIGN_NONE) {
-            side = SideType(Campaigns[Scen->CampaignID]->WhichCD);
+
+            const char *scen_name = Campaigns[Scen->CampaignID]->Scenario;
+
+            if (std::strstr(scen_name, "GDI")) {
+                side = SIDE_GDI;
+
+            } else if (std::strstr(scen_name, "NOD")) {
+                side = SIDE_NOD;
+            }
+
         }
 
     /**

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -57,6 +57,7 @@
 #include "progressscreen.h"
 #include "language.h"
 #include "wsproto.h"
+#include "rulesext.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -237,6 +238,18 @@ static void Init_Loading_Screen(const char *filename)
 
     bool solo = Session.Singleplayer_Game();
     int player_count = solo ? 1 : Session.Players.Count();
+
+    /**
+     *  #EDGE-CASE/#BUGFIX:
+     * 
+     *  We need to do the fixup even earlier now as we need to use the Side
+     *  value from the players HouseType.
+     */
+    {
+        CCFileClass file(filename);
+        CCINIClass ini(file);
+        RuleExtension->Fixups(ini);
+    }
 
     /**
      *  For the campaign, we abuse the required CD to get the desired Side.

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -285,12 +285,33 @@ static void Init_Loading_Screen(const char *filename)
      */
     if (ScreenRect.Width >= 640 && ScreenRect.Height == 400) {
 
+        /**
+         *  #issue-294
+         * 
+         *  Centralises the position of the loading screen text.
+         * 
+         *  Original code retained below.
+         */
+#if 0
         if (solo) {
             textpos.X = 440;
             textpos.Y = 158;
         } else {
             textpos.X = 570;
             textpos.Y = 155;
+        }
+#endif
+
+        /**
+         *  The text box is in slightly different positions between GDI and NOD.
+         */
+        if (side == SIDE_GDI) {
+            textpos.X = solo ? 435 : 435;
+            textpos.Y = solo ? 157 : 157;
+
+        } else {
+            textpos.X = solo ? 436 : 436;
+            textpos.Y = solo ? 161 : 161;
         }
 
         image_width = 640;
@@ -300,12 +321,33 @@ static void Init_Loading_Screen(const char *filename)
 
     } else if (ScreenRect.Width >= 640 && ScreenRect.Height == 480) {
 
+        /**
+         *  #issue-294
+         *
+         *  Centralises the position of the loading screen text.
+         *
+         *  Original code retained below.
+         */
+#if 0
         if (solo) {
             textpos.X = 440;
             textpos.Y = 189;
         } else {
             textpos.X = 570;
             textpos.Y = 180;
+        }
+#endif
+
+        /**
+         *  The text box is in slightly different positions between GDI and NOD.
+         */
+        if (side == SIDE_GDI) {
+            textpos.X = solo ? 435 : 435;
+            textpos.Y = solo ? 195 : 195;
+
+        } else {
+            textpos.X = solo ? 436 : 436;
+            textpos.Y = solo ? 200 : 200;
         }
 
         image_width = 640;
@@ -315,12 +357,33 @@ static void Init_Loading_Screen(const char *filename)
 
     } else if (ScreenRect.Width >= 800 && ScreenRect.Height >= 600) {
 
+        /**
+         *  #issue-294
+         *
+         *  Centralises the position of the loading screen text.
+         *
+         *  Original code retained below.
+         */
+#if 0
         if (solo) {
             textpos.X = 550;
             textpos.Y = 236;
         } else {
             textpos.X = 715;
             textpos.Y = 230;
+        }
+#endif
+
+        /**
+         *  The text box is in slightly different positions between GDI and NOD.
+         */
+        if (side == SIDE_GDI) {
+            textpos.X = solo ? 563 : 563;
+            textpos.Y = solo ? 252 : 252;
+
+        } else {
+            textpos.X = solo ? 565 : 565;
+            textpos.Y = solo ? 258 : 258;
         }
 
         image_width = 800;

--- a/src/extensions/scenario/scenarioext_init.cpp
+++ b/src/extensions/scenario/scenarioext_init.cpp
@@ -137,52 +137,6 @@ original_code:
 
 
 /**
- *  Patch for reading the extended class members from the ini instance.
- *
- *  @warning: Do not touch this unless you know what you are doing!
- *
- *  @author: CCHyper
- */
-DECLARE_PATCH(_ScenarioClass_Read_INI_Patch)
-{
-    GET_REGISTER_STATIC(CCINIClass *, ini, ebp);
-    static bool retval;
-
-    /**
-     *  Stolen bytes/code.
-     */
-    retval |= Scen->Read_INI(*ini);
-
-    retval |= ScenExtension->Read_INI(*ini);
-
-    _asm { mov al, retval }
-    JMP_REG(ecx, 0x005DD947);
-}
-
-
-/**
- *  Patch for reading the extended class members from the ini instance.
- *
- *  @warning: Do not touch this unless you know what you are doing!
- *
- *  @author: CCHyper
- */
-DECLARE_PATCH(_ScenarioClass_Read_Scenario_INI_Patch)
-{
-    GET_REGISTER_STATIC(CCINIClass *, ini, ebp);
-
-    ScenExtension->Read_Scenario_INI(*ini);
-
-    /**
-     *  Stolen bytes/code.
-     */
-    Session.Loading_Callback(3);
-
-    JMP(0x005DD65E);
-}
-
-
-/**
  *  Main function for patching the hooks.
  */
 void ScenarioClassExtension_Init()
@@ -190,6 +144,4 @@ void ScenarioClassExtension_Init()
     Patch_Jump(0x005DADDE, &_ScenarioClass_Constructor_Patch);
     Patch_Jump(0x006023CC, &_ScenarioClass_Destructor_Patch); // Inlined in game shutdown.
     Patch_Jump(0x005DB166, &_ScenarioClass_Init_Clear_Patch);
-    Patch_Jump(0x005DD93B, &_ScenarioClass_Read_INI_Patch);
-    Patch_Jump(0x005DD652, &_ScenarioClass_Read_Scenario_INI_Patch);
 }

--- a/src/extensions/scenario/scenarioext_init.cpp
+++ b/src/extensions/scenario/scenarioext_init.cpp
@@ -29,6 +29,7 @@
 #include "scenarioext.h"
 #include "scenario.h"
 #include "tibsun_globals.h"
+#include "session.h"
 #include "vinifera_util.h"
 #include "extension.h"
 #include "extension_globals.h"
@@ -160,6 +161,28 @@ DECLARE_PATCH(_ScenarioClass_Read_INI_Patch)
 
 
 /**
+ *  Patch for reading the extended class members from the ini instance.
+ *
+ *  @warning: Do not touch this unless you know what you are doing!
+ *
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_ScenarioClass_Read_Scenario_INI_Patch)
+{
+    GET_REGISTER_STATIC(CCINIClass *, ini, ebp);
+
+    ScenExtension->Read_Scenario_INI(*ini);
+
+    /**
+     *  Stolen bytes/code.
+     */
+    Session.Loading_Callback(3);
+
+    JMP(0x005DD65E);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void ScenarioClassExtension_Init()
@@ -168,4 +191,5 @@ void ScenarioClassExtension_Init()
     Patch_Jump(0x006023CC, &_ScenarioClass_Destructor_Patch); // Inlined in game shutdown.
     Patch_Jump(0x005DB166, &_ScenarioClass_Init_Clear_Patch);
     Patch_Jump(0x005DD93B, &_ScenarioClass_Read_INI_Patch);
+    Patch_Jump(0x005DD652, &_ScenarioClass_Read_Scenario_INI_Patch);
 }

--- a/src/extensions/session/sessionext_hooks.cpp
+++ b/src/extensions/session/sessionext_hooks.cpp
@@ -32,6 +32,9 @@
 #include "debughandler.h"
 #include "asserthandler.h"
 
+#include "hooker.h"
+#include "hooker_macros.h"
+
 
 /**
  *  Main function for patching the hooks.
@@ -42,4 +45,12 @@ void SessionClassExtension_Hooks()
      *  Initialises the extended class.
      */
     SessionClassExtension_Init();
+
+    /**
+     *  #issue-218
+     *
+     *  Changes the default value of SessionClass 0x1D91 (IsGDI) from "1" to "0".. This is
+     *  because we now use it as a HouseType index, and need it to default to the first index.
+     */
+    Patch_Byte(0x005ED06B+1, 0x85); // changes "dl" (1) to "al" (0)
 }

--- a/src/extensions/taction/tactionext_hooks.cpp
+++ b/src/extensions/taction/tactionext_hooks.cpp
@@ -1170,7 +1170,7 @@ bool TActionClassExt::_TAction_Give_Credits(HouseClass* house, ObjectClass* obje
      *  Give credits to the house.
      */
     if (other) {
-        other->Refund_Money(Data.Value);
+        other->Refund_Money(Bounds.X); // Don't know, maybe it could be refactored somehow? This is where P3 should end up.
     }
 
     return true;

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -185,6 +185,8 @@ HRESULT TechnoTypeClassExtension::Save(IStream *pStm, BOOL fClearDirty)
         return hr;
     }
 
+    ScrapExplosion.Save(pStm);
+
     return hr;
 }
 

--- a/src/spawner/spawner.cpp
+++ b/src/spawner/spawner.cpp
@@ -350,7 +350,7 @@ void Spawner::Init_Network()
     Session.CommProtocol                = 2;
     Session.LatencyFudge                = 0;
     Session.DesiredFrameRate            = 60;
-    TournamentGameType                  = static_cast<WOL::Tournament>(Config->Tournament);
+    PlanetWestwoodTournament            = static_cast<WOL::Tournament>(Config->Tournament);
     PlanetWestwoodGameID                = Config->WOLGameID;
     FrameSyncSettings[GAME_IPX].Timeout = Config->ReconnectTimeout;
 

--- a/src/spawner/spawner.cpp
+++ b/src/spawner/spawner.cpp
@@ -47,6 +47,7 @@
 #include "gscreen.h"
 #include "housetype.h"
 #include "language.h"
+#include "housetypeext.h"
 #include "mouse.h"
 #include "ownrdraw.h"
 #include "saveload.h"
@@ -100,7 +101,6 @@ bool Spawner::Start_Game()
     GameActive = true;
 
     Init_UI();
-    Read_Houses_And_Sides();
 
     const bool result = Start_Scenario(Config->ScenarioName);
 
@@ -166,11 +166,6 @@ bool Spawner::Start_Scenario(const char* scenario_name)
     Seed = Config->Seed;
     BuildLevel = Config->TechLevel;
     Options.GameSpeed = Config->GameSpeed;
-
-    // Inverted for now as the sidebar hack until we reimplement loading
-    Session.IsGDI = true;// HouseTypes[Config->Players[0].House]->Get_Heap_ID();
-    //Session.IsGDI = HouseTypes[Config->Players[0].House]->Side != SIDE_NOD;
-    DEBUG_INFO("[Spawner] Session.IsGDI = %d\n", Session.IsGDI);
 
     Vinifera_NextAutoSaveNumber = Config->NextAutoSaveNumber;
 
@@ -515,19 +510,4 @@ void Spawner::Prepare_Screen()
 
     Map.TabClass::Activate(1);
     Map.SidebarClass::Flag_To_Redraw();
-}
-
-
-/**
- *  Reads Houses and Sides to Rules so that we can use them to choose a loading screen.
- *
- *  @author: ZivDero
- */
-void Spawner::Read_Houses_And_Sides()
-{
-    Rule->Houses(*RuleINI);
-    Rule->Sides(*RuleINI);
-
-    for (int i = 0; i < Houses.Count(); i++)
-        Houses[i]->Read_INI(*RuleINI);
 }

--- a/src/spawner/spawner.h
+++ b/src/spawner/spawner.h
@@ -59,5 +59,4 @@ private:
 
     static void Init_UI();
     static void Prepare_Screen();
-    static void Read_Houses_And_Sides();
 };

--- a/src/spawner/spawner_hooks.cpp
+++ b/src/spawner/spawner_hooks.cpp
@@ -112,18 +112,6 @@ DECLARE_PATCH(_HouseClass_Expert_AI_Check_Allies)
 
 
 /**
- *  Patches the score screen to be skipped if SkipScoreScreen is set.
- *
- *  @author: ZivDero
- */
-static void MultiScore_Wrapper()
-{
-    if (!Spawner::Get_Config()->SkipScoreScreen)
-        MultiScore::Presentation();
-}
-
-
-/**
  *  Players skipping movies in multiplayer leads to disconnects.
  *  Prevent players from skipping movies in MP.
  *
@@ -218,12 +206,6 @@ void Spawner_Hooks()
 
     Patch_Jump(0x004C06EF, &_HouseClass_Expert_AI_Check_Allies);
     Patch_Jump(0x004C3630, &HouseClassExt::_Computer_Paranoid);  // Disable paranoid computer behavior
-
-    /**
-     *  SkipScoreScreen feature.
-     */
-    Patch_Call(0x005DC9DA, &MultiScore_Wrapper);
-    Patch_Call(0x005DCD98, &MultiScore_Wrapper);
 
     /**
      *  PlayMoviesInMultiplayer feature.

--- a/src/spawner/spawnerconfig.cpp
+++ b/src/spawner/spawnerconfig.cpp
@@ -128,6 +128,8 @@ void SpawnerConfig::Read_INI(CCINIClass& spawn_ini)
     UseMPAIBaseNodes         = spawn_ini.Get_Bool(SETTINGS, "UseMPAIBaseNodes", UseMPAIBaseNodes);
     AttackNeutralUnits       = spawn_ini.Get_Bool(SETTINGS, "AttackNeutralUnits", AttackNeutralUnits);
     ScrapMetal               = spawn_ini.Get_Bool(SETTINGS, "ScrapMetal", ScrapMetal);
+    /* CustomLoadScreen   */   spawn_ini.Get_String(SETTINGS, "CustomLoadScreen", CustomLoadScreen, sizeof(CustomLoadScreen));
+    CustomLoadScreenPos      = spawn_ini.Get_Point(SETTINGS, "CustomLoadScreenPos", CustomLoadScreenPos);
 }
 
 

--- a/src/spawner/spawnerconfig.h
+++ b/src/spawner/spawnerconfig.h
@@ -170,6 +170,8 @@ public:
     bool UseMPAIBaseNodes;
     bool AttackNeutralUnits;
     bool ScrapMetal;
+    char CustomLoadScreen[PATH_MAX];
+    TPoint2D<int> CustomLoadScreenPos;
 
     SpawnerConfig()
         : Bases { true }
@@ -254,6 +256,8 @@ public:
         , UseMPAIBaseNodes { false }
         , AttackNeutralUnits{ false }
         , ScrapMetal { false }
+        , CustomLoadScreen { "" }
+        , CustomLoadScreenPos {}
     { }
 
     void Read_INI(CCINIClass& spawn_ini);

--- a/src/spawner/spawnerconfig.h
+++ b/src/spawner/spawnerconfig.h
@@ -257,7 +257,7 @@ public:
         , AttackNeutralUnits{ false }
         , ScrapMetal { false }
         , CustomLoadScreen { "" }
-        , CustomLoadScreenPos {}
+        , CustomLoadScreenPos { }
     { }
 
     void Read_INI(CCINIClass& spawn_ini);

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -624,9 +624,9 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
      *  bugfix works without extending any of the games classes, but this does mean we
      *  are limited to 255 unique houses!
      */
-    HousesType house = HousesType(Scen->IsGDI);
+    const HousesType house = static_cast<HousesType>(Scen->IsGDI);
     ASSERT_FATAL(house != HOUSE_NONE & house < HouseTypes.Count());
-    HouseTypeClass* housetype = HouseTypes[house];
+    const HouseTypeClass* housetype = HouseTypes[house];
     ASSERT_FATAL(housetype != nullptr);
 
     /**

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -1079,9 +1079,21 @@ bool LoadOptionsClassExt::_Read_File(FileEntryClass* file, WIN32_FIND_DATA* file
                 return false;
             }
 
-            if (GameActive && Session.Type == GAME_NORMAL && saveversion.Get_Playthrough_ID() != Vinifera_PlaythroughID) {
-                DEBUG_INFO("Save file \"%s\" belongs to a different playthough, skipping.\n", formatted_file_name);
-                return false;
+            /**
+             *  Don't allow loading saves from other campaign playthroughs, or campaign saves in general if we're not in campaign
+             *  (to facilitate the client's playthrough tracking).
+             */
+            if (GameActive) {
+
+                if (Session.Type == GAME_NORMAL && saveversion.Get_Playthrough_ID() != Vinifera_PlaythroughID) {
+                    DEBUG_INFO("Save file \"%s\" belongs to a different playthough, skipping.\n", formatted_file_name);
+                    return false;
+                }
+
+                if (Session.Type != GAME_NORMAL && saveversion.Get_Game_Type() == GAME_NORMAL) {
+                    DEBUG_INFO("Save file \"%s\" is a campaign save and the player is currently not in campaign, skipping.\n", formatted_file_name);
+                    return false;
+                }
             }
 
             wsprintfA(file->Descr, "%s", saveversion.Get_Scenario_Description());

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -140,6 +140,8 @@
 #include "technoext.h"
 #include "verses.h"
 
+#include "scenarioext.h"
+
 
 /**
  *  Constant of the current build version number. This number should be
@@ -481,7 +483,7 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
      *  Fetch the houses side type and use this to decide which assets to load.
      */
     DEBUG_INFO("About to call Prep_For_Side()...\n");
-    if (!Prep_For_Side(housetype->Side)) {
+    if (!Prep_For_Side(ScenExtension->SidebarSide)) {
         DEBUG_WARNING("Prep_For_Side(%d) failed! Trying with side 0...\n", housetype->Side);
 
         /**

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -430,19 +430,6 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
     Scen->Load(pStm);
 
     /**
-     *  #issue-218
-     *
-     *  We now abuse ScenarioClass::IsGDI to store the player house so it can be used to
-     *  fetch the SideType from it for loading the assets. This also means this
-     *  bugfix works without extending any of the games classes, but this does mean we
-     *  are limited to 255 unique houses!
-     */
-    HousesType house = HousesType(Scen->IsGDI);
-    ASSERT_FATAL(house != HOUSE_NONE & house < HouseTypes.Count());
-    HouseTypeClass *housetype = HouseTypes[house];
-    ASSERT_FATAL(housetype != nullptr);
-
-    /**
      *  #issue-123
      *
      *  Save files do not store the tutorial messages, so we reload them from
@@ -479,22 +466,6 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
 
     Enable_Addon(Scen->RequiredAddOn);
 
-    /**
-     *  Fetch the houses side type and use this to decide which assets to load.
-     */
-    DEBUG_INFO("About to call Prep_For_Side()...\n");
-    if (!Prep_For_Side(ScenExtension->SidebarSide)) {
-        DEBUG_WARNING("Prep_For_Side(%d) failed! Trying with side 0...\n", housetype->Side);
-
-        /**
-         *  Try once again but with the Side 0 (GDI) assets.
-         */
-        if (!Prep_For_Side(SIDE_GDI)) {
-            DEBUG_ERROR("Prep_For_Side() failed!\n");
-            return false;
-        }
-    }
-
     {
     Rect tactical_rect = Get_Tactical_Rect();
     Rect composite_rect(0, 0, tactical_rect.Width, ScreenRect.Height);
@@ -522,22 +493,6 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
 
     DEBUG_INFO("Loading Rule...\n");
     Rule->Load(pStm);
-
-    /**
-     *  Fetch the houses side type and use this to decide which speech assets to load.
-     */
-    DEBUG_INFO("About to call Prep_Speech_For_Side()...\n");
-    if (!Prep_Speech_For_Side(housetype->Side)) {
-        DEBUG_WARNING("Prep_Speech_For_Side(%d) failed! Trying with side 0...\n", housetype->Side);
-
-        /**
-         *  Try once again but with the Side 0 (GDI) assets.
-         */
-        if (!Prep_Speech_For_Side(SIDE_GDI)) {
-            DEBUG_ERROR("Prep_Speech_For_Side() failed!\n");
-            return false;
-        }
-    }
 
     if (FAILED(Vinifera_Load_Vector(pStm, AnimTypes, "AnimTypes"))) { return false; }
 
@@ -659,6 +614,51 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
     if (!Extension::Load(pStm)) {
         DEBUG_ERROR("\t***** FAILED!\n");
         return false;
+    }
+
+    /**
+     *  #issue-218
+     *
+     *  We now abuse ScenarioClass::IsGDI to store the player house so it can be used to
+     *  fetch the SideType from it for loading the assets. This also means this
+     *  bugfix works without extending any of the games classes, but this does mean we
+     *  are limited to 255 unique houses!
+     */
+    HousesType house = HousesType(Scen->IsGDI);
+    ASSERT_FATAL(house != HOUSE_NONE & house < HouseTypes.Count());
+    HouseTypeClass* housetype = HouseTypes[house];
+    ASSERT_FATAL(housetype != nullptr);
+
+    /**
+     *  Fetch the houses side type and use this to decide which assets to load.
+     */
+    DEBUG_INFO("About to call Prep_For_Side()...\n");
+    if (!Prep_For_Side(ScenExtension->SidebarSide)) {
+        DEBUG_WARNING("Prep_For_Side(%d) failed! Trying with side 0...\n", housetype->Side);
+
+        /**
+         *  Try once again but with the Side 0 (GDI) assets.
+         */
+        if (!Prep_For_Side(SIDE_GDI)) {
+            DEBUG_ERROR("Prep_For_Side() failed!\n");
+            return false;
+        }
+    }
+
+    /**
+     *  Fetch the houses side type and use this to decide which speech assets to load.
+     */
+    DEBUG_INFO("About to call Prep_Speech_For_Side()...\n");
+    if (!Prep_Speech_For_Side(housetype->Side)) {
+        DEBUG_WARNING("Prep_Speech_For_Side(%d) failed! Trying with side 0...\n", housetype->Side);
+
+        /**
+         *  Try once again but with the Side 0 (GDI) assets.
+         */
+        if (!Prep_Speech_For_Side(SIDE_GDI)) {
+            DEBUG_ERROR("Prep_Speech_For_Side() failed!\n");
+            return false;
+        }
     }
 
     Map.Flag_To_Redraw(2);


### PR DESCRIPTION
Closes #218, Closes #309, Closes #294, Closes #665, Closes #922

This pull request implements support/bug-fixes for the following;

- Removes the limit of only two sides allowed to have unique sidebar and speech assets.
- Removes the limit of only two sides allowed to have unique loading screens.
- Fixes a bug where the loading screen text was inconsistent, it is now centered in the text box.
- Ability to override the player's sidebar graphics. `[Basic]` -> `SidebarSide=<SideType>` _(campaign scenarios only)_.
- Custom loading screens can now be defined per scenario, for each supported resolution.

**_NOTES:_**
 
**Loading Screens;**
The original game used `LOAD###C` and `LOAD###D` for the GDI loading screens, and `LOAD###A` and `LOAD###B` for the NOD loading screens. This behavior is retained, and all further sides will use the correct suffixes _(e.g. `LOAD###E` and `LOAD###F` for the 3rd side, etc)_.

**Custom Loading Screens;**
You can now override the loading screen for a specific scenario. _(There is a limit of 32 characters for the filename)_. These are to be defined under the `[Basic]` section of a scenario.
`LS400BkgdName=`, `LS480BkgdName=`, `LS600BkgdName=`, for example; `LS400BkgdName=LS400GDI1A.PCX`

In addition to this, you can also set the position of the text on the loading screen _(only if a custom loading screen has been defined)_;
`LS400TextLoc=`, `LS480TextLoc=`, `LS600TextLoc=`. Each is in the format of `LS400TextLoc=X,Y`.