### PR TITLE
Adds `IceStrength` to Rules, and `IceDestructionEnabled` scenario option.

### DIFF
--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -73,7 +73,8 @@ RulesClassExtension::RulesClassExtension(const RulesClass *this_ptr) :
     IsMPAutoDeployMCV(false),
     IsMPPrePlacedConYards(false),
     IsBuildOffAlly(true),
-    IsShowSuperWeaponTimers(true)
+    IsShowSuperWeaponTimers(true),
+    IceStrength(0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("RulesClassExtension::RulesClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
@@ -189,6 +190,7 @@ void RulesClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(IsMPPrePlacedConYards);
     crc(IsBuildOffAlly);
     crc(IsShowSuperWeaponTimers);
+    crc(IceStrength);
 }
 
 
@@ -272,6 +274,7 @@ void RulesClassExtension::Process(CCINIClass &ini)
     General(ini);
     MPlayer(ini);
     AudioVisual(ini);
+    CombatDamage(ini);
 
     /**
      *  Process the objects (extension classes).
@@ -444,6 +447,27 @@ bool RulesClassExtension::AudioVisual(CCINIClass &ini)
     }
 
     IsShowSuperWeaponTimers = ini.Get_Bool(AUDIOVISUAL, "ShowSuperWeaponTimers", IsShowSuperWeaponTimers);
+
+    return true;
+}
+
+
+/**
+ *  Process the combat damage related game settings.
+ *
+ *  @author: Rampastring
+ */
+bool RulesClassExtension::CombatDamage(CCINIClass & ini)
+{
+    //EXT_DEBUG_TRACE("RulesClassExtension::CombatDamage - 0x%08X\n", (uintptr_t)(This()));
+
+    static char const * const COMBATDAMAGE = "CombatDamage";
+
+    if (!ini.Is_Present(COMBATDAMAGE)) {
+        return false;
+    }
+
+    IceStrength = ini.Get_Int(COMBATDAMAGE, "IceStrength", IceStrength);
 
     return true;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -63,6 +63,7 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
         bool General(CCINIClass &ini);
         bool MPlayer(CCINIClass &ini);
         bool AudioVisual(CCINIClass &ini);
+        bool CombatDamage(CCINIClass &ini);
         bool Weapons(CCINIClass &ini);
 
     private:
@@ -90,4 +91,10 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
          *  on the tactical view?
          */
         bool IsShowSuperWeaponTimers;
+
+        /**
+         *  Defines the strength of ice. Higher values make ice less likely
+         *  to break from a shot.
+         */
+        int IceStrength;
 };

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -54,7 +54,8 @@
  *  @author: CCHyper
  */
 ScenarioClassExtension::ScenarioClassExtension(const ScenarioClass *this_ptr) :
-    GlobalExtensionClass(this_ptr)
+    GlobalExtensionClass(this_ptr),
+    IsIceDestruction(true)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("ScenarioClassExtension::ScenarioClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
@@ -158,6 +159,8 @@ void ScenarioClassExtension::Detach(TARGET target, bool all)
 void ScenarioClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     //EXT_DEBUG_TRACE("ScenarioClassExtension::Compute_CRC - 0x%08X\n", (uintptr_t)(This()));
+
+    crc(IsIceDestruction);
 }
 
 
@@ -169,6 +172,8 @@ void ScenarioClassExtension::Compute_CRC(WWCRCEngine &crc) const
 void ScenarioClassExtension::Init_Clear()
 {
     //EXT_DEBUG_TRACE("ScenarioClassExtension::Init_Clear - 0x%08X\n", (uintptr_t)(This()));
+
+    IsIceDestruction = true;
 
     {
         /**
@@ -195,6 +200,10 @@ void ScenarioClassExtension::Init_Clear()
 bool ScenarioClassExtension::Read_INI(CCINIClass &ini)
 {
     //EXT_DEBUG_TRACE("ScenarioClassExtension::Read_INI - 0x%08X\n", (uintptr_t)(This()));
+
+    static const char * const BASIC = "Basic";
+
+    IsIceDestruction = ini.Get_Bool(BASIC, "IceDestructionEnabled", IsIceDestruction);
 
     /**
      *  #issue-123

--- a/src/extensions/scenario/scenarioext.h
+++ b/src/extensions/scenario/scenarioext.h
@@ -59,5 +59,8 @@ class ScenarioClassExtension final : public GlobalExtensionClass<ScenarioClass>
         static void Create_Units(bool official);
 
     public:
-
+        /**
+         *  Can ice get destroyed when hit by certain weapons?
+         */
+        bool IsIceDestruction;
 };


### PR DESCRIPTION
Closes #897 

This PR adds two keys for customizing ice destruction logic.

1) In a scenario file,

```ini
[Basic]
IceDestructionEnabled=<bool> ; determines whether ice tiles can be destroyed in the scenario. Defaults to yes.
```

2) In rules,

```ini
[CombatDamage]
IceStrength=<int> ; Defines the strength of ice. Higher values make ice less likely to
                              ; break from a shot. 0 makes ice break from any shot, like in the original game.
```