### PR TITLE
Implements developer mode command to reload Rules and Art files.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -124,6 +124,7 @@ This page lists all the individual contributions to the project by their author.
   - Adds keyboard commands to reproduce the last items that were built.
   - Change starting unit placement to be the same as Red Alert 2.
   - Add the framework for new ArmorTypes.
+  - Implement developer mode command to reload Rules and Art files.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **MarkJFox**:

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -126,7 +126,7 @@ It is not recommended that you modify or remove any of the original mix files, t
 - The name shown in the dialog is the value of the `Name=` _(with a limit of 128 characters)_ entry under `[General]` in the Rule INI. If the user presses Cancel on the dialog, the game will load the standard `RULES.INI` file.
 
 ```{note}
-Due to the nature of its use, this feature is only available when Vinifera is running in Developer Mode
+Due to the nature of its use, this feature is only available when Vinifera is running in Developer Mode.
 ```
 
 ![image](https://user-images.githubusercontent.com/73803386/137135038-0a1e983f-d295-4723-86fb-1ab94ba8948b.png)
@@ -185,6 +185,14 @@ This option tells the game to exit when you press Cancel or Back from the dialog
 #### `[ ]` Dump Trigger Info
 
 - Dumps all existing triggers, tags, and local and global variables to the log output.
+
+#### `[ ]` Reload Rules
+
+- Reloads the Rules and Art INI files.
+
+```{warning}
+This could very well crash the game, please use it with caution and make small incremental changes only!
+```
 
 #### `[ ]` Instant Build (Player)
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -142,6 +142,7 @@ New:
 - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes (by Rampastring)
 - Add developer command to dump all existing triggers, tags, and local and global variables to the log output (by Rampastring)
 - Add `PipWrap` (by ZivDero)
+- Implement developer mode command to reload Rules and Art files (by CCHyper)
 
 
 Vanilla fixes:

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -4119,7 +4119,7 @@ const char *ReloadRulesCommandClass::Get_Name() const
     return "ReloadRules";
 }
 
-const char * ReloadRulesCommandClass::Get_UI_Name() const
+const char *ReloadRulesCommandClass::Get_UI_Name() const
 {
     return "Reload Rules";
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -4107,3 +4107,40 @@ bool DumpHeapsCommandClass::Process()
 
     return true;
 }
+
+
+/**
+ *  Reloads the Rules and Art INI files.
+ * 
+ *  @author: CCHyper
+ */
+const char *ReloadRulesCommandClass::Get_Name() const
+{
+    return "ReloadRules";
+}
+
+const char * ReloadRulesCommandClass::Get_UI_Name() const
+{
+    return "Reload Rules";
+}
+
+const char *ReloadRulesCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char *ReloadRulesCommandClass::Get_Description() const
+{
+    return "Reloads the Rules and Art INI files.";
+}
+
+bool ReloadRulesCommandClass::Process()
+{
+    if (!Session.Singleplayer_Game()) {
+        return false;
+    }
+
+    Vinifera_Developer_IsToReloadRules = true;
+
+    return true;
+}

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -1414,3 +1414,22 @@ public:
 
     virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
 };
+
+
+/**
+ *  Reload Rules and Art.
+ */
+class ReloadRulesCommandClass : public ViniferaCommandClass
+{
+    public:
+        ReloadRulesCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+        virtual ~ReloadRulesCommandClass() {}
+
+        virtual const char *Get_Name() const override;
+        virtual const char *Get_UI_Name() const override;
+        virtual const char *Get_Category() const override;
+        virtual const char *Get_Description() const override;
+        virtual bool Process() override;
+
+        virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -431,6 +431,9 @@ void Init_Vinifera_Commands()
 
         cmdptr = new DumpHeapsCommandClass;
         Commands.Add(cmdptr);
+
+        cmdptr = new ReloadRulesCommandClass;
+        Commands.Add(cmdptr);
     }
 
     /**

--- a/src/vinifera/vinifera_globals.cpp
+++ b/src/vinifera/vinifera_globals.cpp
@@ -57,6 +57,7 @@ bool Vinifera_Developer_ShowCursorPosition = false;
 bool Vinifera_Developer_FrameStep = false;
 int Vinifera_Developer_FrameStepCount = 0;
 bool Vinifera_Developer_AIControl = false;
+bool Vinifera_Developer_IsToReloadRules = false;
 
 bool Vinifera_SkipLogoMovies = false;
 bool Vinifera_SkipStartupMovies = false;

--- a/src/vinifera/vinifera_globals.h
+++ b/src/vinifera/vinifera_globals.h
@@ -74,6 +74,7 @@ extern bool Vinifera_Developer_ShowCursorPosition;
 extern bool Vinifera_Developer_FrameStep;
 extern int Vinifera_Developer_FrameStepCount;
 extern bool Vinifera_Developer_AIControl;
+extern bool Vinifera_Developer_IsToReloadRules;
 
 
 /**


### PR DESCRIPTION
This pull request implements a new developer mode command, allowing you to reload the Rules and Art files while the game is running.

It will reload the files in the following order;
ART.INI (ARTFS.INI) -> RULES.INI (FIRESTRM.INI) -> Scenario overrides.

**Warning:** This could very well crash the game, please use it with caution, and make small incremental changes only!