### PR TITLE
Implements `ShowBriefing` to allow the briefing statement to be shown before the mission starts.

### DIFF
--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -55,7 +55,8 @@
  */
 ScenarioClassExtension::ScenarioClassExtension(const ScenarioClass *this_ptr) :
     GlobalExtensionClass(this_ptr),
-    IsIceDestruction(true)
+    IsIceDestruction(true),
+    IsShowBriefing(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("ScenarioClassExtension::ScenarioClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
@@ -204,6 +205,7 @@ bool ScenarioClassExtension::Read_INI(CCINIClass &ini)
     static const char * const BASIC = "Basic";
 
     IsIceDestruction = ini.Get_Bool(BASIC, "IceDestructionEnabled", IsIceDestruction);
+    IsShowBriefing = ini.Get_Bool(BASIC, "ShowBriefing", IsShowBriefing);
 
     /**
      *  #issue-123

--- a/src/extensions/scenario/scenarioext.h
+++ b/src/extensions/scenario/scenarioext.h
@@ -63,4 +63,9 @@ class ScenarioClassExtension final : public GlobalExtensionClass<ScenarioClass>
          *  Can ice get destroyed when hit by certain weapons?
          */
         bool IsIceDestruction;
+
+        /**
+         *  Should the mission briefing statement be shown before the mission starts?
+         */
+        bool IsShowBriefing;
 };

--- a/src/extensions/scenario/scenarioext_init.cpp
+++ b/src/extensions/scenario/scenarioext_init.cpp
@@ -42,9 +42,9 @@
 
 /**
  *  Patch for including the extended class members in the creation process.
- * 
+ *
  *  @warning: Do not touch this unless you know what you are doing!
- * 
+ *
  *  @author: CCHyper
  */
 DECLARE_PATCH(_ScenarioClass_Constructor_Patch)
@@ -77,9 +77,9 @@ original_code:
 
 /**
  *  Patch for including the extended class members in the destruction process.
- * 
+ *
  *  @warning: Do not touch this unless you know what you are doing!
- * 
+ *
  *  @author: CCHyper
  */
 DECLARE_PATCH(_ScenarioClass_Destructor_Patch)
@@ -103,9 +103,9 @@ original_code:
 
 /**
  *  Patch for including the extended class members when initialsing the scenario data.
- * 
+ *
  *  @warning: Do not touch this unless you know what you are doing!
- * 
+ *
  *  @author: CCHyper
  */
 DECLARE_PATCH(_ScenarioClass_Init_Clear_Patch)


### PR DESCRIPTION
Closes #28

This pull request implements a new option to allow the briefing statement to be shown before the mission starts.

_In the scenario file;_
`[Basic]`
`ShowBriefing=<boolean>` - _Should the mission briefing statement be shown before the mission starts? Defaults to `no`._