### PR TITLE
Change Tiberiums to be read additively

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -155,4 +155,5 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where the objects would sometimes receive a minimum of 1 damage even if MinDamage was set to 0.
   - Add a developer command to dump all heaps to the log.
   - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius.
+  - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties.
 

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -9,6 +9,7 @@ This page describes every change in Vinifera that wasn't categorized into a prop
 - Vinifera allows players to set a rally point for their service depot, similar to the functionality already available for factories.
 - OverlayTypes 27 to 38 (fourth Tiberium images) were hardcoded to be impassable by infantry. This limitation is removed.
 - Harvesters used to drop their cargo as Tiberium Riparius on death. They will now drop the Tiberium types they are carrying, instead.
+- It is no longer required to list all Tiberiums in a map to override some Tiberium's properties.
 
 ## Quality of Life
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -138,6 +138,7 @@ New:
 - Implement the support for new ArmorTypes and allow forbidding force-fire, passive-acquire and retaliation versus specific armor types (by ZivDero/CCHyper)
 - Add a developer command to dump all heaps to the log (by ZivDero)
 - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius (by ZivDero)
+- Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties (by ZivDero)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -259,6 +259,14 @@ void RulesClassExtension::Process(CCINIClass &ini)
     This()->VoxelAnims(ini);
     This()->Particles(ini);
     This()->ParticleSystems(ini);
+
+    /**
+     *  Read Tiberiums like all other types, instead of handling them separately.
+     *
+     *  @author: ZivDero
+     */
+    Tiberiums(ini);
+
     This()->JumpjetControls(ini);
     This()->MPlayer(ini);
     This()->AI(ini);
@@ -305,7 +313,7 @@ void RulesClassExtension::Process(CCINIClass &ini)
     This()->CombatDamage(ini);
     This()->AudioVisual(ini);
     This()->SpecialWeapons(ini);
-    TiberiumClass::Process(ini);
+    //TiberiumClass::Process(ini);
 
     /**
      *  Process the rules extension.
@@ -518,6 +526,11 @@ bool RulesClassExtension::Objects(CCINIClass &ini)
     for (int index = 0; index < ParticleSystemTypeExtensions.Count(); ++index) {
         ParticleSystemTypeExtensions[index]->Read_INI(ini);
     }
+
+    DEBUG_INFO("Rules: Processing Tiberiums (Count: %d)...\n", ::Tiberiums.Count());
+    for (int index = 0; index < ::Tiberiums.Count(); ++index) {
+        ::Tiberiums[index]->Read_INI(ini);
+    }
     
     DEBUG_INFO("Rules: Processing VoxelAnimTypes (Count: %d)...\n", VoxelAnimTypes.Count());
     for (int index = 0; index < VoxelAnimTypes.Count(); ++index) {
@@ -712,6 +725,48 @@ bool RulesClassExtension::Armors(CCINIClass &ini)
                 DEV_DEBUG_WARNING("Rules: Error processing ArmorType \"%s\"!\n", buf);
             }
         }
+    }
+
+    return counter > 0;
+}
+
+
+/**
+ *  Reimplemented function to read Tiberiums like all other types,
+ *  instead of handling them in a special way.
+ *
+ *  @author: ZivDero
+ */
+bool RulesClassExtension::Tiberiums(CCINIClass &ini)
+{
+    //EXT_DEBUG_TRACE("RulesClassExtension::Tiberiums - 0x%08X\n", (uintptr_t)(This()));
+
+    static const char * const TIBERIUMS = "Tiberiums";
+
+    char buf[128];
+    const TiberiumClass* tiberium;
+
+    int counter = ini.Entry_Count(TIBERIUMS);
+    for (int index = 0; index < counter; ++index) {
+        const char *entry = ini.Get_Entry(TIBERIUMS, index);
+
+        /**
+         *  Get a Tiberium entry.
+         */
+        if (ini.Get_String(TIBERIUMS, entry, buf, sizeof(buf))) {
+
+            /**
+             *  Find or create a weapon of the name specified.
+             */
+            tiberium = TiberiumClass::Find_Or_Make(buf);
+            if (tiberium) {
+                DEV_DEBUG_INFO("Rules: Found Tiberium \"%s\".\n", buf);
+            } else {
+                DEV_DEBUG_WARNING("Rules: Error processing Tiberium \"%s\"!\n", buf);
+            }
+
+        }
+
     }
 
     return counter > 0;

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -66,6 +66,7 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
         bool CombatDamage(CCINIClass &ini);
         bool Weapons(CCINIClass &ini);
         bool Armors(CCINIClass &ini);
+        bool Tiberiums(CCINIClass &ini);
 
     private:
         void Check();


### PR DESCRIPTION
Previouslky, Tiberiums had a separate routine to read them from Rules. This meant that modders had to specify the entire Tiberiums list in a map if they wanted to override some Tiberium's properties. This is not longer required.