### PR TITLE
Allow adding more Tiberiums and customize their image

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -139,4 +139,5 @@ This page lists all the individual contributions to the project by their author.
   - Technos can have a custom pip be drawn in the same place as the medic pip using `[TechnoType]->SpecialPipIndex`.
   - The location of the control group number and veterancy pips can now be customized in `UI.ini`.
   - MaxPips can now we customized.
+  - Allow adding new Tiberiums and customizing their Image.
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -406,6 +406,41 @@ RequiredAddon=0  ; AddonType, the addon required to be active for this theme to 
 
 ## Tiberiums
 
+### New Tiberiums
+
+- Vinifera allows mods to create new Tiberiums beyond the vanilla 4.
+
+- A Tiberium's Image can be customized manually.
+
+In `RULES.INI`:
+```ini
+[SOMETIBERIUM]   ; Tiberium
+Overlay=         ; OverlayType, the first overlay that the Tiberium uses, defaults to the value usually used by the Image=, or overlay at index 102 if not specified
+UseSlopes=false  ; boolean, does this Tiberium have graphics for slopes?
+```
+
+```{note}
+The new graphics keys override defaults set according to Image=, please refer to [ModEnc](https://modenc.renegadeprojects.com/Image) about its vanilla behavior. It is not required to set Image= if you specify the graphics using new keys.
+```
+
+```{note}
+`OverlayIndex` specifies the index of the first overlay the Tiberium uses. There must be 12 overlays, located one after another sequentially. Additionally, is `UseSlopes` is set to yes, another 8 overlays are required after the previous 12.
+```
+
+```{warning}
+All `OverlayTypes` used by a `Tiberium` must have `Tiberium=yes`, and no other `OverlayTypes` may have `Tiberium=yes`, or this will lead to severe lags/crashes.
+```
+
+### Tiberium Damage to Infantry
+
+- The damage Tiberium deals to infantry is now customizable separately from Power.
+
+In `RULES.INI`:
+```ini
+[SOMETIBERIUM]     ; Tiberium
+DamageToInfantry=  ; integer, the damage to infantry per tick, defaults to Power / 10
+```
+
 ### Pips
 
 - Vinifera allows customizing the pips used for Tiberiums in unit storage, as well as their draw order.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -8,13 +8,16 @@ This page lists the history of changes across stable Vinifera releases and also 
 % You can use the migration utility (can be found on [Vinifera supplementaries repo](https://github.com/Vinifera-Developers/ViniferaSupplementaries)) to apply most of the changes automatically using a corresponding sed script file.
 % ```
 
-% ### From vanilla
+### From vanilla
+
+- Tiberium `[Vinifera]->Power`, previously hardcoded to `17`, has been de-hardcoded. As such, a proper value needs to be set in `RULES.INI`.
 
 % ### When updating Vinifera
 
 ### From TS Patches
 
-- [place_building_hotkey.c](https://github.com/CnCNet/ts-patches/blob/master/src/place_building_hotkey.c) and [repeat_last_building_hotkey.c](https://github.com/CnCNet/ts-patches/blob/master/src/repeat_last_building_hotkey.c) should be disabled to avoid conflict with the analogous Vinifera keyboard commands.
+- [place_building_hotkey](https://github.com/CnCNet/ts-patches/blob/master/src/place_building_hotkey.c) and [repeat_last_building_hotkey](https://github.com/CnCNet/ts-patches/blob/master/src/repeat_last_building_hotkey.c) should be disabled to avoid conflict with the analogous Vinifera keyboard commands.
+- Removal of ts-patches [tiberium_stuff](https://github.com/CnCNet/ts-patches/blob/master/src/tiberium_stuff.asm) and [tiberium_damage](https://github.com/CnCNet/ts-patches/blob/master/src/tiberium_damage.asm) is required for this to work properly. Please keep in mind that Power once again behaves like in vanilla in regards to chain explosions and should be set to reasonable values, while `DamageToInfantry` should be used to customize Tiberium's damage to infantry.
 
 % ### New user settings in `SUN.ini`
 % 
@@ -127,6 +130,7 @@ New:
 - MaxPips can now we customized (by ZivDero)
 - Change starting unit placement to be the same as Red Alert 2 (by CCHyper/tomsons26)
 - Make it possible to assign rally points to service depots (by Rampastring)
+- Allow adding new Tiberiums and customizing their Image (by ZivDero)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/extension.cpp
+++ b/src/extensions/extension.cpp
@@ -872,8 +872,6 @@ bool Extension::Load(IStream *pStm)
      */
     if (!Extension::Request_Pointer_Remap()) { return false; }
 
-    Put_Storage_Pointers();
-
     DEV_DEBUG_INFO("Extension::Load(exit)\n");
 
     return true;
@@ -956,22 +954,6 @@ bool Extension::Request_Pointer_Remap()
     DEBUG_INFO("Extension::Request_Pointer_Remap(exit)\n");
 
     return true;
-}
-
-
-void Extension::Put_Storage_Pointers()
-{
-    for (int i = 0; i < Technos.Count(); i++)
-    {
-        const TechnoClass* techno = Technos[i];
-        Extension::Fetch<TechnoClassExtension>(techno)->Put_Storage_Pointers();
-    }
-
-    for (int i = 0; i < Houses.Count(); i++)
-    {
-        const HouseClass* house = Houses[i];
-        Extension::Fetch<HouseClassExtension>(house)->Put_Storage_Pointers();
-    }
 }
 
 

--- a/src/extensions/extension.cpp
+++ b/src/extensions/extension.cpp
@@ -663,10 +663,10 @@ AbstractClassExtension *Extension::Private::Fetch_Internal(const AbstractClass *
     /**
      *  Its still possible the pointer could be invalid, so perform a final check.
      */
-    if (ext_ptr->What_Am_I() <= RTTI_NONE || ext_ptr->What_Am_I() >= RTTI_COUNT) {
-        DEBUG_ERROR("Extension::Fetch: Invalid extension rtti type for \"%s\"!\n", Extension::Utility::Get_TypeID_Name(abstract).c_str());
-        return nullptr;
-    }
+    //if (ext_ptr->What_Am_I() <= RTTI_NONE || ext_ptr->What_Am_I() >= RTTI_COUNT) {
+    //    DEBUG_ERROR("Extension::Fetch: Invalid extension rtti type for \"%s\"!\n", Extension::Utility::Get_TypeID_Name(abstract).c_str());
+    //    return nullptr;
+    //}
 
     //EXT_DEBUG_INFO("Extension::Fetch: Abstract \"%s\", got extension \"%s\".\n", Extension::Utility::Get_TypeID_Name(abstract).c_str(), ext_ptr->Name());
 

--- a/src/extensions/extension.cpp
+++ b/src/extensions/extension.cpp
@@ -663,10 +663,10 @@ AbstractClassExtension *Extension::Private::Fetch_Internal(const AbstractClass *
     /**
      *  Its still possible the pointer could be invalid, so perform a final check.
      */
-    //if (ext_ptr->What_Am_I() <= RTTI_NONE || ext_ptr->What_Am_I() >= RTTI_COUNT) {
-    //    DEBUG_ERROR("Extension::Fetch: Invalid extension rtti type for \"%s\"!\n", Extension::Utility::Get_TypeID_Name(abstract).c_str());
-    //    return nullptr;
-    //}
+    if (ext_ptr->What_Am_I() <= RTTI_NONE || ext_ptr->What_Am_I() >= RTTI_COUNT) {
+        DEBUG_ERROR("Extension::Fetch: Invalid extension rtti type for \"%s\"!\n", Extension::Utility::Get_TypeID_Name(abstract).c_str());
+        return nullptr;
+    }
 
     //EXT_DEBUG_INFO("Extension::Fetch: Abstract \"%s\", got extension \"%s\".\n", Extension::Utility::Get_TypeID_Name(abstract).c_str(), ext_ptr->Name());
 
@@ -872,6 +872,8 @@ bool Extension::Load(IStream *pStm)
      */
     if (!Extension::Request_Pointer_Remap()) { return false; }
 
+    Put_Storage_Pointers();
+
     DEV_DEBUG_INFO("Extension::Load(exit)\n");
 
     return true;
@@ -954,6 +956,22 @@ bool Extension::Request_Pointer_Remap()
     DEBUG_INFO("Extension::Request_Pointer_Remap(exit)\n");
 
     return true;
+}
+
+
+void Extension::Put_Storage_Pointers()
+{
+    for (int i = 0; i < Technos.Count(); i++)
+    {
+        const TechnoClass* techno = Technos[i];
+        Extension::Fetch<TechnoClassExtension>(techno)->Put_Storage_Pointers();
+    }
+
+    for (int i = 0; i < Houses.Count(); i++)
+    {
+        const HouseClass* house = Houses[i];
+        Extension::Fetch<HouseClassExtension>(house)->Put_Storage_Pointers();
+    }
 }
 
 

--- a/src/extensions/extension.h
+++ b/src/extensions/extension.h
@@ -265,7 +265,6 @@ void Destroy(const AbstractClass *abstract)
 bool Save(IStream *pStm);
 bool Load(IStream *pStm);
 bool Request_Pointer_Remap();
-void Put_Storage_Pointers();
 unsigned Get_Save_Version_Number();
 
 /**

--- a/src/extensions/extension.h
+++ b/src/extensions/extension.h
@@ -265,6 +265,7 @@ void Destroy(const AbstractClass *abstract)
 bool Save(IStream *pStm);
 bool Load(IStream *pStm);
 bool Request_Pointer_Remap();
+void Put_Storage_Pointers();
 unsigned Get_Save_Version_Number();
 
 /**

--- a/src/extensions/extension_hooks.cpp
+++ b/src/extensions/extension_hooks.cpp
@@ -146,6 +146,7 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "storage/storageext_hooks.h"
 
 
 void Extension_Hooks()
@@ -231,6 +232,7 @@ void Extension_Hooks()
     //FoggedObjectClassExtension_Hooks();                   // Not yet implemented
     //AlphaShapeClassExtension_Hooks();                     // Not yet implemented
     //VeinholeMonsterClassExtension_Hooks();                // Not yet implemented
+    StorageClassExtension_Hooks();
 
     /**
      *  All global class extensions here.

--- a/src/extensions/house/houseext.cpp
+++ b/src/extensions/house/houseext.cpp
@@ -31,6 +31,7 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "storage/storageext.h"
 
 
 /**
@@ -39,9 +40,14 @@
  *  @author: CCHyper
  */
 HouseClassExtension::HouseClassExtension(const HouseClass *this_ptr) :
-    AbstractClassExtension(this_ptr)
+    AbstractClassExtension(this_ptr),
+    TiberiumStorage(Tiberiums.Count()),
+    WeedStorage(Tiberiums.Count())
 {
     //if (this_ptr) EXT_DEBUG_TRACE("HouseClassExtension::HouseClassExtension - 0x%08X\n", (uintptr_t)(This()));
+
+    new ((StorageClassExt*)&(this_ptr->Tiberium)) StorageClassExt(&TiberiumStorage);
+    new ((StorageClassExt*)&(this_ptr->Weed)) StorageClassExt(&WeedStorage);
 
     HouseExtensions.Add(this);
 }
@@ -106,6 +112,9 @@ HRESULT HouseClassExtension::Load(IStream *pStm)
     }
 
     new (this) HouseClassExtension(NoInitClass());
+
+    new ((StorageClassExt*)&(This()->Tiberium)) StorageClassExt(&TiberiumStorage);
+    new ((StorageClassExt*)&(This()->Weed)) StorageClassExt(&WeedStorage);
     
     return hr;
 }

--- a/src/extensions/house/houseext.cpp
+++ b/src/extensions/house/houseext.cpp
@@ -50,8 +50,8 @@ HouseClassExtension::HouseClassExtension(const HouseClass *this_ptr) :
 
     for (int i = 0; i < Tiberiums.Count(); i++)
     {
-        TiberiumStorage.Add(0);
-        WeedStorage.Add(0);
+        TiberiumStorage[i] = 0;
+        WeedStorage[i] = 0;
     }
 
     if (this_ptr)

--- a/src/extensions/house/houseext.cpp
+++ b/src/extensions/house/houseext.cpp
@@ -62,7 +62,9 @@ HouseClassExtension::HouseClassExtension(const HouseClass *this_ptr) :
  *  @author: CCHyper
  */
 HouseClassExtension::HouseClassExtension(const NoInitClass &noinit) :
-    AbstractClassExtension(noinit)
+    AbstractClassExtension(noinit),
+    TiberiumStorage(noinit),
+    WeedStorage(noinit)
 {
     //EXT_DEBUG_TRACE("HouseClassExtension::HouseClassExtension(NoInitClass) - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }

--- a/src/extensions/house/houseext.cpp
+++ b/src/extensions/house/houseext.cpp
@@ -46,8 +46,11 @@ HouseClassExtension::HouseClassExtension(const HouseClass *this_ptr) :
 {
     //if (this_ptr) EXT_DEBUG_TRACE("HouseClassExtension::HouseClassExtension - 0x%08X\n", (uintptr_t)(This()));
 
-    new ((StorageClassExt*)&(this_ptr->Tiberium)) StorageClassExt(&TiberiumStorage);
-    new ((StorageClassExt*)&(this_ptr->Weed)) StorageClassExt(&WeedStorage);
+    if (this_ptr)
+    {
+        new ((StorageClassExt*)&(this_ptr->Tiberium)) StorageClassExt(&TiberiumStorage);
+        new ((StorageClassExt*)&(this_ptr->Weed)) StorageClassExt(&WeedStorage);
+    }
 
     HouseExtensions.Add(this);
 }
@@ -112,9 +115,6 @@ HRESULT HouseClassExtension::Load(IStream *pStm)
     }
 
     new (this) HouseClassExtension(NoInitClass());
-
-    new ((StorageClassExt*)&(This()->Tiberium)) StorageClassExt(&TiberiumStorage);
-    new ((StorageClassExt*)&(This()->Weed)) StorageClassExt(&WeedStorage);
     
     return hr;
 }

--- a/src/extensions/house/houseext.cpp
+++ b/src/extensions/house/houseext.cpp
@@ -171,3 +171,9 @@ void HouseClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     //EXT_DEBUG_TRACE("HouseClassExtension::Compute_CRC - 0x%08X\n", (uintptr_t)(This()));
 }
+
+void HouseClassExtension::Put_Storage_Pointers()
+{
+    new ((StorageClassExt*)&(This()->Tiberium)) StorageClassExt(&TiberiumStorage);
+    new ((StorageClassExt*)&(This()->Weed)) StorageClassExt(&WeedStorage);
+}

--- a/src/extensions/house/houseext.cpp
+++ b/src/extensions/house/houseext.cpp
@@ -31,6 +31,8 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "saveload.h"
+#include "vinifera_saveload.h"
 #include "storage/storageext.h"
 
 
@@ -45,6 +47,12 @@ HouseClassExtension::HouseClassExtension(const HouseClass *this_ptr) :
     WeedStorage(Tiberiums.Count())
 {
     //if (this_ptr) EXT_DEBUG_TRACE("HouseClassExtension::HouseClassExtension - 0x%08X\n", (uintptr_t)(This()));
+
+    for (int i = 0; i < Tiberiums.Count(); i++)
+    {
+        TiberiumStorage.Add(0);
+        WeedStorage.Add(0);
+    }
 
     if (this_ptr)
     {
@@ -116,6 +124,9 @@ HRESULT HouseClassExtension::Load(IStream *pStm)
         return E_FAIL;
     }
 
+    Load_Primitive_Vector(pStm, TiberiumStorage);
+    Load_Primitive_Vector(pStm, WeedStorage);
+
     new (this) HouseClassExtension(NoInitClass());
     
     return hr;
@@ -135,6 +146,9 @@ HRESULT HouseClassExtension::Save(IStream *pStm, BOOL fClearDirty)
     if (FAILED(hr)) {
         return hr;
     }
+
+    Save_Primitive_Vector(pStm, TiberiumStorage);
+    Save_Primitive_Vector(pStm, WeedStorage);
 
     return hr;
 }

--- a/src/extensions/house/houseext.h
+++ b/src/extensions/house/houseext.h
@@ -64,4 +64,13 @@ HouseClassExtension final : public AbstractClassExtension
         virtual RTTIType What_Am_I() const override { return RTTI_HOUSE; }
 
     public:
+        /**
+         *  Replacement Tiberium storage.
+         */
+        DynamicVectorClass<int> TiberiumStorage;
+
+        /**
+         *  Replacement Weed storage.
+         */
+        DynamicVectorClass<int> WeedStorage;
 };

--- a/src/extensions/house/houseext.h
+++ b/src/extensions/house/houseext.h
@@ -63,6 +63,8 @@ HouseClassExtension final : public AbstractClassExtension
         virtual const HouseClass *This_Const() const override { return reinterpret_cast<const HouseClass *>(AbstractClassExtension::This_Const()); }
         virtual RTTIType What_Am_I() const override { return RTTI_HOUSE; }
 
+        void Put_Storage_Pointers();
+
     public:
         /**
          *  Replacement Tiberium storage.

--- a/src/extensions/house/houseext.h
+++ b/src/extensions/house/houseext.h
@@ -69,10 +69,10 @@ HouseClassExtension final : public AbstractClassExtension
         /**
          *  Replacement Tiberium storage.
          */
-        DynamicVectorClass<int> TiberiumStorage;
+        VectorClass<int> TiberiumStorage;
 
         /**
          *  Replacement Weed storage.
          */
-        DynamicVectorClass<int> WeedStorage;
+        VectorClass<int> WeedStorage;
 };

--- a/src/extensions/house/houseext_init.cpp
+++ b/src/extensions/house/houseext_init.cpp
@@ -105,29 +105,6 @@ original_code:
 }
 
 
-static void Put_Storage_Pointers(HouseClass* house)
-{
-    new ((StorageClassExt*)&(house->Tiberium)) StorageClassExt(&Extension::Fetch<HouseClassExtension>(house)->TiberiumStorage);
-    new ((StorageClassExt*)&(house->Weed)) StorageClassExt(&Extension::Fetch<HouseClassExtension>(house)->WeedStorage);
-}
-
-
-DECLARE_PATCH(_HouseClass_Load_StorageExtPtr)
-{
-    GET_REGISTER_STATIC(int, result, eax);
-    GET_REGISTER_STATIC(HouseClass*, this_ptr, esi);
-
-    Put_Storage_Pointers(this_ptr);
-
-    if (result >= 0)
-    {
-        JMP(0x004C4AD9);
-    }
-
-    JMP(0x004C503B);
-}
-
-
 /**
  *  Main function for patching the hooks.
  */
@@ -135,5 +112,4 @@ void HouseClassExtension_Init()
 {
     Patch_Jump(0x004BAEBE, &_HouseClass_Constructor_Patch);
     Patch_Jump(0x004BB9B7, &_HouseClass_Destructor_Patch);
-    Patch_Jump(0x004C4AD1, &_HouseClass_Load_StorageExtPtr);
 }

--- a/src/extensions/house/houseext_init.cpp
+++ b/src/extensions/house/houseext_init.cpp
@@ -38,6 +38,7 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "storageext.h"
 
 
 /**
@@ -51,6 +52,9 @@ DECLARE_PATCH(_HouseClass_Constructor_Patch)
 {
     GET_REGISTER_STATIC(HouseClass *, this_ptr, ebp); // "this" pointer.
     GET_STACK_STATIC(const char *, ini_name, esp, 0xC); // ini name.
+
+    new ((StorageClassExt*)&(this_ptr->Tiberium)) StorageClassExt(&Extension::Fetch<HouseClassExtension>(this_ptr)->TiberiumStorage);
+    new ((StorageClassExt*)&(this_ptr->Weed)) StorageClassExt(&Extension::Fetch<HouseClassExtension>(this_ptr)->WeedStorage);
 
     /**
      *  If we are performing a load operation, the Windows API will invoke the

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -44,6 +44,8 @@
 #include "options.h"
 #include "rules.h"
 #include "wwkeyboard.h"
+#include "tiberium.h"
+#include "tiberiumext.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -525,6 +527,24 @@ DECLARE_PATCH(_InfantryClass_Firing_AI_JumpJet_In_Air_Patch)
 
 
 /**
+ *  Uses a new extension value as the damage Tiberium deals to infantry.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_InfantryClass_Per_Cell_Process_Tiberium_Damage_Patch)
+{
+    GET_REGISTER_STATIC(int, tib_id, eax);
+    
+    static int damage;
+    damage = Extension::Fetch<TiberiumClassExtension>(Tiberiums[tib_id])->DamageToInfantry;
+
+    _asm mov edx, damage;
+
+    JMP(0x004D3F7D);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void InfantryClassExtension_Hooks()
@@ -543,6 +563,7 @@ void InfantryClassExtension_Hooks()
     Patch_Jump(0x004D87E9, &_InfantryClass_Firing_AI_Mechanic_Patch);
     Patch_Jump(0x004D3A7B, &_InfantryClass_Per_Cell_Process_Transport_Attach_Sound_Patch);
     Patch_Jump(0x004D35F9, &_InfantryClass_Per_Cell_Process_Engineer_Capture_Damage_Patch);
+    Patch_Jump(0x004D3F5D, &_InfantryClass_Per_Cell_Process_Tiberium_Damage_Patch);
 
     /**
      *  ACTION_DAMAGE no longer a case in DisplayClass::Left_Mouse_Up to show the

--- a/src/extensions/storage/storageext.cpp
+++ b/src/extensions/storage/storageext.cpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          STORAGEEXT.CPP
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Extended StorageClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "storageext.h"
+
+#include "tiberium.h"
+#include "tibsun_globals.h"
+
+int StorageClassExt::Get_Total_Value() const
+{
+	int total = 0;
+
+	for (int i = 0; i < Tiberiums.Count(); i++)
+	{
+		total += ((*Types)[i] * Tiberiums[i]->Value);
+	}
+
+	return total;
+}
+
+int StorageClassExt::Get_Total_Amount() const
+{
+	int total = 0;
+
+	for (int i = 0; i < Tiberiums.Count(); i++)
+	{
+		total += (*Types)[i];
+	}
+
+	return total;
+}
+
+int StorageClassExt::Get_Amount(int index) const
+{
+	return (*Types)[index];
+}
+
+int StorageClassExt::Increase_Amount(int amount, int index)
+{
+	(*Types)[index] += amount;
+	return (*Types)[index];
+}
+
+int StorageClassExt::Decrease_Amount(int amount, int index)
+{
+	if (amount < (*Types)[index])
+		amount = (*Types)[index];
+
+	(*Types)[index] -= amount;
+	return amount;
+}
+
+int StorageClassExt::First_Used_Slot() const
+{
+	for (int i = 0; i < Tiberiums.Count(); i++)
+	{
+		if ((*Types)[i] > 0.0)
+			return i;
+	}
+
+	return -1;
+}
+
+
+StorageClassExt StorageClassExt::operator+=(StorageClassExt& that)
+{
+	for (int i = 0; i < Tiberiums.Count(); i++)
+	{
+		(*Types)[i] += (*that.Types)[i];
+	}
+
+	return *this;
+}
+
+
+StorageClassExt StorageClassExt::operator-=(StorageClassExt& that)
+{
+	for (int i = 0; i < Tiberiums.Count(); i++)
+	{
+		(*Types)[i] -= (*that.Types)[i];
+	}
+
+	return *this;
+}

--- a/src/extensions/storage/storageext.cpp
+++ b/src/extensions/storage/storageext.cpp
@@ -32,77 +32,81 @@
 
 int StorageClassExt::Get_Total_Value() const
 {
-	int total = 0;
+    int total = 0;
 
-	for (int i = 0; i < Tiberiums.Count(); i++)
-	{
-		total += ((*Types)[i] * Tiberiums[i]->Value);
-	}
+    for (int i = 0; i < Tiberiums.Count(); i++)
+    {
+        total += ((*Types)[i] * Tiberiums[i]->Value);
+    }
 
-	return total;
+    return total;
 }
 
 int StorageClassExt::Get_Total_Amount() const
 {
-	int total = 0;
+    int total = 0;
 
-	for (int i = 0; i < Tiberiums.Count(); i++)
-	{
-		total += (*Types)[i];
-	}
+    for (int i = 0; i < Tiberiums.Count(); i++)
+    {
+        total += (*Types)[i];
+    }
 
-	return total;
+    return total;
 }
+
 
 int StorageClassExt::Get_Amount(int index) const
 {
-	return (*Types)[index];
+    return (*Types)[index];
 }
+
 
 int StorageClassExt::Increase_Amount(int amount, int index)
 {
-	(*Types)[index] += amount;
-	return (*Types)[index];
+    (*Types)[index] += amount;
+    return (*Types)[index];
 }
+
 
 int StorageClassExt::Decrease_Amount(int amount, int index)
 {
-	if (amount < (*Types)[index])
-		amount = (*Types)[index];
+    if (amount < (*Types)[index])
+        amount = (*Types)[index];
 
-	(*Types)[index] -= amount;
-	return amount;
+    (*Types)[index] -= amount;
+    return amount;
 }
+
 
 int StorageClassExt::First_Used_Slot() const
 {
-	for (int i = 0; i < Tiberiums.Count(); i++)
-	{
-		if ((*Types)[i] > 0.0)
-			return i;
-	}
+    for (int i = 0; i < Tiberiums.Count(); i++)
+    {
+        if ((*Types)[i] > 0.0)
+            return i;
+    }
 
-	return -1;
+    return -1;
 }
 
 
 StorageClassExt StorageClassExt::operator+=(StorageClassExt& that)
 {
-	for (int i = 0; i < Tiberiums.Count(); i++)
-	{
-		(*Types)[i] += (*that.Types)[i];
-	}
+    for (int i = 0; i < Tiberiums.Count(); i++)
+    {
+        (*Types)[i] += (*that.Types)[i];
+    }
 
-	return *this;
+    return *this;
 }
 
 
 StorageClassExt StorageClassExt::operator-=(StorageClassExt& that)
 {
-	for (int i = 0; i < Tiberiums.Count(); i++)
-	{
-		(*Types)[i] -= (*that.Types)[i];
-	}
+    for (int i = 0; i < Tiberiums.Count(); i++)
+    {
+        (*Types)[i] -= (*that.Types)[i];
+    }
 
-	return *this;
+    return *this;
 }

--- a/src/extensions/storage/storageext.cpp
+++ b/src/extensions/storage/storageext.cpp
@@ -30,6 +30,12 @@
 #include "tiberium.h"
 #include "tibsun_globals.h"
 
+
+ /**
+  *  Reimplements StorageClass::Get_Total_Value.
+  *
+  *  @author: ZivDero
+  */
 int StorageClassExt::Get_Total_Value() const
 {
     int total = 0;
@@ -42,6 +48,12 @@ int StorageClassExt::Get_Total_Value() const
     return total;
 }
 
+
+/**
+ *  Reimplements StorageClass::Get_Total_Amount.
+ *
+ *  @author: ZivDero
+ */
 int StorageClassExt::Get_Total_Amount() const
 {
     int total = 0;
@@ -55,12 +67,22 @@ int StorageClassExt::Get_Total_Amount() const
 }
 
 
+/**
+ *  Reimplements StorageClass::Get_Amount.
+ *
+ *  @author: ZivDero
+ */
 int StorageClassExt::Get_Amount(int index) const
 {
     return (*Types)[index];
 }
 
 
+/**
+ *  Reimplements StorageClass::Increase_Amount.
+ *
+ *  @author: ZivDero
+ */
 int StorageClassExt::Increase_Amount(int amount, int index)
 {
     (*Types)[index] += amount;
@@ -68,6 +90,11 @@ int StorageClassExt::Increase_Amount(int amount, int index)
 }
 
 
+/**
+ *  Reimplements StorageClass::Decrease_Amount.
+ *
+ *  @author: ZivDero
+ */
 int StorageClassExt::Decrease_Amount(int amount, int index)
 {
     if (amount < (*Types)[index])
@@ -78,6 +105,11 @@ int StorageClassExt::Decrease_Amount(int amount, int index)
 }
 
 
+/**
+ *  Reimplements StorageClass::First_Used_Slot.
+ *
+ *  @author: ZivDero
+ */
 int StorageClassExt::First_Used_Slot() const
 {
     for (int i = 0; i < Tiberiums.Count(); i++)
@@ -90,6 +122,11 @@ int StorageClassExt::First_Used_Slot() const
 }
 
 
+/**
+ *  Reimplements StorageClass::operator+=.
+ *
+ *  @author: ZivDero
+ */
 StorageClassExt StorageClassExt::operator+=(StorageClassExt& that)
 {
     for (int i = 0; i < Tiberiums.Count(); i++)
@@ -101,6 +138,11 @@ StorageClassExt StorageClassExt::operator+=(StorageClassExt& that)
 }
 
 
+/**
+ *  Reimplements StorageClass::operator-=.
+ *
+ *  @author: ZivDero
+ */
 StorageClassExt StorageClassExt::operator-=(StorageClassExt& that)
 {
     for (int i = 0; i < Tiberiums.Count(); i++)

--- a/src/extensions/storage/storageext.h
+++ b/src/extensions/storage/storageext.h
@@ -36,7 +36,9 @@ class StorageClassExt
 {
 public:
     StorageClassExt(DynamicVectorClass<int>* vector) :
-    Types(vector) { }
+        Types(vector)
+    {
+    }
 
 public:
     /**
@@ -44,16 +46,14 @@ public:
      */
     DynamicVectorClass<int>* Types;
 
-	int Padding[3];
-
 public:
-	int Get_Total_Value() const;
-	int Get_Total_Amount() const;
-	int Get_Amount(int index) const;
-	int Increase_Amount(int amount, int index);
-	int Decrease_Amount(int amount, int index);
-	int First_Used_Slot() const;
+    int Get_Total_Value() const;
+    int Get_Total_Amount() const;
+    int Get_Amount(int index) const;
+    int Increase_Amount(int amount, int index);
+    int Decrease_Amount(int amount, int index);
+    int First_Used_Slot() const;
 
-	StorageClassExt operator+=(StorageClassExt& that);
-	StorageClassExt operator-=(StorageClassExt& that);
+    StorageClassExt operator+=(StorageClassExt& that);
+    StorageClassExt operator-=(StorageClassExt& that);
 };

--- a/src/extensions/storage/storageext.h
+++ b/src/extensions/storage/storageext.h
@@ -35,16 +35,16 @@
 class StorageClassExt
 {
 public:
-    StorageClassExt(DynamicVectorClass<int>* vector) :
+    StorageClassExt(VectorClass<int>* vector) :
         Types(vector)
     {
     }
 
 public:
     /**
-     *  Pointer to the DVC located in the extension for the class that contains the StorageClass.
+     *  Pointer to the vector located in the extension for the class that contains the StorageClass.
      */
-    DynamicVectorClass<int>* Types;
+    VectorClass<int>* Types;
 
 public:
     int Get_Total_Value() const;

--- a/src/extensions/storage/storageext.h
+++ b/src/extensions/storage/storageext.h
@@ -2,13 +2,13 @@
 /*                 O P E N  S O U R C E  --  V I N I F E R A                  **
 /*******************************************************************************
  *
- *  @project       Vinifera
+ *  @project       ZivDero
  *
- *  @file          TIBERIUMEXT_HOOKS.CPP
+ *  @file          STORAGEEXT.H
  *
  *  @author        CCHyper
  *
- *  @brief         Contains the hooks for the extended TiberiumClass.
+ *  @brief         Extended StorageClass class.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -25,25 +25,35 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#include "tiberiumext_hooks.h"
-#include "tiberiumext_init.h"
-#include "tiberiumext.h"
-#include "tiberium.h"
-#include "fatal.h"
-#include "debughandler.h"
-#include "asserthandler.h"
-#include "hooker.h"
+#pragma once
+#include "vector.h"
 
-
-/**
- *  Main function for patching the hooks.
- */
-void TiberiumClassExtension_Hooks()
+ /**
+  *  This class does not extend the vanilla StorageClass like AbstractClass extensions do.
+  *  Instead, it is constructed in its place by the owner class's extension.
+  */
+class StorageClassExt
 {
-    /**
-     *  Initialises the extended class.
-     */
-    TiberiumClassExtension_Init();
+public:
+    StorageClassExt(DynamicVectorClass<int>* vector) :
+    Types(vector) { }
 
-    Patch_Jump(0x00644DB8, 0x00644DD4); // De-hardcode Power for Tiberium Vinifera
-}
+public:
+    /**
+     *  Pointer to the DVC located in the extension for class that contains the StorageClass.
+     */
+    DynamicVectorClass<int>* Types;
+
+	int Padding[3];
+
+public:
+	int Get_Total_Value() const;
+	int Get_Total_Amount() const;
+	int Get_Amount(int index) const;
+	int Increase_Amount(int amount, int index);
+	int Decrease_Amount(int amount, int index);
+	int First_Used_Slot() const;
+
+	StorageClassExt operator+=(StorageClassExt& that);
+	StorageClassExt operator-=(StorageClassExt& that);
+};

--- a/src/extensions/storage/storageext.h
+++ b/src/extensions/storage/storageext.h
@@ -42,7 +42,7 @@ public:
 
 public:
     /**
-     *  Pointer to the DVC located in the extension for class that contains the StorageClass.
+     *  Pointer to the DVC located in the extension for the class that contains the StorageClass.
      */
     DynamicVectorClass<int>* Types;
 

--- a/src/extensions/storage/storageext_hooks.cpp
+++ b/src/extensions/storage/storageext_hooks.cpp
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          TIBERIUMEXT_HOOKS.CPP
+ *  @file          STORAGEEXT_HOOKS.CPP
  *
- *  @author        CCHyper
+ *  @author        ZivDero
  *
- *  @brief         Contains the hooks for the extended TiberiumClass.
+ *  @brief         Contains the hooks for the extended StorageClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -25,25 +25,28 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#include "tiberiumext_hooks.h"
-#include "tiberiumext_init.h"
-#include "tiberiumext.h"
-#include "tiberium.h"
+#include "storageext_hooks.h"
+#include "extension.h"
 #include "fatal.h"
-#include "debughandler.h"
 #include "asserthandler.h"
+#include "debughandler.h"
+
 #include "hooker.h"
+#include "hooker_macros.h"
+#include "storageext.h"
 
 
 /**
  *  Main function for patching the hooks.
  */
-void TiberiumClassExtension_Hooks()
+void StorageClassExtension_Hooks()
 {
-    /**
-     *  Initialises the extended class.
-     */
-    TiberiumClassExtension_Init();
-
-    Patch_Jump(0x00644DB8, 0x00644DD4); // De-hardcode Power for Tiberium Vinifera
+	Patch_Jump(0x0060AD80, &StorageClassExt::Get_Total_Value);
+	Patch_Jump(0x0060ADB0, &StorageClassExt::Get_Total_Amount);
+	Patch_Jump(0x0060ADD0, &StorageClassExt::Get_Amount);
+	Patch_Jump(0x0060ADE0, &StorageClassExt::Increase_Amount);
+	Patch_Jump(0x0060AE00, &StorageClassExt::Decrease_Amount);
+	Patch_Jump(0x0060AFA0, &StorageClassExt::First_Used_Slot);
+	Patch_Jump(0x0060AE90, &StorageClassExt::operator+=);
+	Patch_Jump(0x0060AF50, &StorageClassExt::operator-=);
 }

--- a/src/extensions/storage/storageext_hooks.cpp
+++ b/src/extensions/storage/storageext_hooks.cpp
@@ -41,12 +41,12 @@
  */
 void StorageClassExtension_Hooks()
 {
-	Patch_Jump(0x0060AD80, &StorageClassExt::Get_Total_Value);
-	Patch_Jump(0x0060ADB0, &StorageClassExt::Get_Total_Amount);
-	Patch_Jump(0x0060ADD0, &StorageClassExt::Get_Amount);
-	Patch_Jump(0x0060ADE0, &StorageClassExt::Increase_Amount);
-	Patch_Jump(0x0060AE00, &StorageClassExt::Decrease_Amount);
-	Patch_Jump(0x0060AFA0, &StorageClassExt::First_Used_Slot);
-	Patch_Jump(0x0060AE90, &StorageClassExt::operator+=);
-	Patch_Jump(0x0060AF50, &StorageClassExt::operator-=);
+    Patch_Jump(0x0060AD80, &StorageClassExt::Get_Total_Value);
+    Patch_Jump(0x0060ADB0, &StorageClassExt::Get_Total_Amount);
+    Patch_Jump(0x0060ADD0, &StorageClassExt::Get_Amount);
+    Patch_Jump(0x0060ADE0, &StorageClassExt::Increase_Amount);
+    Patch_Jump(0x0060AE00, &StorageClassExt::Decrease_Amount);
+    Patch_Jump(0x0060AFA0, &StorageClassExt::First_Used_Slot);
+    Patch_Jump(0x0060AE90, &StorageClassExt::operator+=);
+    Patch_Jump(0x0060AF50, &StorageClassExt::operator-=);
 }

--- a/src/extensions/storage/storageext_hooks.cpp
+++ b/src/extensions/storage/storageext_hooks.cpp
@@ -41,6 +41,12 @@
  */
 void StorageClassExtension_Hooks()
 {
+    /**
+     *  Patch all the methods of StorageClass to our new extension class.
+     *  Operators '+' and '-' are not patched because they are not used in the game,
+     *  and require us to instantiate a new class, which we cannot do
+     *  (because we now store the amounts in a DVC that belongs to the owner class)
+     */
     Patch_Jump(0x0060AD80, &StorageClassExt::Get_Total_Value);
     Patch_Jump(0x0060ADB0, &StorageClassExt::Get_Total_Amount);
     Patch_Jump(0x0060ADD0, &StorageClassExt::Get_Amount);

--- a/src/extensions/storage/storageext_hooks.h
+++ b/src/extensions/storage/storageext_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          TIBERIUMEXT_HOOKS.CPP
+ *  @file          STORAGEEXT_HOOKS.H
  *
- *  @author        CCHyper
+ *  @author        ZivDero
  *
- *  @brief         Contains the hooks for the extended TiberiumClass.
+ *  @brief         Contains the hooks for the extended StorageClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -25,25 +25,7 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#include "tiberiumext_hooks.h"
-#include "tiberiumext_init.h"
-#include "tiberiumext.h"
-#include "tiberium.h"
-#include "fatal.h"
-#include "debughandler.h"
-#include "asserthandler.h"
-#include "hooker.h"
+#pragma once
 
 
-/**
- *  Main function for patching the hooks.
- */
-void TiberiumClassExtension_Hooks()
-{
-    /**
-     *  Initialises the extended class.
-     */
-    TiberiumClassExtension_Init();
-
-    Patch_Jump(0x00644DB8, 0x00644DD4); // De-hardcode Power for Tiberium Vinifera
-}
+void StorageClassExtension_Hooks();

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -63,7 +63,8 @@ TechnoClassExtension::TechnoClassExtension(const TechnoClass *this_ptr) :
  *  @author: CCHyper
  */
 TechnoClassExtension::TechnoClassExtension(const NoInitClass &noinit) :
-    RadioClassExtension(noinit)
+    RadioClassExtension(noinit),
+    Storage(noinit)
 {
     //EXT_DEBUG_TRACE("TechnoClassExtension::TechnoClassExtension(NoInitClass) - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -53,7 +53,10 @@ TechnoClassExtension::TechnoClassExtension(const TechnoClass *this_ptr) :
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoClassExtension::TechnoClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
-    new ((StorageClassExt*)&(this_ptr->Storage)) StorageClassExt(&Storage);
+    if (this_ptr)
+    {
+        new ((StorageClassExt*)&(this_ptr->Storage)) StorageClassExt(&Storage);
+    }
 }
 
 
@@ -98,8 +101,6 @@ HRESULT TechnoClassExtension::Load(IStream *pStm)
     }
 
     ElectricBolt = nullptr;
-
-    new ((StorageClassExt*)&(This()->Storage)) StorageClassExt(&Storage);
     
     return hr;
 }

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -38,6 +38,8 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "saveload.h"
+#include "vinifera_saveload.h"
 #include "storage/storageext.h"
 
 
@@ -52,6 +54,11 @@ TechnoClassExtension::TechnoClassExtension(const TechnoClass *this_ptr) :
     Storage(Tiberiums.Count())
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoClassExtension::TechnoClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    for (int i = 0; i < Tiberiums.Count(); i++)
+    {
+        Storage.Add(0);
+    }
 
     if (this_ptr)
     {
@@ -100,6 +107,8 @@ HRESULT TechnoClassExtension::Load(IStream *pStm)
         return E_FAIL;
     }
 
+    Load_Primitive_Vector(pStm, Storage);
+
     ElectricBolt = nullptr;
     
     return hr;
@@ -120,6 +129,7 @@ HRESULT TechnoClassExtension::Save(IStream *pStm, BOOL fClearDirty)
         return hr;
     }
 
+    Save_Primitive_Vector(pStm, Storage);
     ElectricBolt = nullptr;
 
     return hr;

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -57,7 +57,7 @@ TechnoClassExtension::TechnoClassExtension(const TechnoClass *this_ptr) :
 
     for (int i = 0; i < Tiberiums.Count(); i++)
     {
-        Storage.Add(0);
+        Storage[i] = 0;
     }
 
     if (this_ptr)

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -38,6 +38,7 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "storage/storageext.h"
 
 
 /**
@@ -47,9 +48,12 @@
  */
 TechnoClassExtension::TechnoClassExtension(const TechnoClass *this_ptr) :
     RadioClassExtension(this_ptr),
-    ElectricBolt(nullptr)
+    ElectricBolt(nullptr),
+    Storage(Tiberiums.Count())
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoClassExtension::TechnoClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    new ((StorageClassExt*)&(this_ptr->Storage)) StorageClassExt(&Storage);
 }
 
 
@@ -93,6 +97,8 @@ HRESULT TechnoClassExtension::Load(IStream *pStm)
     }
 
     ElectricBolt = nullptr;
+
+    new ((StorageClassExt*)&(This()->Storage)) StorageClassExt(&Storage);
     
     return hr;
 }

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -386,6 +386,12 @@ bool TechnoClassExtension::Can_Passive_Acquire() const
 }
 
 
+void TechnoClassExtension::Put_Storage_Pointers()
+{
+    new ((StorageClassExt*)&(This()->Storage)) StorageClassExt(&Storage);
+}
+
+
 /**
  *  Provides access to the TechnoTypeClass instance for this extension. 
  * 

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -64,6 +64,8 @@ class TechnoClassExtension : public RadioClassExtension
         virtual void Response_Harvest();
         virtual bool Can_Passive_Acquire() const;
 
+        void Put_Storage_Pointers();
+
     private:
         const TechnoTypeClass *Techno_Type_Class() const;
         const TechnoTypeClassExtension *Techno_Type_Class_Ext() const;

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -73,4 +73,9 @@ class TechnoClassExtension : public RadioClassExtension
          *  The current electric bolt instance fired by this object.
          */
         EBoltClass *ElectricBolt;
+
+        /**
+         *  Replacement Tiberium storage.
+         */
+        DynamicVectorClass<int> Storage;
 };

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -79,5 +79,5 @@ class TechnoClassExtension : public RadioClassExtension
         /**
          *  Replacement Tiberium storage.
          */
-        DynamicVectorClass<int> Storage;
+        VectorClass<int> Storage;
 };

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -986,12 +986,18 @@ DECLARE_PATCH(_TechnoClass_Null_House_Warning_Patch)
 }
 
 
+static void Put_Storage_Pointers(TechnoClass* techno)
+{
+    new ((StorageClassExt*)&(techno->Storage)) StorageClassExt(&Extension::Fetch<TechnoClassExtension>(techno)->Storage);
+}
+
+
 DECLARE_PATCH(_TechnoClass_Load_StorageExtPtr)
 {
     GET_REGISTER_STATIC(int, result, eax);
     GET_REGISTER_STATIC(TechnoClass*, this_ptr, esi);
 
-    new ((StorageClassExt*)&(this_ptr->Storage)) StorageClassExt(&Extension::Fetch<TechnoClassExtension>(this_ptr)->Storage);
+    Put_Storage_Pointers(this_ptr);
 
     if (result >= 0)
     {

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -58,6 +58,7 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "storageext.h"
 #include "textprint.h"
 #include "tiberiumext.h"
 #include "unittype.h"
@@ -985,6 +986,22 @@ DECLARE_PATCH(_TechnoClass_Null_House_Warning_Patch)
 }
 
 
+DECLARE_PATCH(_TechnoClass_Load_StorageExtPtr)
+{
+    GET_REGISTER_STATIC(int, result, eax);
+    GET_REGISTER_STATIC(TechnoClass*, this_ptr, esi);
+
+    new ((StorageClassExt*)&(this_ptr->Storage)) StorageClassExt(&Extension::Fetch<TechnoClassExtension>(this_ptr)->Storage);
+
+    if (result >= 0)
+    {
+        JMP(0x00638D94);
+    }
+
+    JMP(0x00638E73);
+}
+
+
 /**
  *  Main function for patching the hooks.
  */
@@ -1006,4 +1023,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00636F09, &_TechnoClass_Is_Allowed_To_Retaliate_Can_Retaliate_Patch);
     Patch_Jump(0x0062D4CA, &_TechnoClass_Evaluate_Object_Is_Legal_Target_Patch);
     Patch_Jump(0x00637540, &TechnoClassExt::_Draw_Pips);
+    Patch_Jump(0x00638D8C, &_TechnoClass_Load_StorageExtPtr);
 }

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -986,28 +986,6 @@ DECLARE_PATCH(_TechnoClass_Null_House_Warning_Patch)
 }
 
 
-static void Put_Storage_Pointers(TechnoClass* techno)
-{
-    new ((StorageClassExt*)&(techno->Storage)) StorageClassExt(&Extension::Fetch<TechnoClassExtension>(techno)->Storage);
-}
-
-
-DECLARE_PATCH(_TechnoClass_Load_StorageExtPtr)
-{
-    GET_REGISTER_STATIC(int, result, eax);
-    GET_REGISTER_STATIC(TechnoClass*, this_ptr, esi);
-
-    Put_Storage_Pointers(this_ptr);
-
-    if (result >= 0)
-    {
-        JMP(0x00638D94);
-    }
-
-    JMP(0x00638E73);
-}
-
-
 /**
  *  Main function for patching the hooks.
  */
@@ -1029,5 +1007,4 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00636F09, &_TechnoClass_Is_Allowed_To_Retaliate_Can_Retaliate_Patch);
     Patch_Jump(0x0062D4CA, &_TechnoClass_Evaluate_Object_Is_Legal_Target_Patch);
     Patch_Jump(0x00637540, &TechnoClassExt::_Draw_Pips);
-    Patch_Jump(0x00638D8C, &_TechnoClass_Load_StorageExtPtr);
 }

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -167,7 +167,7 @@ void TechnoClassExt::_Draw_Pips(Point2D& bottomleft, Point2D& center, Rect& rect
                     **  Add the pips to draw to a vector.
                     */
                     for (int i = 0; i < pips; i++)
-                        pips_to_draw.push_back(RuleExtension->WeedPipIndex);
+                        pips_to_draw.emplace_back(RuleExtension->WeedPipIndex);
                 }
                 else
                 {
@@ -180,7 +180,7 @@ void TechnoClassExt::_Draw_Pips(Point2D& bottomleft, Point2D& center, Rect& rect
                     **  Add all the Tiberiums and sort.
                     */
                     for (int i = 0; i < Tiberiums.Count(); i++)
-                        tibtypes.push_back(std::make_tuple(Extension::Fetch<TiberiumClassExtension>(Tiberiums[i])->PipDrawOrder, i));
+                        tibtypes.emplace_back(Extension::Fetch<TiberiumClassExtension>(Tiberiums[i])->PipDrawOrder, i);
 
                     std::stable_sort(tibtypes.begin(), tibtypes.end());
 

--- a/src/extensions/tiberium/tiberiumext.cpp
+++ b/src/extensions/tiberium/tiberiumext.cpp
@@ -31,6 +31,8 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "overlaytype.h"
+#include "tibsun_globals.h"
 
 
 /**
@@ -191,6 +193,10 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
 {
     //EXT_DEBUG_TRACE("TiberiumClassExtension::Read_INI - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
+    // Default values set from the TiberiumType
+    OverlayIndex = This()->Image ? This()->Image->Get_Heap_ID() : 0;
+    UseSlopes = This()->NumSlopeFacings > 0;
+
     if (!AbstractTypeClassExtension::Read_INI(ini)) {
         return false;
     }
@@ -203,6 +209,17 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
 
     PipIndex = ini.Get_Int(ini_name, "PipIndex", PipIndex);
     PipDrawOrder = ini.Get_Int(ini_name, "PipDrawOrder", PipDrawOrder);
+
+    OverlayIndex = ini.Get_Int(ini_name, "OverlayIndex", OverlayIndex);
+    UseSlopes = ini.Get_Bool(ini_name, "UseSlopes", UseSlopes);
+
+    ASSERT_PRINT(OverlayIndex >= 0 && OverlayIndex < OverlayTypes.Count(), "TiberiumType %d has an invalid OverlayIndex %d!\n", This()->Get_Heap_ID(), OverlayIndex);
+    if (OverlayIndex >= 0 && OverlayIndex < OverlayTypes.Count())
+        This()->Image = OverlayTypes[OverlayIndex];
+
+    This()->NumFrames = 12;
+    This()->NumImages = 12;
+    This()->NumSlopeFacings = UseSlopes ? 8 : 0;
     
     return true;
 }

--- a/src/extensions/tiberium/tiberiumext.cpp
+++ b/src/extensions/tiberium/tiberiumext.cpp
@@ -127,8 +127,6 @@ HRESULT TiberiumClassExtension::Load(IStream *pStm)
     }
 
     new (this) TiberiumClassExtension(NoInitClass());
-
-    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Overlay, "Overlay");
     
     return hr;
 }
@@ -196,11 +194,6 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
 {
     //EXT_DEBUG_TRACE("TiberiumClassExtension::Read_INI - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
-    // Default values set from the TiberiumType
-    Overlay = This()->Image;
-    UseSlopes = This()->NumSlopeFacings > 0;
-    DamageToInfantry = This()->Power / 10;
-
     if (!AbstractTypeClassExtension::Read_INI(ini)) {
         return false;
     }
@@ -214,13 +207,18 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
     PipIndex = ini.Get_Int(ini_name, "PipIndex", PipIndex);
     PipDrawOrder = ini.Get_Int(ini_name, "PipDrawOrder", PipDrawOrder);
 
-    Overlay = (OverlayTypeClass*)ini.Get_Overlay(ini_name, "Overlay", Overlay);
-    UseSlopes = ini.Get_Bool(ini_name, "UseSlopes", UseSlopes);
+    // Default values set from the TiberiumType
+    OverlayTypeClass* overlay = This()->Image;
+    bool useSlopes = This()->NumSlopeFacings > 0;
+    DamageToInfantry = This()->Power / 10;
 
-    This()->Image = Overlay;
+    overlay = (OverlayTypeClass*)ini.Get_Overlay(ini_name, "Overlay", overlay);
+    useSlopes = ini.Get_Bool(ini_name, "UseSlopes", useSlopes);
+
+    This()->Image = overlay;
     This()->NumFrames = 12;
     This()->NumImages = 12;
-    This()->NumSlopeFacings = UseSlopes ? 8 : 0;
+    This()->NumSlopeFacings = useSlopes ? 8 : 0;
 
     DamageToInfantry = ini.Get_Int(ini_name, "DamageToInfantry", DamageToInfantry);
     

--- a/src/extensions/tiberium/tiberiumext.cpp
+++ b/src/extensions/tiberium/tiberiumext.cpp
@@ -196,6 +196,8 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
     // Default values set from the TiberiumType
     OverlayIndex = This()->Image ? This()->Image->Get_Heap_ID() : 0;
     UseSlopes = This()->NumSlopeFacings > 0;
+    DamageToInfantry = This()->Power / 10;
+    ChainReactionDamage = This()->Power;
 
     if (!AbstractTypeClassExtension::Read_INI(ini)) {
         return false;
@@ -220,6 +222,9 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
     This()->NumFrames = 12;
     This()->NumImages = 12;
     This()->NumSlopeFacings = UseSlopes ? 8 : 0;
+
+    DamageToInfantry = ini.Get_Int(ini_name, "DamageToInfantry", DamageToInfantry);
+    ChainReactionDamage = ini.Get_Int(ini_name, "ChainReactionDamage", ChainReactionDamage);
     
     return true;
 }

--- a/src/extensions/tiberium/tiberiumext.cpp
+++ b/src/extensions/tiberium/tiberiumext.cpp
@@ -33,6 +33,7 @@
 #include "debughandler.h"
 #include "overlaytype.h"
 #include "tibsun_globals.h"
+#include "vinifera_saveload.h"
 
 
 /**
@@ -126,6 +127,8 @@ HRESULT TiberiumClassExtension::Load(IStream *pStm)
     }
 
     new (this) TiberiumClassExtension(NoInitClass());
+
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Overlay, "Overlay");
     
     return hr;
 }

--- a/src/extensions/tiberium/tiberiumext.cpp
+++ b/src/extensions/tiberium/tiberiumext.cpp
@@ -194,7 +194,7 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
     //EXT_DEBUG_TRACE("TiberiumClassExtension::Read_INI - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
     // Default values set from the TiberiumType
-    OverlayIndex = This()->Image ? This()->Image->Get_Heap_ID() : 0;
+    Overlay = This()->Image;
     UseSlopes = This()->NumSlopeFacings > 0;
     DamageToInfantry = This()->Power / 10;
 
@@ -211,13 +211,10 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
     PipIndex = ini.Get_Int(ini_name, "PipIndex", PipIndex);
     PipDrawOrder = ini.Get_Int(ini_name, "PipDrawOrder", PipDrawOrder);
 
-    OverlayIndex = ini.Get_Int(ini_name, "OverlayIndex", OverlayIndex);
+    Overlay = (OverlayTypeClass*)ini.Get_Overlay(ini_name, "Overlay", Overlay);
     UseSlopes = ini.Get_Bool(ini_name, "UseSlopes", UseSlopes);
 
-    ASSERT_PRINT(OverlayIndex >= 0 && OverlayIndex < OverlayTypes.Count(), "TiberiumType %d has an invalid OverlayIndex %d!\n", This()->Get_Heap_ID(), OverlayIndex);
-    if (OverlayIndex >= 0 && OverlayIndex < OverlayTypes.Count())
-        This()->Image = OverlayTypes[OverlayIndex];
-
+    This()->Image = Overlay;
     This()->NumFrames = 12;
     This()->NumImages = 12;
     This()->NumSlopeFacings = UseSlopes ? 8 : 0;

--- a/src/extensions/tiberium/tiberiumext.cpp
+++ b/src/extensions/tiberium/tiberiumext.cpp
@@ -197,7 +197,6 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
     OverlayIndex = This()->Image ? This()->Image->Get_Heap_ID() : 0;
     UseSlopes = This()->NumSlopeFacings > 0;
     DamageToInfantry = This()->Power / 10;
-    ChainReactionDamage = This()->Power;
 
     if (!AbstractTypeClassExtension::Read_INI(ini)) {
         return false;
@@ -224,7 +223,6 @@ bool TiberiumClassExtension::Read_INI(CCINIClass &ini)
     This()->NumSlopeFacings = UseSlopes ? 8 : 0;
 
     DamageToInfantry = ini.Get_Int(ini_name, "DamageToInfantry", DamageToInfantry);
-    ChainReactionDamage = ini.Get_Int(ini_name, "ChainReactionDamage", ChainReactionDamage);
     
     return true;
 }

--- a/src/extensions/tiberium/tiberiumext.h
+++ b/src/extensions/tiberium/tiberiumext.h
@@ -73,9 +73,9 @@ TiberiumClassExtension final : public AbstractTypeClassExtension
         int PipDrawOrder;
 
         /**
-         *  Index of a custom OverlayType that is the start of this Tiberium's overlays.
+         *  Custom OverlayType that is the start of this Tiberium's overlays.
          */
-        int OverlayIndex;
+        OverlayTypeClass* Overlay;
 
         /**
          *  Should this Tiberium type use slopes?

--- a/src/extensions/tiberium/tiberiumext.h
+++ b/src/extensions/tiberium/tiberiumext.h
@@ -81,4 +81,14 @@ TiberiumClassExtension final : public AbstractTypeClassExtension
          *  Should this Tiberium type use slopes?
          */
         bool UseSlopes;
+
+        /**
+         *  The damage this Tiberium does to infantry.
+         */
+        int DamageToInfantry;
+
+        /**
+         *  The damage this Tiberium causes when exploding.
+         */
+        int ChainReactionDamage;
 };

--- a/src/extensions/tiberium/tiberiumext.h
+++ b/src/extensions/tiberium/tiberiumext.h
@@ -86,9 +86,4 @@ TiberiumClassExtension final : public AbstractTypeClassExtension
          *  The damage this Tiberium does to infantry.
          */
         int DamageToInfantry;
-
-        /**
-         *  The damage this Tiberium causes when exploding.
-         */
-        int ChainReactionDamage;
 };

--- a/src/extensions/tiberium/tiberiumext.h
+++ b/src/extensions/tiberium/tiberiumext.h
@@ -73,16 +73,6 @@ TiberiumClassExtension final : public AbstractTypeClassExtension
         int PipDrawOrder;
 
         /**
-         *  Custom OverlayType that is the start of this Tiberium's overlays.
-         */
-        OverlayTypeClass* Overlay;
-
-        /**
-         *  Should this Tiberium type use slopes?
-         */
-        bool UseSlopes;
-
-        /**
          *  The damage this Tiberium does to infantry.
          */
         int DamageToInfantry;

--- a/src/extensions/tiberium/tiberiumext.h
+++ b/src/extensions/tiberium/tiberiumext.h
@@ -71,4 +71,14 @@ TiberiumClassExtension final : public AbstractTypeClassExtension
          *  The order in which this Tiberium appears when pips are drawn.
          */
         int PipDrawOrder;
+
+        /**
+         *  Index of a custom OverlayType that is the start of this Tiberium's overlays.
+         */
+        int OverlayIndex;
+
+        /**
+         *  Should this Tiberium type use slopes?
+         */
+        bool UseSlopes;
 };

--- a/src/extensions/tiberium/tiberiumext_hooks.cpp
+++ b/src/extensions/tiberium/tiberiumext_hooks.cpp
@@ -41,43 +41,6 @@
 
 
 /**
- *  Uses a new extension value as the damage Tiberium deals when exploding.
- *
- *  @author: ZivDero
- */
-DECLARE_PATCH(_Chain_Reaction_Damage_Patch)
-{
-    GET_REGISTER_STATIC(CellClass*, cell, esi);
-    GET_REGISTER_STATIC(TiberiumClass*, tib, ebx);
-    static bool reduce_tib;
-    static int damage;
-    static char overlay_data;
-
-    reduce_tib = false;
-    overlay_data = cell->OverlayData;
-
-    damage = (overlay_data / 2) * Extension::Fetch<TiberiumClassExtension>(tib)->ChainReactionDamage;
-
-    if (cell->OverlayData >= 11)
-        reduce_tib = true;
-
-    cell->OverlayData -= overlay_data / 2;
-
-    _asm
-    {
-        movzx eax, reduce_tib
-        mov [esp + 0xF], al
-        mov edi, damage
-        mov esi, cell
-        mov ecx, cell
-        push ebp
-    }
-
-    JMP_REG(eax, 0x0045ED34);
-}
-
-
-/**
  *  For some reason, the WW call to DebugString here causes a crash
  *  under some circumstances, and is otherwise buggy.
  *  This replaces it with a Vinifera equivalent
@@ -105,6 +68,5 @@ void TiberiumClassExtension_Hooks()
     TiberiumClassExtension_Init();
 
     Patch_Jump(0x00644DB8, 0x00644DD4); // De-hardcode Power for Tiberium Vinifera
-    Patch_Jump(0x0045ED02, _Chain_Reaction_Damage_Patch);
     Patch_Jump(0x0058C934, _Get_Tiberium_Type_Debug_Info_Patch);
 }

--- a/src/extensions/tiberium/tiberiumext_hooks.cpp
+++ b/src/extensions/tiberium/tiberiumext_hooks.cpp
@@ -29,6 +29,7 @@
 #include "tiberiumext_init.h"
 #include "tiberiumext.h"
 #include "tiberium.h"
+#include "overlaytype.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -36,13 +37,14 @@
 #include "extension.h"
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "debughandler.h"
 
 
- /**
-  *  Uses a new extension value as the damage Tiberium deals when exploding.
-  *
-  *  @author: ZivDero
-  */
+/**
+ *  Uses a new extension value as the damage Tiberium deals when exploding.
+ *
+ *  @author: ZivDero
+ */
 DECLARE_PATCH(_Chain_Reaction_Damage_Patch)
 {
     GET_REGISTER_STATIC(CellClass*, cell, esi);
@@ -70,6 +72,23 @@ DECLARE_PATCH(_Chain_Reaction_Damage_Patch)
 
 
 /**
+ *  For some reason, the WW call to DebugString here causes a crash
+ *  under some circumstances, and is otherwise buggy.
+ *  This replaces it with a Vinifera equivalent
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_Get_Tiberium_Type_Debug_Info_Patch)
+{
+    GET_REGISTER_STATIC(OverlayTypeClass*, overlaytype, eax);
+
+    DEBUG_FATAL("Overlay %s [%d] is not really Tiberium!\nAll overlays with Tiberium=yes must be used by a Tiberium!\n", overlaytype->Full_Name(), overlaytype->Get_Heap_ID());
+
+    JMP(0x0058C951);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void TiberiumClassExtension_Hooks()
@@ -81,4 +100,5 @@ void TiberiumClassExtension_Hooks()
 
     Patch_Jump(0x00644DB8, 0x00644DD4); // De-hardcode Power for Tiberium Vinifera
     Patch_Jump(0x0045ED02, _Chain_Reaction_Damage_Patch);
+    Patch_Jump(0x0058C934, _Get_Tiberium_Type_Debug_Info_Patch);
 }

--- a/src/extensions/tiberium/tiberiumext_hooks.cpp
+++ b/src/extensions/tiberium/tiberiumext_hooks.cpp
@@ -51,23 +51,29 @@ DECLARE_PATCH(_Chain_Reaction_Damage_Patch)
     GET_REGISTER_STATIC(TiberiumClass*, tib, ebx);
     static bool reduce_tib;
     static int damage;
+    static char overlay_data;
 
     reduce_tib = false;
-    damage = (cell->OverlayData / 2) * Extension::Fetch<TiberiumClassExtension>(tib)->ChainReactionDamage;
+    overlay_data = cell->OverlayData;
+
+    damage = (overlay_data / 2) * Extension::Fetch<TiberiumClassExtension>(tib)->ChainReactionDamage;
 
     if (cell->OverlayData >= 11)
         reduce_tib = true;
 
-    cell->OverlayData -= cell->OverlayData / 2;
+    cell->OverlayData -= overlay_data / 2;
 
     _asm
     {
         movzx eax, reduce_tib
         mov [esp + 0xF], al
         mov edi, damage
+        mov esi, cell
+        mov ecx, cell
+        push ebp
     }
 
-    JMP_REG(ecx, 0x0045ED29);
+    JMP_REG(eax, 0x0045ED34);
 }
 
 

--- a/src/vinifera/vinifera_hooks.cpp
+++ b/src/vinifera/vinifera_hooks.cpp
@@ -453,6 +453,17 @@ failure:
 }
 
 
+DECLARE_PATCH(_Load_Game_Remap_Storage_Pointers)
+{
+    Vinifera_Remap_Storage_Pointers();
+
+    // Stolen instructions
+    Map.Init_IO();
+
+    JMP(0x005D6B52);
+}
+
+
 /**
  *  Do not allow save games below our the base level Vinifera version. This patch
  *  will remove any support for save games made with vanilla Tiberian Sun 2.03!
@@ -832,6 +843,8 @@ void Vinifera_Hooks()
      *  Check the return value of Load_Game to ensure no false game starts.
      */
     Patch_Jump(0x005D6B11, &_Load_Game_Check_Return_Value);
+
+    Patch_Jump(0x005D6B48, &_Load_Game_Remap_Storage_Pointers);
 
     /**
      *  Change SUN.EXE to our DLL name.

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -96,6 +96,7 @@
 #include "waypointpath.h"
 #include "alphashape.h"
 
+#include "houseext.h"
 #include "scenarioext.h"
 
 #include "scenario.h"
@@ -107,6 +108,7 @@
 #include "session.h"
 #include "addon.h"
 #include "ccini.h"
+#include "technoext.h"
 
 
 /**
@@ -703,4 +705,19 @@ bool Vinifera_Remap_Extension_Pointers()
     }
 
     return true;
+}
+
+void Vinifera_Remap_Storage_Pointers()
+{
+    for (int i = 0; i < Technos.Count(); i++)
+    {
+        const TechnoClass* techno = Technos[i];
+        Extension::Fetch<TechnoClassExtension>(techno)->Put_Storage_Pointers();
+    }
+
+    for (int i = 0; i < Houses.Count(); i++)
+    {
+        const HouseClass* house = Houses[i];
+        Extension::Fetch<HouseClassExtension>(house)->Put_Storage_Pointers();
+    }
 }

--- a/src/vinifera/vinifera_saveload.h
+++ b/src/vinifera/vinifera_saveload.h
@@ -96,9 +96,9 @@ void Vinifera_Remap_Storage_Pointers();
 
 
 template<class T>
-HRESULT Save_Primitive_Vector(LPSTREAM& pStm, DynamicVectorClass<T>& list)
+HRESULT Save_Primitive_Vector(LPSTREAM& pStm, VectorClass<T>& list)
 {
-    int count = list.Count();
+    int count = list.Length();
     HRESULT hr = pStm->Write(&count, sizeof(count), nullptr);
     if (FAILED(hr)) {
         return hr;
@@ -122,7 +122,7 @@ HRESULT Save_Primitive_Vector(LPSTREAM& pStm, DynamicVectorClass<T>& list)
 
 
 template<class T>
-HRESULT Load_Primitive_Vector(LPSTREAM& pStm, DynamicVectorClass<T>& list)
+HRESULT Load_Primitive_Vector(LPSTREAM& pStm, VectorClass<T>& list)
 {
     int count = 0;
     HRESULT hr = pStm->Read(&count, sizeof(count), nullptr);
@@ -130,7 +130,7 @@ HRESULT Load_Primitive_Vector(LPSTREAM& pStm, DynamicVectorClass<T>& list)
         return hr;
     }
 
-    new (&list) DynamicVectorClass<T>();
+    new (&list) VectorClass<T>(count);
 
     if (count <= 0) {
         return hr;
@@ -143,7 +143,7 @@ HRESULT Load_Primitive_Vector(LPSTREAM& pStm, DynamicVectorClass<T>& list)
         if (FAILED(hr)) {
             return hr;
         }
-        list.Add(obj);
+        list[index] = obj;
 
     }
 

--- a/src/vinifera/vinifera_saveload.h
+++ b/src/vinifera/vinifera_saveload.h
@@ -92,3 +92,4 @@ extern unsigned ViniferaSaveGameVersion;
 bool Vinifera_Put_All(IStream *pStm, bool save_net = false);
 bool Vinifera_Get_All(IStream *pStm, bool load_net = false);
 bool Vinifera_Remap_Extension_Pointers();
+void Vinifera_Remap_Storage_Pointers();

--- a/src/vinifera/vinifera_saveload.h
+++ b/src/vinifera/vinifera_saveload.h
@@ -93,3 +93,60 @@ bool Vinifera_Put_All(IStream *pStm, bool save_net = false);
 bool Vinifera_Get_All(IStream *pStm, bool load_net = false);
 bool Vinifera_Remap_Extension_Pointers();
 void Vinifera_Remap_Storage_Pointers();
+
+
+template<class T>
+HRESULT Save_Primitive_Vector(LPSTREAM& pStm, DynamicVectorClass<T>& list)
+{
+    int count = list.Count();
+    HRESULT hr = pStm->Write(&count, sizeof(count), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    if (count <= 0) {
+        return hr;
+    }
+
+    for (int index = 0; index < count; ++index) {
+
+        HRESULT hr = pStm->Write(&list[index], sizeof(list[index]), nullptr);
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+    }
+
+    return hr;
+}
+
+
+template<class T>
+HRESULT Load_Primitive_Vector(LPSTREAM& pStm, DynamicVectorClass<T>& list)
+{
+    int count = 0;
+    HRESULT hr = pStm->Read(&count, sizeof(count), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    new (&list) DynamicVectorClass<T>();
+
+    if (count <= 0) {
+        return hr;
+    }
+
+    for (int index = 0; index < count; ++index) {
+
+        T obj;
+        HRESULT hr = pStm->Read(&obj, sizeof(obj), nullptr);
+        if (FAILED(hr)) {
+            return hr;
+        }
+        list.Add(obj);
+
+    }
+
+    return hr;
+}
+


### PR DESCRIPTION
- This PR extends Tiberium Storage to support new Tiberiums.

- New and old Tiberiums' image can now also be customized in more detail.

```ini
[Tiberium]
Overlay = ; OverlayType - defaults to the value usually used by the Image=, or overlay at index 102 if not specified
UseSlopes = ; bool  - does this Tiberium have graphics for slopes?
```

#WARNING: The `Image=` key only works within its vanilla values, and sets `OverlayIndex` and `UseSlopes` defaults. For new values, use those keys, which will override values set by `Image=`.

- `OverlayIndex` specifies the index of the first overlay the Tiberium uses. There must be 12 overlays, located one after another sequentially. Additionally, is UseSlopes is set to yes, another 8 overlays are required after the previous 12.

- Additionally, Power= has been unhardcoded for Tiberium `[Vinifera]`

- Moreover, the damage Tiberium deals to infantry is now customizable separately from `Power`.
```ini
[Tiberium]
DamageToInfantry = ; integer - damage to infantry per tick, defaults to Power / 10
```

Removal of ts-patches [tiberium_stuff](https://github.com/CnCNet/ts-patches/blob/master/src/tiberium_stuff.asm) and [tiberium_damage](https://github.com/CnCNet/ts-patches/blob/master/src/tiberium_damage.asm) is required for this to work properly. Please keep in mind that Power once again behaves like in vanilla in regards to chain explosions and should be set to reasonable values, while `DamageToInfantry` should be used to customize Tiberium's damage to infantry.

#WARNING: All `OverlayTypes` used by a `Tiberium` must have `Tiberium=yes`, and no other `OverlayTypes` may have `Tiberium=yes`, or this will lead to severe lags/crashes.

Resolves #1062 