### PR TITLE
Fix bug where player starting waypoints did not work with the TS Client

### DIFF
--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -484,6 +484,15 @@ void ScenarioClassExtension::Read_Waypoint_INI(CCINIClass &ini)
          */
         Waypoint[wp_num] = cell;
 
+#if defined(TS_CLIENT)
+        /**
+         *  Also store original waypoint value for the CnCNet ts-patches spawner.
+         */
+        if (wp_num < WAYPOINT_COUNT) {
+            Scen->Waypoint[wp_num] = cell;
+        }
+#endif
+
         /**
          *  If the cell location is valid, flag the cell on the map as a waypoint holder.
          */


### PR DESCRIPTION
Assign waypoints to original waypoint array for TS Client so the original game and ts-patches spawner code can still use waypoints as required