### PR TITLE
Make harvesters drop the correct Tiberium on death

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -154,4 +154,5 @@ This page lists all the individual contributions to the project by their author.
   - Implement the support for new ArmorTypes and allow forbidding force-fire, passive-acquire and retaliation versus specific armor types.
   - Fix a bug where the objects would sometimes receive a minimum of 1 damage even if MinDamage was set to 0.
   - Add a developer command to dump all heaps to the log.
+  - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius.
 

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -8,6 +8,7 @@ This page describes every change in Vinifera that wasn't categorized into a prop
 - Vinifera implements the Blowfish algorithm into the Vinifera DLL itself, removing the requirement for the external BLOWFISH.DLL library. As a result, this allows the game will run without BLOWFISH.DLL registered on the target system or present in the installation directory. The game can still load encrypted mix files to be loaded without any issues.
 - Vinifera allows players to set a rally point for their service depot, similar to the functionality already available for factories.
 - OverlayTypes 27 to 38 (fourth Tiberium images) were hardcoded to be impassable by infantry. This limitation is removed.
+- Harvesters used to drop their cargo as Tiberium Riparius on death. They will now drop the Tiberium types they are carrying, instead.
 
 ## Quality of Life
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -137,6 +137,7 @@ New:
 - Make OverlayTypes 27 to 38 (fourth Tiberium images) passable by infantry (by AlexB)
 - Implement the support for new ArmorTypes and allow forbidding force-fire, passive-acquire and retaliation versus specific armor types (by ZivDero/CCHyper)
 - Add a developer command to dump all heaps to the log (by ZivDero)
+- Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius (by ZivDero)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)


### PR DESCRIPTION
On death harvesters drop their cargo as Tiberium. However, they would always drop Tiberium Riparius. This PR changes that so they now drop the TIberium they are carrying.