### PR TITLE
Implements the loading of Tutorial messages from scenarios.

### DIFF
--- a/src/extensions/scenario/scenarioext.h
+++ b/src/extensions/scenario/scenarioext.h
@@ -51,6 +51,9 @@ class ScenarioClassExtension final : public GlobalExtensionClass<ScenarioClass>
         virtual const char *Full_Name() const override { return "Scenario"; }
 
         void Init_Clear();
+        bool Read_INI(CCINIClass &ini);
+
+        bool Read_Tutorial_INI(CCINIClass &ini, bool log = false);
 
     public:
 

--- a/src/extensions/scenario/scenarioext_init.cpp
+++ b/src/extensions/scenario/scenarioext_init.cpp
@@ -136,6 +136,30 @@ original_code:
 
 
 /**
+ *  Patch for reading the extended class members from the ini instance.
+ *
+ *  @warning: Do not touch this unless you know what you are doing!
+ *
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_ScenarioClass_Read_INI_Patch)
+{
+    GET_REGISTER_STATIC(CCINIClass *, ini, ebp);
+    static bool retval;
+
+    /**
+     *  Stolen bytes/code.
+     */
+    retval |= Scen->Read_INI(*ini);
+
+    retval |= ScenExtension->Read_INI(*ini);
+
+    _asm { mov al, retval }
+    JMP_REG(ecx, 0x005DD947);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void ScenarioClassExtension_Init()
@@ -143,4 +167,5 @@ void ScenarioClassExtension_Init()
     Patch_Jump(0x005DADDE, &_ScenarioClass_Constructor_Patch);
     Patch_Jump(0x006023CC, &_ScenarioClass_Destructor_Patch); // Inlined in game shutdown.
     Patch_Jump(0x005DB166, &_ScenarioClass_Init_Clear_Patch);
+    Patch_Jump(0x005DD93B, &_ScenarioClass_Read_INI_Patch);
 }

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -96,6 +96,8 @@
 #include "waypointpath.h"
 #include "alphashape.h"
 
+#include "scenarioext.h"
+
 #include "scenario.h"
 #include "endgame.h"
 #include "rules.h"
@@ -482,6 +484,31 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
      */
     DEBUG_INFO("Loading Scenario...\n");
     Scen->Load(pStm);
+
+    /**
+     *  #issue-123
+     *
+     *  Save files do not store the tutorial messages, so we reload them from
+     *  the scenario file.
+     */
+    {
+        DEBUG_INFO("Loading Tutorial section from scenario (if present)...\n");
+
+        CCFileClass scen_file(Scen->ScenarioName);
+        CCINIClass scen_ini;
+
+        if (!scen_file.Is_Available()) {
+            DEBUG_ERROR("Failed to read scenario file!\n");
+            return false;
+        }
+
+        scen_ini.Load(scen_file, false);
+
+        if (!ScenExtension->Read_Tutorial_INI(scen_ini, true)) {
+            DEBUG_ERROR("Failed to read tutorial strings from scenario file!\n");
+            return false;
+        }
+    }
 
     Addon_4071C0(ADDON_NONE);
 


### PR DESCRIPTION
Closes #123

This pull request implements the loading of Tutorial messages from scenarios. This can be used to replace/update an existing entry from `TUTORIAL.INI`, or to add a new tutorial message index which can be used by trigger actions.