### PR TITLE
Implements `CurleyShuffle` for AircraftTypes.

### DIFF
--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -29,6 +29,7 @@
 #include "aircraftext_init.h"
 #include "aircraft.h"
 #include "aircrafttype.h"
+#include "aircrafttypeext.h"
 #include "object.h"
 #include "target.h"
 #include "unit.h"
@@ -44,6 +45,71 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  #issue-996
+ * 
+ *  Implements IsCurleyShuffle for AircraftTypes.
+ * 
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET0_Can_Fire_FIRE_FACING_Patch)
+{
+    GET_REGISTER_STATIC(AircraftClass *, this_ptr, esi);
+    static AircraftTypeClassExtension *class_ext;
+    static bool is_curley_shuffle;
+
+    class_ext = Extension::Fetch<AircraftTypeClassExtension>(this_ptr->Class);
+
+    is_curley_shuffle = class_ext->IsCurleyShuffle;
+
+    _asm { mov al, is_curley_shuffle }
+    JMP_REG(edx, 0x0040BDDB);
+
+}
+
+DECLARE_PATCH(_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_FIRE_OK_Patch)
+{
+    GET_REGISTER_STATIC(AircraftClass *, this_ptr, esi);
+    static AircraftTypeClassExtension * class_ext;
+    static bool is_curley_shuffle;
+
+    class_ext = Extension::Fetch<AircraftTypeClassExtension>(this_ptr->Class);
+
+    is_curley_shuffle = class_ext->IsCurleyShuffle;
+
+    _asm { mov cl, is_curley_shuffle }
+    JMP_REG(edx, 0x0040BFA8);
+}
+
+DECLARE_PATCH(_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_FIRE_FACING_Patch)
+{
+    GET_REGISTER_STATIC(AircraftClass *, this_ptr, esi);
+    static AircraftTypeClassExtension * class_ext;
+    static bool is_curley_shuffle;
+
+    class_ext = Extension::Fetch<AircraftTypeClassExtension>(this_ptr->Class);
+
+    is_curley_shuffle = class_ext->IsCurleyShuffle;
+
+    _asm { mov dl, is_curley_shuffle }
+    JMP_REG(edx, 0x0040C060);
+}
+
+DECLARE_PATCH(_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_DEFAULT_Patch)
+{
+    GET_REGISTER_STATIC(AircraftClass *, this_ptr, esi);
+    static AircraftTypeClassExtension *class_ext;
+    static bool is_curley_shuffle;
+
+    class_ext = Extension::Fetch<AircraftTypeClassExtension>(this_ptr->Class);
+
+    is_curley_shuffle = class_ext->IsCurleyShuffle;
+
+    _asm { mov al, is_curley_shuffle }
+    JMP_REG(edx, 0x0040C0B8);
+}
 
 
 /**
@@ -263,4 +329,8 @@ void AircraftClassExtension_Hooks()
     Patch_Jump(0x0040B819, &_AircraftClass_What_Action_Is_Totable_Patch);
     Patch_Jump(0x0040A413, &_AircraftClass_Mission_Move_LAND_Is_Moving_Check_Patch);
     Patch_Jump(0x0040988C, &_AircraftClass_Mission_Unload_Transport_Detach_Sound_Patch);
+    Patch_Jump(0x0040BDCF, &_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET0_Can_Fire_FIRE_FACING_Patch);
+    Patch_Jump(0x0040C054, &_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_FIRE_OK_Patch);
+    Patch_Jump(0x0040BF9D, &_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_FIRE_FACING_Patch);
+    Patch_Jump(0x0040C0AC, &_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_DEFAULT_Patch);
 }

--- a/src/extensions/aircrafttype/aircrafttypeext.cpp
+++ b/src/extensions/aircrafttype/aircrafttypeext.cpp
@@ -42,6 +42,7 @@
  */
 AircraftTypeClassExtension::AircraftTypeClassExtension(const AircraftTypeClass *this_ptr) :
     TechnoTypeClassExtension(this_ptr),
+    IsCurleyShuffle(false), // Same as the RulesClass default.
     ReloadRate(0.05f) // Same as the RulesClass default.
 {
     //if (this_ptr) EXT_DEBUG_TRACE("AircraftTypeClassExtension::AircraftTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
@@ -186,6 +187,7 @@ bool AircraftTypeClassExtension::Read_INI(CCINIClass &ini)
         return false;
     }
 
+    IsCurleyShuffle = ini.Get_Bool(ini_name, "CurleyShuffle", Rule->IsCurleyShuffle);
     ReloadRate = ini.Get_Float(ini_name, "ReloadRate", Rule->ReloadRate);
 
     return true;

--- a/src/extensions/aircrafttype/aircrafttypeext.h
+++ b/src/extensions/aircrafttype/aircrafttypeext.h
@@ -63,6 +63,11 @@ AircraftTypeClassExtension final : public TechnoTypeClassExtension
 
     public:
         /**
+         *  Should this aircraft shuffle its position between firing at its target?
+         */
+        bool IsCurleyShuffle;
+
+        /**
          *  This is the rate that this aircraft will reload its ammo when docked with a helipad.
          */
         double ReloadRate;

--- a/src/extensions/bullet/bulletext_hooks.cpp
+++ b/src/extensions/bullet/bulletext_hooks.cpp
@@ -33,6 +33,9 @@
 #include "warheadtypeext.h"
 #include "iomap.h"
 #include "extension.h"
+#include "vinifera_globals.h"
+#include "session.h"
+#include "tacticalext.h"
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
@@ -74,13 +77,13 @@ create_trailer_anim:
 
 
 /**
- *  #issue-415
+ *  #issue-415, #issue-
  * 
  *  Implements screen shake values for WarheadTypes.
  * 
  *  @author: CCHyper
  */
-DECLARE_PATCH(_BulletClass_Logic_ShakeScreen_Patch)
+DECLARE_PATCH(_BulletClass_Logic_Start_Patch)
 {
     GET_REGISTER_STATIC(BulletClass *, this_ptr, ebx);
     GET_REGISTER_STATIC(WarheadTypeClass *, warhead, eax);
@@ -104,6 +107,15 @@ DECLARE_PATCH(_BulletClass_Logic_ShakeScreen_Patch)
     }
 
     /**
+     *  Does this warhead trigger a screen flash (offline games only)? 
+     */
+    if (Session.Singleplayer_Game()) {
+        if (warheadext->IsScreenFlash && !TacticalMapExtension->IsPendingScreenFlash) {
+            TacticalMapExtension->IsPendingScreenFlash = true;
+        }
+    }
+
+    /**
      *  Restore some registers.
      */
     _asm { mov eax, warhead }
@@ -121,6 +133,6 @@ DECLARE_PATCH(_BulletClass_Logic_ShakeScreen_Patch)
  */
 void BulletClassExtension_Hooks()
 {
-    Patch_Jump(0x00446652, &_BulletClass_Logic_ShakeScreen_Patch);
+    Patch_Jump(0x00446652, &_BulletClass_Logic_Start_Patch);
     Patch_Jump(0x004447BF, &_BulletClass_AI_SpawnDelay_Patch);
 }

--- a/src/extensions/tactical/tacticalext.h
+++ b/src/extensions/tactical/tacticalext.h
@@ -34,6 +34,7 @@
 #include "stimer.h"
 #include "wstring.h"
 #include "point.h"
+#include "rgb.h"
 #include "textprint.h"
 #include <objidl.h>
 
@@ -78,6 +79,8 @@ class TacticalExtension final : public GlobalExtensionClass<Tactical>
 
         void Render_Post();
 
+        void Screen_Flash_AI();
+
 #ifndef NDEBUG
         bool Debug_Draw_Facings();
 #endif
@@ -120,4 +123,19 @@ class TacticalExtension final : public GlobalExtensionClass<Tactical>
          *  The lifetime timer for the information text.
          */
         CDTimerClass<MSTimerClass> InfoTextTimer;
+
+        /**
+         *  x
+         */
+        bool IsPendingScreenFlash;
+
+        /**
+         *
+         */
+        RGBClass ScreenFlashColor;
+
+        /**
+         *
+         */
+        unsigned ScreenFlashTrans;
 };

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -43,6 +43,9 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     AbstractTypeClassExtension(this_ptr),
     IsWallAbsoluteDestroyer(false),
     IsAffectsAllies(true),
+    IsScreenFlash(false),
+    ScreenFlashColor(255,255,255),
+    ScreenFlashTrans(100),
     CombatLightSize(0.0f),
     ShakePixelYHi(0),
     ShakePixelYLo(0),
@@ -172,6 +175,7 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
 
     crc(IsWallAbsoluteDestroyer);
     crc(IsAffectsAllies);
+    crc(IsScreenFlash);
     crc(CombatLightSize);
     crc(ShakePixelYHi);
     crc(ShakePixelYLo);
@@ -197,6 +201,9 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
 
     IsWallAbsoluteDestroyer = ini.Get_Bool(ini_name, "WallAbsoluteDestroyer", IsWallAbsoluteDestroyer);
     IsAffectsAllies = ini.Get_Bool(ini_name, "AffectsAllies", IsAffectsAllies);
+    IsScreenFlash = ini.Get_Bool(ini_name, "ScreenFlash", IsScreenFlash);
+    ScreenFlashColor = ini.Get_RGB(ini_name, "ScreenFlashColor", ScreenFlashColor);
+    ScreenFlashTrans = ini.Get_Int(ini_name, "ScreenFlashTrans", ScreenFlashTrans);
     CombatLightSize = ini.Get_Float_Clamp(ini_name, "CombatLightSize", 0.0f, 1.0f, CombatLightSize);
     ShakePixelYHi = ini.Get_Int(ini_name, "ShakeYhi", ShakePixelYHi);
     ShakePixelYLo = ini.Get_Int(ini_name, "ShakeYlo", ShakePixelYLo);

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -29,6 +29,7 @@
 
 #include "abstracttypeext.h"
 #include "warheadtype.h"
+#include "rgb.h"
 
 
 class DECLSPEC_UUID(UUID_WARHEADTYPE_EXTENSION)
@@ -73,6 +74,21 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
         bool IsAffectsAllies;
 
         /**
+         *  
+         */
+        bool IsScreenFlash;
+
+        /**
+         *
+         */
+        RGBClass ScreenFlashColor;
+
+        /**
+         *
+         */
+        unsigned ScreenFlashTrans;
+
+        /**
          *  This is used to override the size of the combat light flash at the point of impact.
          */
         float CombatLightSize;
@@ -80,8 +96,8 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
         /**
          *  These values are used to shake the screen when the projectile impacts.
          */
-        unsigned int ShakePixelYHi;
-        unsigned int ShakePixelYLo;
-        unsigned int ShakePixelXHi;
-        unsigned int ShakePixelXLo;
+        unsigned ShakePixelYHi;
+        unsigned ShakePixelYLo;
+        unsigned ShakePixelXHi;
+        unsigned ShakePixelXLo;
 };


### PR DESCRIPTION
Closes #996 

This pull request implements an override to the Rules global, `CurleyShuffle`, which controls if the aircraft will shuffle its position between firing at its target.

**`[AircraftType]`**
`CurleyShuffle=<boolean>`
_Should this aircraft shuffle its position between firing at its target? Defaults to the value of Rules -> `[General]` -> `CurleyShuffle`._