### PR TITLE
Add `TransformsInto` for UnitTypes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -131,8 +131,9 @@ This page lists all the individual contributions to the project by their author.
 - **Rampastring**:
   - Add `IceStrength` to Rules, and `IceDestructionEnabled` scenario option.
   - Add `ImmuneToEMP` to TechnoTypes.
+  - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes.
   - Make it possible to assign rally points to service depots.
-  - Fix an issue where losers were not marked as defeated in multiplayer when using TACTION_WIN or TACTION_LOSE to end the game (by Rampastring)
+  - Fix an issue where losers were not marked as defeated in multiplayer when using TACTION_WIN or TACTION_LOSE to end the game
   - Add extended descriptions in tooltips for objects on the sidebar.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -525,6 +525,18 @@ WeedPipIndex=1  ; integer, the pip index used for Weeds.
 
 ## Vehicles
 
+### Unit Transform
+
+- Vinifera adds a new flag that allows a unit to transform into another type of unit upon deploying instead of transforming into a building.
+
+In `RULES.INI`:
+```ini
+[SOMEUNIT]
+TransformsInto=OTHERUNIT
+```
+
+- Additionally, the unit can be configured to require full charge to be able to transform, reusing the charge mechanic from the vanilla Mobile EMP Cannon. To do this, give the unit `TransformRequiresFullCharge=yes`.
+
 ### Totable
 
 - Vinifera adds a new flag which can prevent a vehicle from being picked up by a Carryall.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -139,6 +139,7 @@ New:
 - Add a developer command to dump all heaps to the log (by ZivDero)
 - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius (by ZivDero)
 - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties (by ZivDero)
+- Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -35,6 +35,8 @@
 #include "super.h"
 #include "factory.h"
 #include "techno.h"
+#include "unittype.h"
+#include "unittypeext.h"
 #include "mouse.h"
 #include "fatal.h"
 #include "debughandler.h"
@@ -359,6 +361,116 @@ return_true:
 
 
 /**
+ *  #issue-715
+ *
+ *  Gets the number of queued objects when determining whether a cameo
+ *  should be disabled.
+ *
+ *  Author: Rampastring
+ */
+int _HouseClass_ShouldDisableCameo_Get_Queued_Count(FactoryClass* factory, TechnoTypeClass* technotype)
+{
+    int count = factory->Total_Queued(*technotype);
+    TechnoClass* factoryobject = factory->Get_Object();
+
+    if (factoryobject == nullptr || count == 0) {
+        return 0;
+    }
+
+    /**
+     *  Check that the factory is trying to create the object that the player is trying to queue
+     *  If not, we don't need to mess with the count
+     */
+    if (factoryobject->Techno_Type_Class() != technotype) {
+        return count;
+    }
+
+    /**
+    *  #issue-715
+    *
+    *  If the object can transform into another object through our special logic,
+    *  then check that doing so doesn't allow circumventing build limits
+    */
+    if (technotype->What_Am_I() == RTTI_UNITTYPE) {
+        UnitTypeClass* unittype = reinterpret_cast<UnitTypeClass*>(technotype);
+        UnitTypeClassExtension* unittypeext = Extension::Fetch<UnitTypeClassExtension>(unittype);
+
+        if (unittype->DeploysInto == nullptr && unittypeext->TransformsInto != nullptr) {
+            count += factory->House->UQuantity.Count_Of((UnitType)(unittypeext->TransformsInto->Get_Heap_ID()));
+        }
+    }
+
+    return count;
+}
+
+
+/**
+ *  #issue-715
+ *
+ *  Updates the build limit logic with unit queuing to
+ *  take our unit transformation logic into account.
+ */
+DECLARE_PATCH(_HouseClass_ShouldDisableCameo_BuildLimit_Fix)
+{
+    GET_REGISTER_STATIC(FactoryClass*, factory, ecx);
+    GET_REGISTER_STATIC(TechnoTypeClass*, technotype, esi);
+    static int queuedcount;
+
+    queuedcount = _HouseClass_ShouldDisableCameo_Get_Queued_Count(factory, technotype);
+
+    _asm { mov eax, [queuedcount] }
+    JMP_REG(ecx, 0x004CB77D);
+}
+
+
+/**
+ *  #issue-715
+ *
+ *  Take vehicles that can transform into other vehicles into acccount when
+ *  determining whether a build limit has been met/exceeded.
+ *  Otherwise these kinds of units could be used to bypass build limits
+ *  (build a limited vehicle, transform it, now you can build another vehicle).
+ *
+ *  Author: Rampastring
+ */
+DECLARE_PATCH(_HouseClass_Can_Build_BuildLimit_Handle_Vehicle_Transform)
+{
+    GET_REGISTER_STATIC(UnitTypeClass*, unittype, edi);
+    GET_REGISTER_STATIC(HouseClass*, house, ebp);
+    static UnitTypeClassExtension* unittypeext;
+    static int objectcount;
+
+    unittypeext = Extension::Fetch<UnitTypeClassExtension>(unittype);
+
+    /**
+     *  Stolen bytes / code.
+     */
+    objectcount = house->UQuantity.Count_Of((UnitType)unittype->Get_Heap_ID());
+
+    /**
+     *  Check whether this unit can deploy into a building.
+     *  If it can, increment the object count by the number of buildings.
+     */
+    if (unittype->DeploysInto != nullptr) {
+        objectcount += house->BQuantity.Count_Of((BuildingType)unittype->DeploysInto->Get_Heap_ID());
+    }
+    else if (unittypeext->TransformsInto != nullptr) {
+
+        /**
+         *  This unit can transform into another unit, increment the object count
+         *  by the number of transformed units.
+         */
+        objectcount += house->UQuantity.Count_Of((UnitType)(unittypeext->TransformsInto->Get_Heap_ID()));
+    }
+
+    _asm { mov esi, objectcount }
+
+continue_function:
+    JMP(0x004BC1B9);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void HouseClassExtension_Hooks()
@@ -373,4 +485,7 @@ void HouseClassExtension_Hooks()
 
     Patch_Jump(0x004BE200, &HouseClassExt::_Begin_Production);
     Patch_Jump(0x004BE6A0, &HouseClassExt::_Abandon_Production);
+
+    Patch_Jump(0x004CB777, &_HouseClass_ShouldDisableCameo_BuildLimit_Fix);
+    Patch_Jump(0x004BC187, &_HouseClass_Can_Build_BuildLimit_Handle_Vehicle_Transform);
 }

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -31,6 +31,7 @@
 #include "vinifera_globals.h"
 #include "tibsun_globals.h"
 #include "tibsun_functions.h"
+#include "tag.h"
 #include "technotype.h"
 #include "technotypeext.h"
 #include "warheadtype.h"
@@ -705,6 +706,269 @@ DECLARE_PATCH(_UnitClass_Jellyfish_AI_Armor_Patch)
 
 
 /**
+ *  Helper function.
+ *  Creates a unit based on an already existing unit.
+ *  Returns the new unit if successful, otherwise null.
+ *
+ *  @author: Rampastring
+ */
+UnitClass* Create_Transform_Unit(UnitClass* this_ptr) {
+
+    UnitTypeClassExtension* unittypeext = Extension::Fetch<UnitTypeClassExtension>(this_ptr->Class);
+
+    UnitClass* newunit = reinterpret_cast<UnitClass*>(unittypeext->TransformsInto->Create_One_Of(this_ptr->House));
+    if (newunit == nullptr) {
+
+        /**
+         *  Creating the new unit failed! Re-mark our occupation bits and return false.
+         */
+        return nullptr;
+    }
+
+    // Try_To_Deploy copies the tag this way at 0x0065112C
+    if (this_ptr->Tag != nullptr) {
+        newunit->Attach_Tag(this_ptr->Tag);
+        this_ptr->Tag->AttachCount--;
+        this_ptr->Tag = nullptr;
+    }
+
+    newunit->ActLike = this_ptr->ActLike;
+    newunit->LimpetSpeedFactor = this_ptr->LimpetSpeedFactor;
+    newunit->field_214 = this_ptr->field_214; // also copied at 0x00650F4E
+    newunit->Veterancy.From_Integer(this_ptr->Veterancy.To_Integer());
+    newunit->Group = this_ptr->Group;
+    newunit->BarrelFacing.Set(this_ptr->BarrelFacing.Current());
+    newunit->BarrelFacing.Set_Desired(this_ptr->BarrelFacing.Desired());
+    newunit->PrimaryFacing.Set(this_ptr->PrimaryFacing.Current());
+    newunit->PrimaryFacing.Set_Desired(this_ptr->PrimaryFacing.Desired());
+    newunit->SecondaryFacing.Set(this_ptr->SecondaryFacing.Current());
+    newunit->SecondaryFacing.Set_Desired(this_ptr->SecondaryFacing.Desired());
+    newunit->Strength = (int)(this_ptr->Health_Ratio() * (int)newunit->Class->MaxStrength);
+    newunit->ArmorBias = this_ptr->ArmorBias;
+    newunit->FirepowerBias = this_ptr->FirepowerBias;
+    newunit->SpeedBias = this_ptr->SpeedBias;
+    newunit->Coord = this_ptr->Coord;
+    newunit->EMPFramesRemaining = this_ptr->EMPFramesRemaining;
+    newunit->Ammo = this_ptr->Ammo;
+
+
+    if (newunit->Unlimbo(newunit->Coord, this_ptr->PrimaryFacing.Current().Get_Dir())) {
+
+        /**
+         *  Unlimbo successful, select our new unit and return it
+         */
+
+        if (PlayerPtr == newunit->Owning_House()) {
+            newunit->Select();
+        }
+
+        if (this_ptr->TarCom) {
+            newunit->Assign_Target(this_ptr->TarCom);
+            newunit->Assign_Mission(MISSION_ATTACK);
+            newunit->Commence();
+        }
+
+        return newunit;
+    }
+
+    /**
+     *  Unlimboing the new unit failed! Delete the new unit and return false.
+     */
+    delete newunit;
+    return nullptr;
+}
+
+
+enum TransformReturnValue {
+    OriginalCode = 0x00650BC2,
+    NotEnoughCharge = 0x006511A0,
+    TransformSucceeded = 0x0065114C,
+    TransformFailed = 0x00651168
+};
+
+/**
+ *  Work-around function because the compiler likes smashing the stack by using ebp
+ *  when calling locomotor functions :)
+ *
+ *  Returns the address that the calling function should jump to after calling this.
+ *
+ *  @author: Rampastring
+ */
+TransformReturnValue _UnitClass_Try_To_Deploy_Transform_To_Vehicle_Patch_Func(UnitClass* this_ptr) {
+
+    /**
+     *  Stolen bytes/code.
+     */
+    if (this_ptr->Class->DeploysInto != nullptr) {
+
+        /**
+         *  This unit is deployable rather than transformable, check whether it can deploy.
+         */
+        return OriginalCode;
+    }
+
+    UnitTypeClassExtension* unittypeext = Extension::Fetch<UnitTypeClassExtension>(this_ptr->Class);
+
+    if (unittypeext->TransformsInto != nullptr) {
+
+        /**
+         *  Use custom "transform to vehicle" logic if we don't need charge or we have enough of it.
+         */
+
+        if (unittypeext->IsTransformRequiresFullCharge && this_ptr->CurrentCharge < this_ptr->Class->MaxCharge) {
+
+            /**
+             *  We don't have enough charge, return false
+             */
+            return NotEnoughCharge;
+        }
+
+        this_ptr->Mark(MARK_UP);
+        this_ptr->Locomotor_Ptr()->Mark_All_Occupation_Bits(MARK_UP);
+
+        UnitClass* newunit = Create_Transform_Unit(this_ptr);
+
+        if (newunit != nullptr) {
+
+            /**
+             *  Creating transformed unit succeeded, erase the original unit and force function to return true
+             */
+            return TransformSucceeded;
+        }
+        else {
+
+            /**
+             *  Creating transformed unit failed. Re-mark our occupation bits and return false.
+             */
+            return TransformFailed;
+        }
+    }
+
+    /**
+     *  Continue to deployability check.
+     */
+    return OriginalCode;
+}
+
+
+/**
+ *  #issue-715
+ *
+ *  Transforms a unit to another unit when a transformable unit deploys.
+ *
+ *  @author: Rampastring
+ */
+DECLARE_PATCH(_UnitClass_Try_To_Deploy_Transform_To_Vehicle_Patch) {
+    GET_REGISTER_STATIC(UnitClass*, this_ptr, esi);
+    static int address;
+    address = (int)(_UnitClass_Try_To_Deploy_Transform_To_Vehicle_Patch_Func(this_ptr));
+    JMP(address);
+}
+
+
+/**
+ *  #issue-715
+ *
+ *  Hack to display the the correct cursor for transformable units
+ *  upon ACTION_SELF.
+ *
+ *  @author: Rampastring
+ */
+DECLARE_PATCH(_UnitClass_What_Action_Self_Check_For_Vehicle_Transform_Patch) {
+    GET_REGISTER_STATIC(UnitClass*, this_ptr, esi);
+    static UnitTypeClass* unittype;
+    static UnitTypeClassExtension* unittypeext;
+    static ActionType action;
+
+    unittype = this_ptr->Class;
+    unittypeext = Extension::Fetch<UnitTypeClassExtension>(unittype);
+
+    /**
+     *  Stolen bytes/code.
+     *  If the unit can deploy into a building, check whether it's currently allowed.
+     */
+    if (unittype->DeploysInto != nullptr) {
+        JMP(0x0065602B);
+    }
+
+    /**
+     *  Check if this unit is able to transform into another unit.
+     *  If not, we don't have anything else to do here.
+     */
+    if (unittypeext->TransformsInto == nullptr) {
+        _asm { mov eax, unittype }
+        JMP_REG(ecx, 0x00656344);
+    }
+
+    /**
+     *  If this unit is able to transform to a different unit, check if it requires charge for it.
+     *  If it does, then check whether we have enough charge.
+     */
+    if (unittypeext->IsTransformRequiresFullCharge && this_ptr->CurrentCharge < this_ptr->Class->MaxCharge) {
+
+        /**
+         *  We don't have enough charge!
+         */
+        action = ACTION_NO_DEPLOY;
+    }
+    else if (this_ptr->Is_Immobilized()) {
+
+        /**
+         *  The unit is dying or under an EMP effect, don't allow it to transform.
+         */
+        action = ACTION_NO_DEPLOY;
+    }
+    else {
+        action = ACTION_SELF;
+    }
+
+    /**
+     *  Rebuilt function epilogue
+     */
+    _asm { pop edi }
+    _asm { pop esi }
+    _asm { pop ebp }
+    _asm { pop ebx }
+    _asm { add esp, 10h }
+    _asm { mov eax, dword ptr ds:action }
+    _asm { retn 8 }    
+}
+
+
+/**
+ *  #issue-715
+ *
+ *  Check whether the unit is able to transform into another unit
+ *  when performing the "Unload" mission.
+ *
+ *  @author: Rampastring
+ */
+DECLARE_PATCH(_UnitClass_Mission_Unload_Transform_To_Vehicle_Patch) {
+    GET_REGISTER_STATIC(UnitTypeClass*, unittype, eax);
+    static UnitTypeClassExtension* unittypeext;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    if (unittype->IsToHarvest || unittype->IsToVeinHarvest) {
+    harvester_process:
+        JMP(0x006545A5);
+    }
+
+    unittypeext = Extension::Fetch<UnitTypeClassExtension>(unittype);
+
+    if (unittype->DeploysInto != nullptr || unittypeext->TransformsInto != nullptr) {
+    deployable_process:
+        JMP(0x00654403);
+    }
+
+mobile_emp_process:
+    _asm { mov eax, unittype }
+    JMP_REG(edx, 0x006543FD);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void UnitClassExtension_Hooks()
@@ -724,6 +988,9 @@ void UnitClassExtension_Hooks()
     Patch_Jump(0x00656623, &_UnitClass_What_Action_ACTION_HARVEST_Block_On_Bridge_Patch); // IsToHarvest
     Patch_Jump(0x0065665D, &_UnitClass_What_Action_ACTION_HARVEST_Block_On_Bridge_Patch); // IsToVeinHarvest
     Patch_Jump(0x0064F2BE, &_UnitClass_Jellyfish_AI_Armor_Patch);
+    Patch_Jump(0x00650BAE, &_UnitClass_Try_To_Deploy_Transform_To_Vehicle_Patch);
+    Patch_Jump(0x00656017, &_UnitClass_What_Action_Self_Check_For_Vehicle_Transform_Patch);
+    Patch_Jump(0x006543DB, &_UnitClass_Mission_Unload_Transform_To_Vehicle_Patch);
     //Patch_Jump(0x0065054F, &_UnitClass_Enter_Idle_Mode_Block_Harvesting_On_Bridge_Patch); // Removed, keeping code for reference.
     //Patch_Jump(0x00654AB0, &_UnitClass_Mission_Harvest_Block_Harvesting_On_Bridge_Patch); // Removed, keeping code for reference.
 }

--- a/src/extensions/unittype/unittypeext.cpp
+++ b/src/extensions/unittype/unittypeext.cpp
@@ -30,6 +30,7 @@
 #include "ccini.h"
 #include "tibsun_globals.h"
 #include "extension.h"
+#include "vinifera_saveload.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
@@ -45,7 +46,9 @@ UnitTypeClassExtension::UnitTypeClassExtension(const UnitTypeClass *this_ptr) :
     StartTurretFrame(-1),
     TurretFacings(32),		// Must default to 32 as all Tiberian Sun units have 32 facings for turrets.,
     StartIdleFrame(0),
-    IdleFrames(0)
+    IdleFrames(0),
+    TransformsInto(nullptr),
+    IsTransformRequiresFullCharge(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("UnitTypeClassExtension::UnitTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -113,6 +116,8 @@ HRESULT UnitTypeClassExtension::Load(IStream *pStm)
 
     new (this) UnitTypeClassExtension(NoInitClass());
     
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(TransformsInto, "TransformsInto");
+
     return hr;
 }
 
@@ -191,6 +196,8 @@ bool UnitTypeClassExtension::Read_INI(CCINIClass &ini)
     //}
 
     IsTotable = ini.Get_Bool(ini_name, "Totable", IsTotable);
+    TransformsInto = ini.Get_Unit(ini_name, "TransformsInto", TransformsInto);
+    IsTransformRequiresFullCharge = ini.Get_Bool(ini_name, "TransformRequiresFullCharge", IsTransformRequiresFullCharge);
 
     StartTurretFrame = ArtINI.Get_Int(graphic_name, "StartTurretFrame", StartTurretFrame);
     TurretFacings = ArtINI.Get_Int(graphic_name, "TurretFacings", TurretFacings);
@@ -203,6 +210,6 @@ bool UnitTypeClassExtension::Read_INI(CCINIClass &ini)
 
     StartIdleFrame = ArtINI.Get_Int(graphic_name, "StartIdleFrame", StartIdleFrame);
     IdleFrames = ArtINI.Get_Int(graphic_name, "IdleFrames", IdleFrames);
-    
+
     return true;
 }

--- a/src/extensions/unittype/unittypeext.h
+++ b/src/extensions/unittype/unittypeext.h
@@ -86,4 +86,14 @@ UnitTypeClassExtension final : public TechnoTypeClassExtension
          *  The number of image frames for each of the idle animation sequences.
          */
         unsigned IdleFrames;
+
+        /**
+         *  The unit type that this unit type transforms into upon deploying, if any.
+         */
+        const UnitTypeClass* TransformsInto;
+
+        /**
+         *  If set, transforming to another unit will require this unit to have full charge.
+         */
+        bool IsTransformRequiresFullCharge;
 };


### PR DESCRIPTION
Closes #611 , Closes #715 

This patch makes it possible for vehicles to transform into other vehicles on deploy.

This behaviour is controlled by a new `TransformsInto=<unit type>` key for `UnitType`s. If it points to a valid `UnitType`, the unit is transformed into the specified unit type when deployed.

Also, in DTA we have a use-case where we want the transform to have a cooldown. This can be optionally enabled by giving the unit `TransformRequiresFullCharge=yes`. This re-uses the Mobile EMP's Charge logic: when this key is set, the unit is required to have full charge or it isn't able to transform.

Finally, for implementing this without having the transform break the build limits of units, I had to re-implement a part of the build limit checking for this patch. While at it, I also fixed #611 .

### Remarks

If the unit also has `DeploysInto=` pointing to a building type, the `DeploysInto` logic is prioritized over unit transformation.

The unit transformation logic, however, is prioritized over the Mobile EMP blast logic.