### PR TITLE
Reimplement aircraft carriers and rocket launchers from Red Alert 2

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -188,4 +188,6 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying.
   - Allow customizing the hunter-seeker unit type per side.
   - Allow customizing power plants per side.
+  - Reimplement aircraft carriers and missile launchers from Red Alert 2.
+  - Implement `DontScore`.
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -212,6 +212,103 @@ HunterSeeker=  ; UnitType, the unit that is this side's Hunter-Seeker.
 
 ## Technos
 
+### Spawns
+
+- Vinifera ports the spawn manager, responsible for AircraftType missiles and aircraft carries from Red Alert 2.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]        ; TechnoType
+Spawns=             ; AircraftType, the type that this Techno spawns.
+SpawnsNumber=0      ; integer, the number of aircraft that this Techno spawns.
+SpawnRegenRate=0    ; integer, the time it takes for a spawn to regenerate after death.
+SpawnReloadRate=0   ; integer, the time it takes for a spawn to reload its ammo and restore its strength.
+```
+
+- Additionally, it's possible to specify an alternative voxel model to use when the spawner has no spawns docked.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]        ; TechnoType
+NoSpawnAlt=no       ; boolean, should this Techno use an alternate voxel model when it's out of spawns?
+                    ; When true, the model named SOMETECHNOWO will be used when it's out of spawns.
+```
+
+```{note}
+`NoSpawnAlt` is only available for Technos that use voxel models.
+```
+
+```{note}
+Unlike in Red Alert 2, the voxel model used by `NoSpawnAlt` is loaded into a separate area of memory from the turet model. This means that Technos that have `NoSpawnAlt=yes` set **can** have turrets.
+```
+
+- For the unit to create spawns upon attack, a flag needs to be set on its weapon.
+
+In `RULES.INI`:
+```ini
+[SOMEWEAPON]  ; WeaponType
+Spawner=no    ; boolean, does this weapon spawn aircraft when firing?
+```
+
+- Additionally, spawned objects should have `Spawned=yes` to prevent the announcement of their death by EVA.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]  ; TechnoType
+Spawned=no    ; boolean, is this object meant to be spawned, either by a spawner, or off-map?
+```
+
+#### Rockets
+
+- For rocket launchers to function, RocketTypes need to be defined.
+
+In `RULES.INI`:
+```ini
+[RocketTypes]
+0=SOMEROCKET
+
+[SOMEROCKET]            ; RocketType
+PauseFrames=0           ; integer, how many frames the rocket pauses on the launcher before tilting.
+TiltFrames=60           ; integer, how many frames it takes for the rocket to tilt to firing position.
+PitchInitial=0.21       ; float, starting pitch of the rocket before tilting up (0 = horizontal, 1 = vertical).
+PitchFinal=0.5          ; float, ending pitch of the rocket after tilting up before it fires.
+TurnRate=0.05           ; float, pitch maneuverability of rocket in air.
+RaiseRate=1             ; integer, how much the missile will raise each turn on the launcher (for Cruise Missiles only).
+Acceleration=0.4        ; float, this much is added to the rocket's velocity each frame during launch.
+Altitude=768            ; integer, cruising altitude in leptons (1/256 of a cell): at this height rocket begins leveling off.
+Damage=200              ; integer, the rocker does this much damage when it explodes.
+EliteDamage=400         ; integer, the rocker does this much damage when it explodes when the spawner is elite.
+BodyLength=256          ; integer, the length of  thebody of the rocket in leptons (1/256 of a cell).
+LazyCurve=yes           ; boolean, is the rocket's path a big, lazy curve, like the V3 is Red Alert 2.
+CruiseMissile=no        ; boolean, is this rocket a Cruise Missile, like Boomer missiles in Yuri's Revenge.
+Type=                   ; AircraftType, the type this rocket is associated with.
+Warhead=                ; WarheadType, the warhead that this rocket's explosion uses.
+EliteWarhead=           ; WarheadType, the warhead that this rocket's explosion uses when the spawner is elite.
+TakeoffAnim=            ; AnimType, the takeoff animation used by this rocket.
+TrailAnim=              ; AnimType, the trail animation used by this rocket.
+```
+
+```{note}
+The rocket object is an AircraftType, like in Red Alert 2. When determining its characteristics, the rocket will use the first RocketType whose `Type=` is equal to the type of the rocket itself.
+```
+
+- If `SpawnsNumber > 1`, missiles can be made to spawn at alternating offsets. For this, `Burst` on the `Weapon` needs to be set to a value greater than `1`. Up to `Burst` missiles will use alternating spawn offsets, and the rest will use the the odd missiles' spawn offset.
+- Additionally, an additional offset for missiles spawned at even numbers can be defined.
+
+In `ART.INI`:
+```ini
+[SOMETECHNO]             ; TechnoType
+SecondSpawnOffset=0,0,0  ; 3 integers, an offset to be added to the firing FLH for the every second spawn's location.
+```
+
+- Additionally, missile aircraft should have `MissileSpawn=yes` for some missile logics to be considered correctly.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]     ; TechnoType
+MissileSpawn=no  ; boolean, is this object a missile meant to be spawned?
+```
+
 ### New ArmorTypes
 
 - Vinifera allows adding new armor types, as well as customizing the ability of warheads to target them.
@@ -471,6 +568,16 @@ In `SUN.INI`:
 ```ini
 [Options]
 FilterBandBoxSelection=yes  ; boolean, should the band box selection be filtered?
+```
+
+### DontScore
+
+- Vinifera ports the `DontScore` key from Red Alert 2. When `DontScore=yes` is set, killing the unit won't grant the killer experience, or give score to it's owner's house. It will, however, count towards your lost unit count.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]  ; TechnoType
+DontScore=no  ; boolean, should this Techno not count towards promotion and multiplayer score?
 ```
 
 ## Terrain

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -243,7 +243,7 @@ NoSpawnAlt=no       ; boolean, should this Techno use an alternate voxel model w
 ```
 
 ```{note}
-Unlike in Red Alert 2, the voxel model used by `NoSpawnAlt` is loaded into a separate area of memory from the turet model. This means that Technos that have `NoSpawnAlt=yes` set **can** have turrets.
+Unlike in Red Alert 2, the voxel model used by `NoSpawnAlt` is loaded into a separate area of memory from the turret model. This means that Technos that have `NoSpawnAlt=yes` set **can** have turrets.
 ```
 
 - For the unit to create spawns upon attack, a flag needs to be set on its weapon.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -212,9 +212,13 @@ HunterSeeker=  ; UnitType, the unit that is this side's Hunter-Seeker.
 
 ## Technos
 
-### Spawns
+### Spawners
 
 - Vinifera ports the spawn manager, responsible for AircraftType missiles and aircraft carries from Red Alert 2.
+
+```{warning}
+Aircraft carriers (i. e. spawners that spawn non-rockets) are known to have issues with Tiberian Sun aircraft, and as such may not function properly. This will be fixed in a future version of Vinifera.
+```
 
 In `RULES.INI`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -150,6 +150,8 @@ New:
 - Implement `FilterFromBandBoxSelection` (by ZivDero/Rampastring)
 - Add the possibility to customize the UI and Tooltip colors per-side (by Rampastring/ZivDero)
 - Add per-side crew customization (by ZivDero)
+- Reimplement aircraft carriers and missile launchers from Red Alert 2 (by ZivDero)
+- Implement `DontScore` (by ZivDero)
 
 
 Vanilla fixes:

--- a/src/extensions/abstract/abstractext.cpp
+++ b/src/extensions/abstract/abstractext.cpp
@@ -184,7 +184,7 @@ HRESULT AbstractClassExtension::Internal_Load(IStream *pStm)
     VINIFERA_SWIZZLE_REGISTER_POINTER(id, this, this_name.Peek_Buffer());
 
     /**
-     *  Read this classes binary blob data directly into this instance.
+     *  Read this class's binary blob data directly into this instance.
      */
     hr = pStm->Read(this, Size_Of(), nullptr);
     if (FAILED(hr)) {

--- a/src/extensions/aircraft/aircraftext.cpp
+++ b/src/extensions/aircraft/aircraftext.cpp
@@ -31,6 +31,7 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "vinifera_saveload.h"
 
 
 /**
@@ -150,6 +151,8 @@ int AircraftClassExtension::Size_Of() const
 void AircraftClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("AircraftClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    FootClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/aircraft/aircraftext.h
+++ b/src/extensions/aircraft/aircraftext.h
@@ -64,4 +64,5 @@ AircraftClassExtension final : public FootClassExtension
         virtual RTTIType What_Am_I() const override { return RTTI_AIRCRAFT; }
 
     public:
+
 };

--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -39,6 +39,7 @@
 #include "technotypeext.h"
 #include "extension.h"
 #include "voc.h"
+#include "mouse.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -316,6 +317,35 @@ DECLARE_PATCH(_AircraftClass_Init_IsCloakable_BugFix_Patch)
 
 
 /**
+ *  Patch that makes the game not stick rockets on the ground
+ *  when unlimboing them.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_AircraftClass_Unlimbo_MissileSpawn_Patch)
+{
+    GET_REGISTER_STATIC(AircraftClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(Coordinate *, coord, ebp);
+    static AircraftTypeClassExtension* class_ext;
+
+    class_ext = Extension::Fetch<AircraftTypeClassExtension>(this_ptr->Class);
+    if (!class_ext->IsMissileSpawn)
+    {
+        if (this_ptr->IsALoaner || !Map.In_Local_Radar(*coord))
+        {
+            JMP(0x0040898D);
+        }
+        else
+        {
+            JMP(0x000897C);
+        }
+    }
+
+    JMP(0x004089B0);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void AircraftClassExtension_Hooks()
@@ -343,4 +373,5 @@ void AircraftClassExtension_Hooks()
      */
     Patch_Jump(0x0040D0C5, (uintptr_t)0x0040D0EA);
 
+    Patch_Jump(0x00408963, &_AircraftClass_Unlimbo_MissileSpawn_Patch);
 }

--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -216,7 +216,7 @@ bool AircraftClassExt::_Enter_Idle_Mode(bool initial, bool a2)
                     mission = MISSION_ATTACK;
                 }
                 else if (In_Air()) {
-                    if (Target_Legal(NavCom) && Mission != MISSION_MOVE && Mission != MISSION_ENTER) {
+                    if (!Target_Legal(NavCom) || (Mission != MISSION_MOVE && Mission != MISSION_ENTER)) {
                         if (Class->Dock.Count() > 0 && (IsLocked || !Team)) {
 
                             /**

--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -95,7 +95,8 @@ bool AircraftClassExt::_Unlimbo(Coordinate& coord, DirType dir)
 
     if (FootClass::Unlimbo(adjusted_coord, dir)) {
 
-        if (!Class->IsSelectable || !Class->IsLandable || (Class->Fetch_Weapon_Info(WEAPON_SLOT_PRIMARY).Weapon && Class->Fetch_Weapon_Info(WEAPON_SLOT_PRIMARY).Weapon->IsCamera)) {
+        const auto weapon = Class->Fetch_Weapon_Info(WEAPON_SLOT_PRIMARY).Weapon;
+        if (!Class->IsSelectable || !Class->IsLandable || (weapon && weapon->IsCamera)) {
             IsALoaner = true;
         }
 

--- a/src/extensions/aircrafttype/aircrafttypeext.cpp
+++ b/src/extensions/aircrafttype/aircrafttypeext.cpp
@@ -154,6 +154,8 @@ int AircraftTypeClassExtension::Size_Of() const
 void AircraftTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("AircraftTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    TechnoTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/anim/animext.cpp
+++ b/src/extensions/anim/animext.cpp
@@ -150,6 +150,8 @@ int AnimClassExtension::Size_Of() const
 void AnimClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("AnimClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -158,6 +158,8 @@ int AnimTypeClassExtension::Size_Of() const
 void AnimTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("AnimTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/building/buildingext.cpp
+++ b/src/extensions/building/buildingext.cpp
@@ -158,6 +158,8 @@ int BuildingClassExtension::Size_Of() const
 void BuildingClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("BuildingClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    TechnoClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -61,6 +61,7 @@
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "session.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
@@ -935,6 +936,26 @@ DECLARE_PATCH(_EventClass_Execute_Archive_Selling_Patch)
 
 
 /**
+ *  Patch in BuildingClass::Captured to not score captured DoneScore buildings.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_BuildingClass_Captured_IncrementUnitTracker_Patch)
+{
+    GET_REGISTER_STATIC(BuildingClass*, this_ptr, esi);
+    static BuildingTypeClassExtension* ext;
+
+    ext = Extension::Fetch<BuildingTypeClassExtension>(this_ptr->Class);
+    if ((Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !ext->IsDontScore)
+    {
+        JMP(0x00448541);
+    }
+
+    JMP(0x0042F7BB);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void BuildingClassExtension_Hooks()
@@ -965,4 +986,5 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x00430A01, &_BuildingClass_Mission_Deconstruction_ConYard_Unlimbo_Patch);
     Patch_Jump(0x00430F2B, &_BuildingClass_Mission_Deconstruction_Double_Survivors_Patch);
     Patch_Jump(0x0049436A, &_EventClass_Execute_Archive_Selling_Patch);
+    Patch_Jump(0x0042F799, &_BuildingClass_Captured_IncrementUnitTracker_Patch);
 }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -936,11 +936,11 @@ DECLARE_PATCH(_EventClass_Execute_Archive_Selling_Patch)
 
 
 /**
- *  Patch in BuildingClass::Captured to not score captured DontScore buildings.
+ *  Patch in BuildingClass::Captured to not count captured DontScore buildings.
  *
  *  @author: ZivDero
  */
-DECLARE_PATCH(_BuildingClass_Captured_IncrementUnitTracker_Patch)
+DECLARE_PATCH(_BuildingClass_Captured_DontScore_Patch)
 {
     GET_REGISTER_STATIC(BuildingClass*, this_ptr, esi);
     static BuildingTypeClassExtension* ext;
@@ -986,5 +986,5 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x00430A01, &_BuildingClass_Mission_Deconstruction_ConYard_Unlimbo_Patch);
     Patch_Jump(0x00430F2B, &_BuildingClass_Mission_Deconstruction_Double_Survivors_Patch);
     Patch_Jump(0x0049436A, &_EventClass_Execute_Archive_Selling_Patch);
-    Patch_Jump(0x0042F799, &_BuildingClass_Captured_IncrementUnitTracker_Patch);
+    Patch_Jump(0x0042F799, &_BuildingClass_Captured_DontScore_Patch);
 }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -936,7 +936,7 @@ DECLARE_PATCH(_EventClass_Execute_Archive_Selling_Patch)
 
 
 /**
- *  Patch in BuildingClass::Captured to not score captured DoneScore buildings.
+ *  Patch in BuildingClass::Captured to not score captured DontScore buildings.
  *
  *  @author: ZivDero
  */
@@ -948,7 +948,7 @@ DECLARE_PATCH(_BuildingClass_Captured_IncrementUnitTracker_Patch)
     ext = Extension::Fetch<BuildingTypeClassExtension>(this_ptr->Class);
     if ((Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !ext->IsDontScore)
     {
-        JMP(0x00448541);
+        JMP(0x0042F7A3);
     }
 
     JMP(0x0042F7BB);

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -162,6 +162,8 @@ int BuildingTypeClassExtension::Size_Of() const
 void BuildingTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("BuildingTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    TechnoTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/bullettype/bullettypeext.cpp
+++ b/src/extensions/bullettype/bullettypeext.cpp
@@ -152,6 +152,8 @@ int BulletTypeClassExtension::Size_Of() const
 void BulletTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("BulletTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -73,6 +73,7 @@
 #include "voxelanimtype.h"
 #include "particletype.h"
 #include "particlesystype.h"
+#include "rockettype.h"
 #include "vox.h"
 #include "event.h"
 #include "queue.h"
@@ -4102,6 +4103,7 @@ bool DumpHeapsCommandClass::Process()
 
     LOG_HEAP(TiberiumClass, Tiberiums);
     LOG_HEAP(ArmorTypeClass, ArmorTypes);
+    LOG_HEAP(RocketTypeClass, RocketTypes);
 
     DEBUG_INFO("\nFinished!\n\n");
 

--- a/src/extensions/extension.cpp
+++ b/src/extensions/extension.cpp
@@ -152,6 +152,11 @@
 
 #include <iostream>
 
+#include "armortype.h"
+#include "kamikazetracker.h"
+#include "rockettype.h"
+#include "spawnmanager.h"
+
 
 extern int Execute_Day;
 extern int Execute_Month;
@@ -2052,6 +2057,10 @@ unsigned Extension::Get_Save_Version_Number()
      *  All other classes.
      */
     version += sizeof(ThemeControlExtension);
+    version += sizeof(ArmorTypeClass);
+    version += sizeof(RocketTypeClass);
+    version += sizeof(SpawnManagerClass);
+    version += sizeof(KamikazeTrackerClass);
 
     return version;
 }

--- a/src/extensions/extension.h
+++ b/src/extensions/extension.h
@@ -418,7 +418,7 @@ HRESULT GlobalExtensionClass<T>::Load(IStream *pStm)
     HRESULT hr;
 
     /**
-     *  Read this classes binary blob data directly into this instance.
+     *  Read this class's binary blob data directly into this instance.
      */
     hr = pStm->Read(this, Size_Of(), nullptr);
     if (FAILED(hr)) {

--- a/src/extensions/extension_hooks.cpp
+++ b/src/extensions/extension_hooks.cpp
@@ -150,6 +150,7 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "spawnmanager_hooks.h"
 
 
 void Extension_Hooks()
@@ -293,4 +294,5 @@ void Extension_Hooks()
      *  New classes and interfaces.
      */
     TheaterTypeClassExtension_Hooks();
+    SpawnManager_Hooks();
 }

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -726,4 +726,6 @@ void HouseClassExtension_Hooks()
     Patch_Jump(0x004CB6C1, &_HouseClass_Enable_SWs_Check_For_Building_Power);
 
     Patch_Jump(0x004C10E0, &HouseClassExt::_AI_Building);
+
+    Patch_Jump(0x004BAC2C, 0x004BAC39); // Patch a jump in the constructor to always allocate unit trackers
 }

--- a/src/extensions/infantry/infantryext.cpp
+++ b/src/extensions/infantry/infantryext.cpp
@@ -150,6 +150,8 @@ int InfantryClassExtension::Size_Of() const
 void InfantryClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("InfantryClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    FootClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/infantrytype/infantrytypeext.cpp
+++ b/src/extensions/infantrytype/infantrytypeext.cpp
@@ -153,6 +153,8 @@ int InfantryTypeClassExtension::Size_Of() const
 void InfantryTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("InfantryTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    TechnoTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/isotiletype/isotiletypeext.cpp
+++ b/src/extensions/isotiletype/isotiletypeext.cpp
@@ -154,6 +154,8 @@ int IsometricTileTypeClassExtension::Size_Of() const
 void IsometricTileTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("IsometricTileTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/objecttype/objecttypeext.h
+++ b/src/extensions/objecttype/objecttypeext.h
@@ -59,6 +59,8 @@ class ObjectTypeClassExtension : public AbstractTypeClassExtension
 
         virtual bool Read_INI(CCINIClass &ini) override;
 
+        void Fetch_Voxel_Image(const char* graphic_name);
+
     protected:
         /**
          *  These are only to be accessed for save and load operations!
@@ -67,4 +69,15 @@ class ObjectTypeClassExtension : public AbstractTypeClassExtension
         char AlphaGraphicName[24 + 1];
 
     public:
+
+        /**
+         *  Should the object use a different voxel model when it has no spawn?
+         */
+        bool NoSpawnAlt;
+
+        /**
+         *  The voxel model to use when the object has no spawn, and its cache.
+         */
+        VoxelObject AltVoxel;
+        VoxelIndexClass AltVoxelIndex;
 };

--- a/src/extensions/overlay/overlayext.cpp
+++ b/src/extensions/overlay/overlayext.cpp
@@ -152,6 +152,8 @@ int OverlayClassExtension::Size_Of() const
 void OverlayClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("OverlayClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/overlaytype/overlaytypeext.cpp
+++ b/src/extensions/overlaytype/overlaytypeext.cpp
@@ -150,6 +150,8 @@ int OverlayTypeClassExtension::Size_Of() const
 void OverlayTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("OverlayTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/particlesystype/particlesystypeext.cpp
+++ b/src/extensions/particlesystype/particlesystypeext.cpp
@@ -150,6 +150,8 @@ int ParticleSystemTypeClassExtension::Size_Of() const
 void ParticleSystemTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("ParticleSystemTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/particletype/particletypeext.cpp
+++ b/src/extensions/particletype/particletypeext.cpp
@@ -150,6 +150,8 @@ int ParticleTypeClassExtension::Size_Of() const
 void ParticleTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("ParticleTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -34,6 +34,7 @@
 #include "housetype.h"
 #include "side.h"
 #include "armortype.h"
+#include "rockettype.h"
 #include "wstring.h"
 #include "wwcrc.h"
 #include "noinit.h"
@@ -249,6 +250,13 @@ void RulesClassExtension::Process(CCINIClass &ini)
      */
     Armors(ini);
 
+    /**
+     *  Read the new RocketTypes.
+     *
+     *  @author: ZivDero
+     */
+    Rockets(ini);
+
     This()->SuperWeapons(ini);
     This()->Warheads(ini);
     This()->Smudges(ini);
@@ -361,13 +369,8 @@ bool RulesClassExtension::Objects(CCINIClass &ini)
     //EXT_DEBUG_TRACE("RulesClassExtension::Objects - 0x%08X\n", (uintptr_t)(This()));
 
     /**
-     *  Fetch the game object (extension) values from the rules file.
+     *  Fetch the game object and extension values from the rules file.
      */
-
-    DEBUG_INFO("Rules: Processing ArmorTypes (Count: %d)...\n", ArmorTypes.Count());
-    for (int index = 0; index < ArmorTypes.Count(); ++index) {
-        ArmorTypes[index]->Read_INI(ini);
-    }
 
     DEBUG_INFO("Rules: Processing HouseTypes (Count: %d)...\n", HouseTypes.Count());
     for (int index = 0; index < HouseTypes.Count(); ++index) {
@@ -560,6 +563,20 @@ bool RulesClassExtension::Objects(CCINIClass &ini)
         SideExtensions[index]->Read_INI(ini);
     }
 
+    /**
+     *  Fetch new Vinifera object values from the rules file.
+     */
+
+    DEBUG_INFO("Rules: Processing ArmorTypes (Count: %d)...\n", ArmorTypes.Count());
+    for (int index = 0; index < ArmorTypes.Count(); ++index) {
+        ArmorTypes[index]->Read_INI(ini);
+    }
+
+    DEBUG_INFO("Rules: Processing RocketTypes (Count: %d)...\n", RocketTypes.Count());
+    for (int index = 0; index < RocketTypes.Count(); ++index) {
+        RocketTypes[index]->Read_INI(ini);
+    }
+
     return true;
 }
 
@@ -735,6 +752,45 @@ bool RulesClassExtension::Armors(CCINIClass &ini)
                 DEV_DEBUG_INFO("Rules: Found ArmorType \"%s\".\n", buf);
             } else {
                 DEV_DEBUG_WARNING("Rules: Error processing ArmorType \"%s\"!\n", buf);
+            }
+        }
+    }
+
+    return counter > 0;
+}
+
+
+/**
+ *  Fetch all the Rocket characteristic values.
+ *
+ *  @author: ZivDero
+ */
+bool RulesClassExtension::Rockets(CCINIClass &ini)
+{
+    //EXT_DEBUG_TRACE("RulesClassExtension::Rockets - 0x%08X\n", (uintptr_t)(This()));
+
+    static const char *const ROCKETTYPES = "RocketTypes";
+
+    char buf[128];
+    const RocketTypeClass *rockettype;
+
+    int counter = ini.Entry_Count(ROCKETTYPES);
+    for (int index = 0; index < counter; ++index) {
+        const char *entry = ini.Get_Entry(ROCKETTYPES, index);
+
+        /**
+         *  Get a rocket entry.
+         */
+        if (ini.Get_String(ROCKETTYPES, entry, buf, sizeof(buf))) {
+
+            /**
+             *  Find or create a rocket of the name specified.
+             */
+            rockettype = RocketTypeClass::Find_Or_Make(buf);
+            if (rockettype) {
+                DEV_DEBUG_INFO("Rules: Found RocketType \"%s\".\n", buf);
+            } else {
+                DEV_DEBUG_WARNING("Rules: Error processing RocketType \"%s\"!\n", buf);
             }
         }
     }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -66,6 +66,7 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
         bool CombatDamage(CCINIClass &ini);
         bool Weapons(CCINIClass &ini);
         bool Armors(CCINIClass &ini);
+        bool Rockets(CCINIClass &ini);
         bool Tiberiums(CCINIClass &ini);
 
     private:

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -44,7 +44,9 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "kamikazetracker.h"
 #include "mouse.h"
+#include "vinifera_globals.h"
 
 
 /**
@@ -80,11 +82,11 @@ class ScenarioClassExt final : public ScenarioClass
 /**
  *  #issue-71
  * 
- *  Clear all waypoints in preperation for loading the scenario data.
+ *  Clear things in preparation for loading the scenario data.
  *
  *  @author: CCHyper
  */
-DECLARE_PATCH(_Clear_Scenario_Clear_Waypoints_Patch)
+DECLARE_PATCH(_Clear_Scenario_Patch)
 {
     /**
      *  Stolen bytes/code.
@@ -93,6 +95,8 @@ DECLARE_PATCH(_Clear_Scenario_Clear_Waypoints_Patch)
 
     //DEBUG_INFO("Clearing waypoints...\n");
     ScenExtension->Clear_All_Waypoints();
+
+    KamikazeTracker->Clear();
 
     JMP(0x005DC872);
 }
@@ -351,7 +355,7 @@ void ScenarioClassExtension_Hooks()
     Patch_Jump(0x005E16E0, &ScenarioClassExt::_Set_Waypoint_Cell);
     Patch_Jump(0x005E1700, &ScenarioClassExt::_Get_Waypoint_CellPtr);
     Patch_Jump(0x005E1720, &ScenarioClassExt::_Waypoint_As_String);
-    Patch_Jump(0x005DC852, &_Clear_Scenario_Clear_Waypoints_Patch);
+    Patch_Jump(0x005DC852, &_Clear_Scenario_Patch);
     Patch_Jump(0x005DC0A0, &_Fill_In_Data_Home_Cell_Patch);
     Patch_Jump(0x00673330, &_Waypoint_From_Name);
     Patch_Jump(0x006732B0, &_Waypoint_To_Name);

--- a/src/extensions/smudge/smudgeext.cpp
+++ b/src/extensions/smudge/smudgeext.cpp
@@ -152,6 +152,8 @@ int SmudgeClassExtension::Size_Of() const
 void SmudgeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("SmudgeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/smudgetype/smudgetypeext.cpp
+++ b/src/extensions/smudgetype/smudgetypeext.cpp
@@ -150,6 +150,8 @@ int SmudgeTypeClassExtension::Size_Of() const
 void SmudgeTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("SmudgeTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -31,6 +31,7 @@
 #include "techno.h"
 
 
+class SpawnManagerClass;
 class EBoltClass;
 class TechnoTypeClass;
 class TechnoTypeClassExtension;
@@ -63,6 +64,7 @@ class TechnoClassExtension : public RadioClassExtension
         virtual void Response_Deploy();
         virtual void Response_Harvest();
         virtual bool Can_Passive_Acquire() const;
+        virtual Coordinate Fire_Coord(WeaponSlotType which, TPoint3D<int> offset = TPoint3D<int>()) const;
 
         void Put_Storage_Pointers();
 
@@ -80,4 +82,14 @@ class TechnoClassExtension : public RadioClassExtension
          *  Replacement Tiberium storage.
          */
         VectorClass<int> Storage;
+
+        /**
+         *  The spawn manager of this unit.
+         */
+        SpawnManagerClass* SpawnManager;
+
+        /**
+         *  The object that spawned this object.
+         */
+        TechnoClass* SpawnOwner;
 };

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1157,12 +1157,12 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
     if (source && !typeext->IsDontScore) {
 
         const auto source_ext = Extension::Fetch<TechnoClassExtension>(source);
-        const auto source_text = Extension::Fetch<TechnoTypeClassExtension>(source->Techno_Type_Class());
+        const auto source_typeext = Extension::Fetch<TechnoTypeClassExtension>(source->Techno_Type_Class());
 
         if (source->Techno_Type_Class()->IsTrainable) {
             source->Veterancy.Gain_Experience(Techno_Type_Class()->Cost_Of(House), points);
 
-        } else if (source_text->IsMissileSpawn) {
+        } else if (source_typeext->IsMissileSpawn) {
 
             if (source_ext->SpawnOwner && source_ext->SpawnOwner->Techno_Type_Class()->IsTrainable) {
                 source_ext->SpawnOwner->Veterancy.Gain_Experience(Techno_Type_Class()->Cost_Of(House), points);

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1139,7 +1139,7 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
     int total_recorded = 0;
     const int points = Techno_Type_Class()->Cost_Of(House);
 
-    const auto text = Extension::Fetch<TechnoTypeClassExtension>(Techno_Type_Class());
+    const auto typeext = Extension::Fetch<TechnoTypeClassExtension>(Techno_Type_Class());
 
     /**
      *  Handle any trigger event associated with this object.
@@ -1154,7 +1154,7 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
 
     if (IsActive && What_Am_I() != RTTI_UNIT && Tag) Tag->Spring(TEVENT_FAKES_DESTROYED, this);
 
-    if (source && !text->IsDontScore) {
+    if (source && !typeext->IsDontScore) {
 
         const auto source_ext = Extension::Fetch<TechnoClassExtension>(source);
         const auto source_text = Extension::Fetch<TechnoTypeClassExtension>(source->Techno_Type_Class());
@@ -1188,7 +1188,7 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
         }
 
         if (source) {
-            if ((Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+            if ((Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !typeext->IsDontScore) {
                 source->House->DestroyedBuildings->Increment_Unit_Total(reinterpret_cast<BuildingClass*>(this)->Class->Type);
             }
             source->House->BuildingsKilled[Owner()]++;
@@ -1205,24 +1205,24 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
     break;
 
     case RTTI_AIRCRAFT:
-        if (source && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+        if (source && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !typeext->IsDontScore) {
             source->House->DestroyedAircraft->Increment_Unit_Total(reinterpret_cast<AircraftClass*>(this)->Class->Type);
             total_recorded++;
         }
         // Fall through.....
     case RTTI_INFANTRY:
-        if (source && !total_recorded && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+        if (source && !total_recorded && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !typeext->IsDontScore) {
             source->House->DestroyedInfantry->Increment_Unit_Total(reinterpret_cast<InfantryClass*>(this)->Class->Type);
             total_recorded++;
         }
         // Fall through.....
     case RTTI_UNIT:
-        if (source && !total_recorded && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+        if (source && !total_recorded && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !typeext->IsDontScore) {
             source->House->DestroyedUnits->Increment_Unit_Total(reinterpret_cast<UnitClass*>(this)->Class->Type);
         }
 
         House->UnitsLost++;
-        if (source && !text->IsDontScore) source->House->UnitsKilled[Owner()]++;
+        if (source && !typeext->IsDontScore) source->House->UnitsKilled[Owner()]++;
 
         /**
          *  If the map is displaying the multiplayer player names & their

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -25,6 +25,7 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
+#include "spawnmanager.h"
 #include "technoext_hooks.h"
 
 #include <vector>
@@ -55,6 +56,7 @@
 #include "voc.h"
 #include "tactical.h"
 #include "clipline.h"
+#include "mouse.h"
 #include "vinifera_util.h"
 #include "extension.h"
 #include "fatal.h"
@@ -69,6 +71,7 @@
 #include "hooker.h"
 #include "hooker_macros.h"
 #include "language.h"
+#include "ionstorm.h"
 #include "storageext.h"
 #include "textprint.h"
 #include "tiberiumext.h"
@@ -78,6 +81,11 @@
 #include "session.h"
 #include "mouse.h"
 #include "sideext.h"
+#include "tag.h"
+#include "tibsun_functions.h"
+#include "utracker.h"
+#include "aircraft.h"
+
 
 
 /**
@@ -104,6 +112,15 @@ public:
     void _Draw_Text_Overlay(Point2D& point1, Point2D& point2, Rect& rect) const;
     const InfantryTypeClass* _Crew_Type() const;
     int _How_Many_Survivors() const;
+    bool _Spawner_Fire_At(TARGET target, WeaponTypeClass* weapon);
+    bool _Target_Something_Nearby(Coordinate& coord, ThreatType threat);
+    void _Stun();
+    void _Mission_AI();
+    FireErrorType _Can_Fire(TARGET target, WeaponSlotType which = WEAPON_SLOT_PRIMARY);
+    bool _Can_Player_Move() const;
+    Coordinate _Fire_Coord(WeaponSlotType which) const;
+    void _Record_The_Kill(TechnoClass* source);
+
 };
 
 
@@ -128,6 +145,7 @@ void TechnoClassExt::_Draw_Pips(Point2D& bottomleft, Point2D& center, Rect& rect
 
     const auto ttype = Techno_Type_Class();
     const auto ttype_ext = Extension::Fetch<TechnoTypeClassExtension>(ttype);
+    const auto ext = Extension::Fetch<TechnoClassExtension>(this);
 
     if (What_Am_I() != RTTI_BUILDING)
     {
@@ -236,6 +254,14 @@ void TechnoClassExt::_Draw_Pips(Point2D& bottomleft, Point2D& center, Rect& rect
                         shape = pips_to_draw[index];
                     }
                     CC_Draw_Shape(LogicSurface, NormalDrawer, pip_shapes, shape, &Point2D(drawx + dx * index, drawy + dy * index), &rect, SHAPE_WIN_REL | SHAPE_CENTER);
+                }
+            }
+            else if (ext->SpawnManager && ext->SpawnManager->SpawnCount > 0)
+            {
+                for (int index = 0; index < ext->SpawnManager->SpawnCount; index++)
+                {
+                    const int pip = index < ext->SpawnManager->Docked_Count() ? 1 : 0;
+                    CC_Draw_Shape(LogicSurface, NormalDrawer, pip_shapes, pip, &Point2D(drawx + dx * index, drawy + dy * index), &rect, SHAPE_WIN_REL | SHAPE_CENTER);
                 }
             }
             else if (Techno_Type_Class()->PipScale == PIP_AMMO)
@@ -435,6 +461,339 @@ WeaponSlotType TechnoClassExt::_What_Weapon_Should_I_Use(TARGET target) const
     }
 
     return immobilize == webby_secondary ? WEAPON_SLOT_SECONDARY : WEAPON_SLOT_PRIMARY;
+}
+
+
+/**
+ *  Patch in TechnoClass::Fire_At to order the spawner to fire at the target,
+ *  as well as reveal it if the weapon is RevealOnFire.
+ *
+ *  @author: ZivDero
+ */
+bool TechnoClassExt::_Spawner_Fire_At(TARGET target, WeaponTypeClass* weapon)
+{
+    auto weapon_ext = Extension::Fetch<WeaponTypeClassExtension>(weapon);
+
+    if (weapon_ext->IsSpawner)
+    {
+        auto techno_ext = Extension::Fetch<TechnoClassExtension>(this);
+        techno_ext->SpawnManager->Queue_Target(target);
+        if (IsOwnedByPlayer || IsDiscoveredByPlayer)
+        {
+            if (!Map.Is_Shrouded(Center_Coord()) && !Map.Is_Fogged(Center_Coord()))
+                return true;
+
+            if (What_Am_I() == RTTI_AIRCRAFT && IsOwnedByPlayer)
+                return true;
+        }
+
+        HouseClass* target_house = target->Owning_House();
+        if (target_house && target_house->Is_Player_Control())
+        {
+            if (weapon_ext->IsRevealOnFire)
+            {
+                Map.Sight_From(Center_Coord(), 3, target_house);
+            }
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+
+/**
+ *  Reimplementation of TechnoClass::Target_Something_Nearby with adjustments
+ *  for the spawner.
+ *
+ *  @author: ZivDero
+ */
+bool TechnoClassExt::_Target_Something_Nearby(Coordinate& coord, ThreatType threat)
+{
+    /**
+     *  Determine that if there is an existing target it is still legal
+     *  and within range.
+     */
+    if (Target_Legal(TarCom))
+    {
+        // This bit is roughly ported from YR but is missing `ShouldLoseTargetNow`
+        if (threat & THREAT_RANGE)
+        {
+            WeaponSlotType primary = What_Weapon_Should_I_Use(TarCom);
+            FireErrorType fire = Can_Fire(TarCom, primary);
+
+            if (fire == FIRE_CANT)
+            {
+                SpawnManagerClass* spawn_manager = Extension::Fetch<TechnoClassExtension>(this)->SpawnManager;
+                if (spawn_manager)
+                    spawn_manager->Abandon_Target();
+
+                Assign_Target(nullptr);
+            }
+            else if (fire == FIRE_ILLEGAL || fire == FIRE_RANGE)
+            {
+                Assign_Target(nullptr);
+            }
+        }
+    }
+
+    /**
+     *  If there is no target, then try to find one and assign it as
+     *  the target for this unit.
+     */
+    if (!Target_Legal(TarCom)) {
+        Assign_Target(Greatest_Threat(threat & (THREAT_RANGE | THREAT_AREA), coord));
+    }
+
+    /**
+     *  Return with answer to question: Does this unit now have a target?
+     */
+    return Target_Legal(TarCom);
+}
+
+
+/**
+ *  Reimplementation of TechnoClass::Stun with adjustments for the spawner.
+ *
+ *  @author: ZivDero
+ */
+void TechnoClassExt::_Stun()
+{
+    Assign_Target(nullptr);
+    Assign_Destination(nullptr);
+    Transmit_Message(RADIO_OVER_OUT);
+
+    const auto extension = Extension::Fetch<TechnoClassExtension>(this);
+    if (extension->SpawnManager)
+    {
+        extension->SpawnManager->Detach_Spawns();
+        extension->SpawnManager->Abandon_Target();
+    }
+
+    Detach_All(true);
+    Unselect();
+}
+
+
+/**
+ *  Wrapper function to patch the call in TechnoClass::AI to call
+ *  SpawnManagerClass::AI.
+ *
+ *  @author: ZivDero
+ */
+void TechnoClassExt::_Mission_AI()
+{
+    MissionClass::AI();
+
+    const auto extension = Extension::Fetch<TechnoClassExtension>(this);
+
+    if (extension->SpawnManager)
+        extension->SpawnManager->AI();
+}
+
+
+/**
+ *  Determines if this techno object can fire.
+ *
+ *  @author: 12/23/1994 JLB - Created.
+ *           ZivDero - Adjustments for Tiberian Sun.
+ */
+FireErrorType TechnoClassExt::_Can_Fire(TARGET target, WeaponSlotType which)
+{
+    /**
+     *  Don't allow firing if the target is illegal.
+     */
+    if (!Target_Legal(target))
+        return FIRE_ILLEGAL;
+
+    const auto ext = Extension::Fetch<TechnoClassExtension>(this);
+
+    /**
+     *  If this unit is a spawner, don't let it fire if it's currently in the process of spawning.
+     */
+    if (ext->SpawnManager && ext->SpawnManager->Preparing_Count())
+        return FIRE_BUSY;
+
+    ObjectClass* object = Target_As_Techno(target);
+
+    /**
+     *  If the object is completely cloaked, then you can't fire on it.
+     */
+    if (object && object->Visual_Character(true, House) == VISUAL_HIDDEN
+        && !Map[target->Center_Coord()].Sensed_By(static_cast<HousesType>(House->Get_Heap_ID()))
+        && object->Owning_House() != House
+        && (Combat_Damage() > 0 || !object->Owning_House()->Is_Ally(House)))
+    {
+        return FIRE_CANT;
+    }
+
+    /**
+     *  A falling object is too busy falling to fire.
+     */
+    if (IsFalling)
+        return FIRE_CANT;
+
+    /**
+     *  An immobilized object can't fire, unless it's a visceroid.
+     */
+    if (Is_Immobilized())
+    {
+        if (What_Am_I() != RTTI_UNIT
+            || !(reinterpret_cast<UnitClass*>(this)->Class->IsLargeVisceroid
+            || reinterpret_cast<UnitClass*>(this)->Class->IsSmallVisceroid))
+        {
+            return FIRE_CANT;
+        }
+    }
+
+    /**
+     *  If there is no weapon, then firing is not allowed.
+     */
+    WeaponTypeClass const* weapon = Get_Weapon(which)->Weapon;
+    if (!weapon)
+        return FIRE_CANT;
+
+    /**
+     *  If the weapon is ion sensitive and there's an active Ion Storm,
+     *  then firing is not allowed.
+     */
+    if (weapon->IsIonSensitive && IonStorm_Is_Active())
+        return FIRE_CANT;
+
+    /**
+     *  If the weapon is a spawner, it needs to have an object ready to spawn.
+     */
+    if (weapon && Extension::Fetch<WeaponTypeClassExtension>(weapon)->IsSpawner)
+    {
+        const auto techno_ext = Extension::Fetch<TechnoClassExtension>(this);
+        if (techno_ext->SpawnManager->Active_Count() == 0)
+            return FIRE_REARM;
+    }
+
+    /**
+     *  If we're firing our primary particle-based/wave/railgun weapon, then
+     *  we can't fire our secondary weapon of the same kind.
+     */
+    WeaponTypeClass const* other_weapon = Get_Weapon(which == WEAPON_SLOT_PRIMARY ? WEAPON_SLOT_SECONDARY : WEAPON_SLOT_PRIMARY)->Weapon;
+    
+    if (other_weapon)
+    {
+        if ((other_weapon->IsSonic && Wave)
+            || (other_weapon->IsRailgun && ParticleSystems[4])
+            || (other_weapon->IsUseFireParticles && ParticleSystems[0])
+            || (other_weapon->IsUseSparkParticles && ParticleSystems[1]))
+        {
+            return FIRE_CANT;
+        }
+    }
+
+    /**
+     *  Can only fire anti-aircraft weapons against aircraft unless the aircraft is
+     *  sitting on the ground. If the object is on the ground,
+     *  then don't allow firing if it can't fire upon ground objects.
+     */
+    if (target->In_Air() && !weapon->Bullet->IsAntiAircraft ||
+        target->On_Ground() && !weapon->Bullet->IsAntiGround)
+    {
+        return FIRE_CANT;
+    }
+
+    /**
+     *  Check if the unit has synchronized shooting.
+     */
+    bool check_rearm = true;
+    if (which != WEAPON_SLOT_NONE && What_Am_I() == RTTI_UNIT)
+    {
+        const auto unit = reinterpret_cast<UnitClass*>(this);
+        const int burst = CurrentBurstIndex % weapon->Burst;
+        if (burst < 2)
+        {
+            if (unit->Class->FiringSyncFrame[burst] != -1
+                && unit->FiringSyncDelay != -1)
+            {
+                if (unit->Class->FiringSyncFrame[burst] != unit->FiringSyncDelay)
+                    return FIRE_REARM;
+                
+                check_rearm = false;
+            }
+        }
+    }
+
+    /**
+     *  Don't allow firing if still rearming.
+     */
+    if (check_rearm && Arm != 0)
+        return FIRE_REARM;
+
+    /**
+     *  The target must be within range in order to allow firing.
+     */
+    if (!In_Range_Of(target, which))
+        return FIRE_RANGE;
+
+    /**
+     *  If the object has an armor type that this unit's warhead is forbidden to fire at, bail.
+     */
+    if (object && !Verses::Get_ForceFire(object->Techno_Type_Class()->Armor, weapon->WarheadPtr))
+    {
+        return FIRE_ILLEGAL;
+    }
+
+    /**
+     *  If there is no ammo left, then it can't fire.
+     */
+    if (!Ammo)
+        return FIRE_AMMO;
+
+    /**
+     *  If cloaked, then firing is disabled.
+     */
+    if (Cloak != UNCLOAKED && (What_Am_I() != RTTI_AIRCRAFT || Cloak == CLOAKED))
+        return FIRE_CLOAKED;
+
+    /**
+     *  Hunter seekers can't fire since they need to kamikaze into the target.
+     */
+    if (Techno_Type_Class()->IsHunterSeeker)
+        return FIRE_RANGE;
+
+    return FIRE_OK;
+}
+
+
+/**
+ *  Determines if the object can move be moved by player.
+ *
+ *  @author: 01/19/1995 JLB - Created.
+ *           ZivDero - Adjustments for Tiberian Sun.
+ */
+bool TechnoClassExt::_Can_Player_Move() const
+{
+    if (!House->Is_Player_Control())
+        return false;
+
+    if (Is_Immobilized())
+        return false;
+
+    const auto ext = Extension::Fetch<TechnoClassExtension>(this);
+    if (ext->SpawnManager)
+    {
+        const auto typeext = Extension::Fetch<TechnoTypeClassExtension>(Techno_Type_Class());
+        if (ext->SpawnManager->Preparing_Count() > 0 && ext->SpawnManager->Preparing_Count() < typeext->SpawnsNumber)
+            return false;
+    }
+
+    return true;
+}
+
+
+/**
+ *  Wrapper for TechnoClassExtension::Fire_Coord.
+ */
+Coordinate TechnoClassExt::_Fire_Coord(WeaponSlotType which) const
+{
+    return Extension::Fetch<TechnoClassExtension>(this)->Fire_Coord(which, TPoint3D<int>());
 }
 
 
@@ -767,6 +1126,118 @@ void TechnoClassExt::_Drop_Tiberium()
         }
     }
 }
+
+
+/**
+ *  Records the death of this object.
+ *
+ *  @author:  07/08/1995 JLB - Created.
+ *            ZivDero - Adjustments for Tiberian Sun.
+ */
+void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
+{
+    int total_recorded = 0;
+    const int points = Techno_Type_Class()->Cost_Of(House);
+
+    const auto text = Extension::Fetch<TechnoTypeClassExtension>(Techno_Type_Class());
+
+    /**
+     *  Handle any trigger event associated with this object.
+     */
+    if (IsActive && Tag && source) Tag->Spring(TEVENT_ATTACKED, this);
+
+    if (IsActive && Tag && source) Tag->Spring(TEVENT_DISCOVERED, this);
+
+    if (IsActive && What_Am_I() != RTTI_UNIT && Tag) Tag->Spring(TEVENT_DESTROYED, this);
+
+    if (IsActive && What_Am_I() != RTTI_UNIT && Tag) Tag->Spring(TEVENT_DESTROYED_BY_ANYTHING, this);
+
+    if (IsActive && What_Am_I() != RTTI_UNIT && Tag) Tag->Spring(TEVENT_FAKES_DESTROYED, this);
+
+    if (source && !text->IsDontScore) {
+
+        const auto source_ext = Extension::Fetch<TechnoClassExtension>(source);
+        const auto source_text = Extension::Fetch<TechnoTypeClassExtension>(source->Techno_Type_Class());
+
+        if (source->Techno_Type_Class()->IsTrainable) {
+            source->Veterancy.Gain_Experience(Techno_Type_Class()->Cost_Of(House), points);
+
+        } else if (source_text->IsMissileSpawn) {
+
+            if (source_ext->SpawnOwner && source_ext->SpawnOwner->Techno_Type_Class()->IsTrainable) {
+                source_ext->SpawnOwner->Veterancy.Gain_Experience(Techno_Type_Class()->Cost_Of(House), points);
+            }
+        }
+
+        House->WhoLastHurtMe = source->Owner();
+
+        /**
+         *  Add up the score for killing this unit
+         */
+        source->House->PointTotal += points;
+    }
+
+    switch (What_Am_I()) {
+    case RTTI_BUILDING:
+    {
+        if (!Techno_Type_Class()->IsInsignificant) {
+
+            if (reinterpret_cast<BuildingClass*>(this)->WhoLastHurtMe != HOUSE_NONE) {
+                House->BuildingsLost++;
+            }
+        }
+
+        if (source) {
+            if ((Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+                source->House->DestroyedBuildings->Increment_Unit_Total(reinterpret_cast<BuildingClass*>(this)->Class->Type);
+            }
+            source->House->BuildingsKilled[Owner()]++;
+        }
+
+        /**
+         *  If the map is displaying the multiplayer player names & their
+         *  # of kills, tell it to redraw.
+         */
+        if (Map.Is_Player_Names()) {
+            Map.Player_Names(false);
+        }
+    }
+    break;
+
+    case RTTI_AIRCRAFT:
+        if (source && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+            source->House->DestroyedAircraft->Increment_Unit_Total(reinterpret_cast<AircraftClass*>(this)->Class->Type);
+            total_recorded++;
+        }
+        // Fall through.....
+    case RTTI_INFANTRY:
+        if (source && !total_recorded && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+            source->House->DestroyedInfantry->Increment_Unit_Total(reinterpret_cast<InfantryClass*>(this)->Class->Type);
+            total_recorded++;
+        }
+        // Fall through.....
+    case RTTI_UNIT:
+        if (source && !total_recorded && (Session.Type == GAME_INTERNET || Session.Type == GAME_IPX) && !text->IsDontScore) {
+            source->House->DestroyedUnits->Increment_Unit_Total(reinterpret_cast<UnitClass*>(this)->Class->Type);
+        }
+
+        House->UnitsLost++;
+        if (source && !text->IsDontScore) source->House->UnitsKilled[Owner()]++;
+
+        /**
+         *  If the map is displaying the multiplayer player names & their
+         *  # of kills, tell it to redraw.
+         */
+        if (Map.Is_Player_Names()) {
+            Map.Player_Names(false);
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
 
 
 /**
@@ -1153,45 +1624,6 @@ continue_checks:
 
 return_false:
     JMP(0x0062D8C0);
-}
-
-
-/**
- *  Adds check for if the warhead forbids force-firing at this unit.
- *
- *  @author: ZivDero
- */
-DECLARE_PATCH(_TechnoClass_Can_Fire_ForceFire_Armor_Patch)
-{
-    GET_REGISTER_STATIC(TechnoClass*, this_ptr, esi);
-    GET_REGISTER_STATIC(TechnoClass*, target, ebp);
-    GET_REGISTER_STATIC(WeaponSlotType, which, ebx);
-
-    /**
-     *  If the object has an armor type that this unit's warhead is forbidden to fire at, bail.
-     */
-    if (Is_Target_Techno(target))
-    {
-        if (!Verses::Get_ForceFire(target->Techno_Type_Class()->Armor, this_ptr->Get_Weapon(which)->Weapon->WarheadPtr))
-        {
-            _asm mov esi, this_ptr
-            // return FIRE_ILLEGAL;
-            JMP(0x0062F991);
-        }
-    }
-
-    /**
-     *  If the object is further away than allowed, bail.
-     */
-    if (!this_ptr->In_Range_Of(target, which))
-    {
-        _asm mov esi, this_ptr
-        // return FIRE_RANGE;
-        JMP(0x0062FC90);
-    }
-
-    _asm mov esi, this_ptr
-    JMP(0x0062FC9F);
 }
 
 
@@ -1866,17 +2298,10 @@ DECLARE_PATCH(_TechnoClass_AI_Abandon_Invalid_Target_Patch)
             which = this_ptr->What_Weapon_Should_I_Use(this_ptr->TarCom);
             weapon = const_cast<WeaponTypeClass*>(this_ptr->Get_Weapon(which)->Weapon);
 
-            if (weapon
-                && !(weapon->IsSonic && this_ptr->Wave)
-                && !(weapon->IsRailgun && this_ptr->ParticleSystems[4])
-                && !(weapon->IsUseFireParticles && this_ptr->ParticleSystems[0])
-                && !(weapon->IsUseSparkParticles && this_ptr->ParticleSystems[1]))
+            fire = this_ptr->Can_Fire(this_ptr->TarCom, which);
+            if (fire == FIRE_ILLEGAL || fire == FIRE_CANT)
             {
-                fire = this_ptr->Can_Fire(this_ptr->TarCom, which);
-                if (fire == FIRE_ILLEGAL || fire == FIRE_CANT)
-                {
-                    this_ptr->Assign_Target(nullptr);
-                }
+                this_ptr->Assign_Target(nullptr);
             }
         }
     }
@@ -1898,6 +2323,83 @@ DECLARE_PATCH(_TechnoClass_Take_Damage_Drop_Tiberium_Type_Patch)
 
     // Return from the function
     JMP(0x00633073);
+}
+
+
+/**
+ *  Patch to update the spawn manager when its owner is captured.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_TechnoClass_Captured_Spawn_Manager_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass*, this_ptr, esi);
+    static TechnoClassExtension* extension;
+
+    extension = Extension::Fetch<TechnoClassExtension>(this_ptr);
+
+    if (extension->SpawnManager)
+        extension->SpawnManager->Detach_Spawns();
+
+    // Stolen instructions
+    if (this_ptr->Tag)
+        this_ptr->Tag->Spring(TEVENT_PLAYER_ENTERED, this_ptr);
+
+    JMP(0x00632518);
+}
+
+
+/**
+ *  Patch to assign the target to the spawner.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_TechnoClass_Assign_Target_Spawn_Manager_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass*, this_ptr, esi);
+    static TechnoClassExtension* extension;
+
+    extension = Extension::Fetch<TechnoClassExtension>(this_ptr);
+
+    if (extension->SpawnManager)
+        extension->SpawnManager->Queue_Target(nullptr);
+
+    // Stolen instructions
+    this_ptr->CurrentBurstIndex = 0;
+
+    JMP(0x0062FDE8);
+}
+
+
+/**
+ *  Patch to pass the fire command to the spawner.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_TechnoClass_Fire_At_Spawn_Manager_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClassExt*, this_ptr, esi);
+    GET_REGISTER_STATIC(WeaponTypeClass*, weapon, ebx);
+    GET_REGISTER_STATIC(TARGET, target, edi);
+
+    // Stolen instructions
+    if (((weapon->IsSonic && this_ptr->Wave)
+      || (weapon->IsRailgun && this_ptr->ParticleSystems[4])
+      || (weapon->IsUseFireParticles && this_ptr->ParticleSystems[0])
+      || (weapon->IsUseSparkParticles && this_ptr->ParticleSystems[1])))
+    {
+        // return FIRE_OK;
+        JMP(0x006304D2);
+    }
+
+    if (this_ptr->_Spawner_Fire_At(target, weapon))
+    {
+        // return FIRE_OK;
+        JMP(0x006304D2);
+    }
+
+    // Continue checks
+    JMP(0x0063052D);
 }
 
 
@@ -2017,7 +2519,6 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00636BFE, &_TechnoClass_Base_Is_Attacked_Armor1_Patch);
     Patch_Jump(0x006369B0, &_TechnoClass_Base_Is_Attacked_Armor2_Patch);
     Patch_Jump(0x0062D11E, &_TechnoClass_Evaluate_Object_PassiveAcquire_Armor_Patch);
-    Patch_Jump(0x0062FC80, &_TechnoClass_Can_Fire_ForceFire_Armor_Patch);
     Patch_Call(0x0042EC25, &TechnoClassExt::_What_Action);
     Patch_Call(0x004A8532, &TechnoClassExt::_What_Action);
     Patch_Jump(0x0062EB27, &_TechnoClass_AI_Abandon_Invalid_Target_Patch);
@@ -2030,4 +2531,14 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00637D60, &TechnoClassExt::_Draw_Text_Overlay);
     Patch_Jump(0x006364A0, &TechnoClassExt::_Crew_Type);
     Patch_Jump(0x0062A300, &TechnoClassExt::_How_Many_Survivors);
+    Patch_Jump(0x006324FF, &_TechnoClass_Captured_Spawn_Manager_Patch);
+    Patch_Jump(0x0062FDE2, &_TechnoClass_Assign_Target_Spawn_Manager_Patch);
+    Patch_Jump(0x006304DD, &_TechnoClass_Fire_At_Spawn_Manager_Patch);
+    Patch_Jump(0x00637450, &TechnoClassExt::_Target_Something_Nearby);
+    Patch_Jump(0x0062FD20, &TechnoClassExt::_Stun);
+    Patch_Call(0x0062E9D1, &TechnoClassExt::_Mission_AI);
+    Patch_Jump(0x0062F980, &TechnoClassExt::_Can_Fire);
+    Patch_Jump(0x00631FF0, &TechnoClassExt::_Can_Player_Move);
+    Patch_Jump(0x006336F0, &TechnoClassExt::_Record_The_Kill);
+    //Patch_Jump(0x0062A3D0, &TechnoClassExt::_Fire_Coord); // Disabled because it's functionally identical to the vanilla function when there's no secondary coordinate
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -26,6 +26,8 @@
  *
  ******************************************************************************/
 #include "technotypeext.h"
+
+#include "aircrafttype.h"
 #include "technotype.h"
 #include "ccini.h"
 #include "filepng.h"
@@ -72,7 +74,15 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsSortCameoAsBaseDefense(false),
     Description(""),
     IsFilterFromBandBoxSelection(false),
-    CrewCount(1)
+    CrewCount(1),
+    IsMissileSpawn(false),
+    Spawns(nullptr),
+    SpawnReloadRate(0),
+    SpawnRegenRate(0),
+    SpawnsNumber(0),
+    SecondSpawnOffset(0, 0, 0),
+    IsDontScore(false),
+    IsSpawned(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -119,6 +129,7 @@ HRESULT TechnoTypeClassExtension::Load(IStream *pStm)
     }
 
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(UnloadingClass, "UnloadingClass");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Spawns, "Spawns");
 
     /**
      *  We need to reload the "Cameo" key because TechnoTypeClass does
@@ -216,6 +227,10 @@ void TechnoTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(ShakePixelXLo);
     crc(SoylentValue);
     crc(IsLegalTargetComputer);
+    crc(Spawns->Get_Heap_ID());
+    crc(SpawnRegenRate);
+    crc(SpawnReloadRate);
+    crc(SpawnsNumber);
 }
 
 
@@ -280,7 +295,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     /**
      *  Fetch the cameo image surface if it exists.
      */
-    BSurface *imagesurface = Vinifera_Get_Image_Surface(This()->CameoFilename);
+    BSurface* imagesurface = Vinifera_Get_Image_Surface(This()->CameoFilename);
     if (imagesurface) {
         CameoImageSurface = imagesurface;
     }
@@ -288,6 +303,16 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsSortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", IsSortCameoAsBaseDefense);
     IsFilterFromBandBoxSelection = ini.Get_Bool(ini_name, "FilterFromBandBoxSelection", IsFilterFromBandBoxSelection);
     CrewCount = ini.Get_Int(ini_name, "CrewCount", CrewCount);
+
+    IsMissileSpawn = ini.Get_Bool(ini_name, "MissileSpawn", IsMissileSpawn);
+    Spawns = ini.Get_Aircraft(ini_name, "Spawns", nullptr);
+    SpawnReloadRate = ini.Get_Int(ini_name, "SpawnReloadRate", SpawnReloadRate);
+    SpawnRegenRate = ini.Get_Int(ini_name, "SpawnRegenRate", SpawnRegenRate);
+    SpawnsNumber = ini.Get_Int(ini_name, "SpawnsNumber", SpawnsNumber);
+    SecondSpawnOffset = ArtINI.Get_Point(graphic_name, "SecondSpawnOffset", SecondSpawnOffset);
+
+    IsDontScore = ini.Get_Bool(ini_name, "DontScore", IsDontScore);
+    IsSpawned = ini.Get_Bool(ini_name, "Spawned", IsSpawned);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -33,6 +33,7 @@
 #include "tibsun_defines.h"
 
 
+class AircraftTypeClass;
 class BSurface;
 
 
@@ -189,4 +190,46 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
          *  How many crew members should exit this object when it is destroyed?
          */
         int CrewCount;
+
+        /**
+         *  This field shares two functions. For spawner units, it designates if it spawns missiles
+         *  (although this appears unused in RA2). For spawned units, it designates if it should be
+         *  treated like a missile.
+         */
+        bool IsMissileSpawn;
+
+        /**
+         *  If this is a spawner (rocket launcher or aircraft carrier), this is the type of object it spawns.
+         */
+        const AircraftTypeClass* Spawns;
+
+        /**
+         *  The rate at which this spawner's spawned object reload (how much time it takes before they can attack again).
+         */
+        int SpawnReloadRate;
+
+        /**
+         *  The rate at which the spawner replenished its destroyed spawned objects.
+         */
+        int SpawnRegenRate;
+
+        /**
+         *  How many objects can this spawner spawn?
+         */
+        int SpawnsNumber;
+
+        /**
+         *  If it can spawn two missiles at once (like the Boomer submarine), this is an extra offset of the second spawn relative to the first.
+         */
+        TPoint3D<int> SecondSpawnOffset;
+
+        /**
+         *  If it can spawn two missiles at once (like the Boomer submarine), this is an extra offset of the second spawn relative to the first.
+         */
+        bool IsDontScore;
+
+        /**
+         *  Is this meant to be spawned by something else (a spawner, or perhaps, off-map like a paradrop plane)?
+         */
+        bool IsSpawned;
 };

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -160,6 +160,8 @@ int TerrainClassExtension::Size_Of() const
 void TerrainClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("TerrainClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/terraintype/terraintypeext.cpp
+++ b/src/extensions/terraintype/terraintypeext.cpp
@@ -157,6 +157,8 @@ int TerrainTypeClassExtension::Size_Of() const
 void TerrainTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("TerrainTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/unit/unitext.cpp
+++ b/src/extensions/unit/unitext.cpp
@@ -150,6 +150,8 @@ int UnitClassExtension::Size_Of() const
 void UnitClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("UnitClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    FootClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/unittype/unittypeext.cpp
+++ b/src/extensions/unittype/unittypeext.cpp
@@ -161,6 +161,8 @@ int UnitTypeClassExtension::Size_Of() const
 void UnitTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("UnitTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    TechnoTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/voxelanimtype/voxelanimtypeext.cpp
+++ b/src/extensions/voxelanimtype/voxelanimtypeext.cpp
@@ -150,6 +150,8 @@ int VoxelAnimTypeClassExtension::Size_Of() const
 void VoxelAnimTypeClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("VoxelAnimTypeClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    ObjectTypeClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/wave/waveext.cpp
+++ b/src/extensions/wave/waveext.cpp
@@ -150,6 +150,8 @@ int WaveClassExtension::Size_Of() const
 void WaveClassExtension::Detach(TARGET target, bool all)
 {
     //EXT_DEBUG_TRACE("WaveClassExtension::Detach - 0x%08X\n", (uintptr_t)(This()));
+
+    ObjectClassExtension::Detach(target, all);
 }
 
 

--- a/src/extensions/weapontype/weapontypeext.cpp
+++ b/src/extensions/weapontype/weapontypeext.cpp
@@ -51,7 +51,9 @@ WeaponTypeClassExtension::WeaponTypeClassExtension(const WeaponTypeClass *this_p
     ElectricBoltSegmentCount(EBOLT_DEFAULT_LINE_SEGEMENTS),
     ElectricBoltLifetime(EBOLT_DEFAULT_LIFETIME),
     ElectricBoltIterationCount(EBOLT_DEFAULT_INTERATIONS),
-    ElectricBoltDeviation(EBOLT_DEFAULT_DEVIATION)
+    ElectricBoltDeviation(EBOLT_DEFAULT_DEVIATION),
+    IsSpawner(false),
+    IsRevealOnFire(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WeaponTypeClassExtension::WeaponTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -174,6 +176,8 @@ void WeaponTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     //EXT_DEBUG_TRACE("WeaponTypeClassExtension::Compute_CRC - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
     crc(IsElectricBolt);
+    crc(IsSpawner);
+    crc(IsRevealOnFire);
 }
 
 
@@ -203,6 +207,8 @@ bool WeaponTypeClassExtension::Read_INI(CCINIClass &ini)
     ElectricBoltLifetime = ini.Get_Int(ini_name, "EBoltLifetime", ElectricBoltLifetime);
     ElectricBoltIterationCount = ini.Get_Int(ini_name, "EBoltIterations", ElectricBoltIterationCount);
     ElectricBoltDeviation = ini.Get_Float(ini_name, "EBoltDeviation", ElectricBoltDeviation);
+    IsSpawner = ini.Get_Bool(ini_name, "Spawner", IsSpawner);
+    //IsRevealOnFire = ini.Get_Bool(ini_name, "RevealOnFire", IsRevealOnFire); // Disabled until it's implemented in all the places it should take effect.
     //ElectricBoltSourceBoltParticleSys = ini.Get_ParticleSys(ini_name, "EBoltSourceParticleSys", ElectricBoltSourceBoltParticleSys);
     //ElectricBoltTargetBoltParticleSys = ini.Get_ParticleSys(ini_name, "EBoltTargetBoltParticleSys", ElectricBoltTargetBoltParticleSys);
 

--- a/src/extensions/weapontype/weapontypeext.h
+++ b/src/extensions/weapontype/weapontypeext.h
@@ -105,6 +105,16 @@ WeaponTypeClassExtension final : public AbstractTypeClassExtension
         float ElectricBoltDeviation;
 
         /**
+         *  Does this weapon spawn aircraft when fired?
+         */
+        bool IsSpawner;
+
+        /**
+         *  Should the firer of this weapon be revealed when firing?
+         */
+        bool IsRevealOnFire;
+
+        /**
          *  Particle systems to display.
          */
         //ParticleSystemClass *ElectricBoltSourceBoltParticleSys;

--- a/src/new/armortype/armortype.cpp
+++ b/src/new/armortype/armortype.cpp
@@ -203,7 +203,7 @@ HRESULT ArmorTypeClass::Load(IStream* pStm)
     VINIFERA_SWIZZLE_REGISTER_POINTER(id, this, IniName);
 
     /**
-     *  Read this classes binary blob data directly into this instance.
+     *  Read this class's binary blob data directly into this instance.
      */
     hr = pStm->Read(this, sizeof(*this), nullptr);
     if (FAILED(hr)) {

--- a/src/new/kamikazetracker/kamikazetracker.cpp
+++ b/src/new/kamikazetracker/kamikazetracker.cpp
@@ -1,0 +1,272 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          KAMIKAZETRACKER.CPP
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         KamikazeTrackerClass reimplementation from YR.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include "kamikazetracker.h"
+
+#include "aircraft.h"
+#include "aircrafttypeext.h"
+#include "cell.h"
+#include "extension.h"
+#include "tibsun_inline.h"
+#include "tibsun_globals.h"
+#include "mouse.h"
+#include "vinifera_globals.h"
+#include "vinifera_saveload.h"
+
+
+/**
+ *  Basic constructor for the KamikazeTrackerClass.
+ *
+ *  @author: ZivDero
+ */
+KamikazeTrackerClass::~KamikazeTrackerClass()
+{
+    for (int i = 0; i < Controls.Count(); i++)
+        delete Controls[i];
+}
+
+
+/**
+ *  Loads the object from the stream and requests a new pointer to
+ *  the class we extended post-load.
+ *
+ *  @author: ZivDero
+ */
+HRESULT KamikazeTrackerClass::Load(IStream* pStm)
+{
+    //EXT_DEBUG_TRACE("KamikazeTrackerClass::Load - 0x%08X\n", (uintptr_t)(this));
+
+    if (!pStm) {
+        return E_POINTER;
+    }
+
+    /**
+     *  Load the unique id for this class.
+     */
+    LONG id = 0;
+    HRESULT hr = pStm->Read(&id, sizeof(LONG), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Register this instance to be available for remapping references to.
+     */
+    VINIFERA_SWIZZLE_REGISTER_POINTER(id, this, "KamikazeTracker");
+
+    /**
+     *  Read this class's binary blob data directly into this instance.
+     */
+    hr = pStm->Read(this, sizeof(*this), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Read the count of active kamikaze controls.
+     */
+    int count;
+
+    hr = pStm->Read(&count, sizeof(count), nullptr);
+    if (FAILED(hr))
+        return hr;
+
+    new (&Controls) DynamicVectorClass<KamikazeControl*>();
+
+    if (count <= 0)
+        return hr;
+
+    /**
+     *  Read each of the controls as a binary blob.
+     */
+    for (int index = 0; index < count; ++index)
+    {
+        const auto control = new KamikazeControl;
+        hr = pStm->Read(control, sizeof(KamikazeControl), nullptr);
+        if (FAILED(hr))
+            return hr;
+        Controls.Add(control);
+    }
+
+    for (int index = 0; index < count; index++)
+    {
+        VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Controls[index]->Aircraft, "Aircraft");
+        VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Controls[index]->Cell, "Cell");
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Saves the object to the stream.
+ *
+ *  @author: ZivDero
+ */
+HRESULT KamikazeTrackerClass::Save(IStream* pStm, BOOL fClearDirty)
+{
+    //EXT_DEBUG_TRACE("KamikazeTrackerClass::Save - 0x%08X\n", (uintptr_t)(this));
+
+    if (!pStm) {
+        return E_POINTER;
+    }
+
+    /**
+     *  Fetch the save id for this instance.
+     */
+    const LONG id = reinterpret_cast<LONG>(this);
+
+    //DEV_DEBUG_INFO("Writing id = 0x%08X.\n", id);
+
+    HRESULT hr = pStm->Write(&id, sizeof(id), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Write this class instance as a binary blob.
+     */
+    hr = pStm->Write(this, sizeof(*this), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Write the count of active kamikaze controls.
+     */
+    const int count = Controls.Count();
+
+    hr = pStm->Write(&count, sizeof(count), nullptr);
+    if (FAILED(hr))
+        return hr;
+
+    if (count <= 0)
+        return hr;
+
+    /**
+     *  Write each of the controls as a binary blob.
+     */
+    for (int index = 0; index < count; ++index)
+    {
+        hr = pStm->Write(Controls[index], sizeof(KamikazeControl), nullptr);
+        if (FAILED(hr))
+            return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Adds a new aircraft to the tracker.
+ *
+ *  @author: ZivDero
+ */
+void KamikazeTrackerClass::Add(AircraftClass* aircraft, TARGET target)
+{
+    if (!Extension::Fetch<AircraftTypeClassExtension>(aircraft->Techno_Type_Class())->IsMissileSpawn)
+    {
+        aircraft->On_Death(nullptr);
+        return;
+    }
+
+    const auto control = new KamikazeControl();
+    control->Aircraft = aircraft;
+    control->Cell = target == nullptr ?
+        &aircraft->Get_Cell_Ptr()->Adjacent_Cell(Dir_Facing(aircraft->PrimaryFacing.Current().Get_Dir())) :
+        &Map[Coord_Cell(target->Center_Coord())];
+    aircraft->IsKamikaze = true;
+    aircraft->Ammo = 1;
+    Controls.Add(control);
+}
+
+
+/**
+ *  Processes the kamikaze tracker logic.
+ *
+ *  @author: ZivDero
+ */
+void KamikazeTrackerClass::AI()
+{
+    if (!UpdateTimer.Expired())
+        return;
+
+    UpdateTimer.Start();
+    UpdateTimer = 30;
+
+    for (int i = 0; i < Controls.Count(); i++)
+    {
+        const auto control = Controls[i];
+        CellClass* cell = control->Cell;
+        AircraftClass* aircraft = control->Aircraft;
+
+        aircraft->Ammo = 1;
+        if (cell)
+            aircraft->Assign_Target(cell);
+        else
+            aircraft->Assign_Target(&aircraft->Get_Cell_Ptr()->Adjacent_Cell(Dir_Facing(aircraft->PrimaryFacing.Current().Get_Dir())));
+
+        aircraft->Assign_Mission(MISSION_ATTACK);
+    }
+}
+
+
+/**
+ *  Removes an aircraft from the tracker.
+ *
+ *  @author: ZivDero
+ */
+void KamikazeTrackerClass::Detach(AircraftClass const* aircraft)
+{
+    for (int i = 0; i < Controls.Count(); i++)
+    {
+        const auto control = Controls[i];
+        if (control->Aircraft == aircraft)
+        {
+            delete control;
+            Controls.Delete(control);
+            return;
+        }
+    }
+}
+
+
+/**
+ *  Clears the tracker.
+ *
+ *  @author: ZivDero
+ */
+void KamikazeTrackerClass::Clear()
+{
+    for (int i = 0; i  < Controls.Count(); i++)
+        delete Controls[i];
+
+    Controls.Clear();
+    UpdateTimer.Start();
+    UpdateTimer = 1;
+}

--- a/src/new/kamikazetracker/kamikazetracker.h
+++ b/src/new/kamikazetracker/kamikazetracker.h
@@ -1,0 +1,71 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          KAMIKAZETRACKER.H
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         KamikazeTrackerClass reimplementation from YR.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "abstract.h"
+#include "ftimer.h"
+#include "ttimer.h"
+#include "vector.h"
+
+class AircraftClass;
+class CellClass;
+class KamikazeTrackerClass;
+
+
+class KamikazeTrackerClass {
+public:
+    struct KamikazeControl {
+        AircraftClass* Aircraft;
+        CellClass* Cell;
+    };
+
+    KamikazeTrackerClass() noexcept : UpdateTimer(100), Controls() { }
+    ~KamikazeTrackerClass();
+
+    HRESULT STDMETHODCALLTYPE Load(IStream* pStm);
+    HRESULT STDMETHODCALLTYPE Save(IStream* pStm, BOOL fClearDirty);
+
+    void Add(AircraftClass* aircraft, TARGET target);
+    void AI();
+    void Detach(AircraftClass const* aircraft);
+    void Clear();
+
+    KamikazeTrackerClass(const KamikazeTrackerClass&) = delete;
+    KamikazeTrackerClass& operator= (const KamikazeTrackerClass&) = delete;
+
+public:
+    /**
+     *  The timer that controls how often the tracker should perform its AI function.
+     */
+    CDTimerClass<FrameTimerClass> UpdateTimer;
+
+    /**
+     *  The vector that contains all kamikaze controls.
+     */
+    DynamicVectorClass<KamikazeControl*> Controls;
+};

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -299,7 +299,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
             {
                 MissionState = RocketMissionState::Flight;
                 Coordinate center_coord = Linked_To()->Center_Coord();
-                ApogeeDistance = static_cast<int>(Vector2(static_cast<float>(center_coord.X - DestinationCoord.X), static_cast<float>(center_coord.Y - DestinationCoord.Y)).Length());
+                ApogeeDistance = (center_coord.As_Cell() - DestinationCoord.As_Cell()).Length();
             }
             break;
         }
@@ -337,7 +337,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
                      *  compared to how far it was when it reached its cruising altitude.
                      */
                     const Coordinate center_coord = Linked_To()->Center_Coord();
-                    const double dist = Vector2(static_cast<float>(center_coord.X - DestinationCoord.X), static_cast<float>(center_coord.Y - DestinationCoord.Y)).Length();
+                    const double dist = (center_coord.As_Cell() - DestinationCoord.As_Cell()).Length();
                     const double ratio = dist / ApogeeDistance;
 
                     CurrentPitch = rocket->PitchFinal * ratio * DEG_TO_RAD(90) + Get_Next_Pitch() * (1 - ratio);

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -525,7 +525,7 @@ IFACEMETHODIMP_(void) RocketLocomotionClass::Stop_Moving()
  */
 IFACEMETHODIMP_(LayerType) RocketLocomotionClass::In_Which_Layer()
 {
-    return LAYER_AIR;
+    return LAYER_TOP;
 }
 
 

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -591,7 +591,7 @@ void RocketLocomotionClass::Explode()
      */
     const auto atype = reinterpret_cast<AircraftClass*>(Linked_To())->Class;
     const RocketTypeClass* rocket = RocketTypeClass::From_AircraftType(atype);
-    const WarheadTypeClass* warhead = IsSpawnerElite ? rocket->EliteWarhead : rocket->Warhead;
+    const WarheadTypeClass* warhead = (IsSpawnerElite && rocket->EliteWarhead) ? rocket->EliteWarhead : rocket->Warhead;
 
     /**
      *  Calculate where it's moving right now.

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -132,8 +132,6 @@ IFACEMETHODIMP_(Matrix3D) RocketLocomotionClass::Draw_Matrix(int *key)
 
     /**
      *  Rotate the rocket to its current facing.
-     *  YR subtracts 8 from the facing, equivalent to 90 degrees, but for some reason
-     *  it's necessary to subtract 12 (135 degrees) in YR to achieve the same result.
      */
     const float z_angle = Linked_To()->PrimaryFacing.Current().Get_Radian<32>();
     matrix.Rotate_Z(z_angle);

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -1,0 +1,647 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          ROCKETLOCOMOTION.CPP
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         Rocket locomotion implementation.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "rocketlocomotion.h"
+#include "tibsun_inline.h"
+#include "tibsun_globals.h"
+#include "iomap.h"
+#include "aircraftext.h"
+#include "aircraft.h"
+#include "aircrafttype.h"
+#include "cell.h"
+#include "anim.h"
+#include "combat.h"
+#include "foot.h"
+#include "tactical.h"
+#include "wwmath.h"
+#include "debughandler.h"
+#include "extension.h"
+#include "fastmath.h"
+#include "vector2.h"
+#include "voc.h"
+
+
+/**
+ *  Retrieves the class identifier (CLSID) of the object.
+ * 
+ *  @author: CCHyper
+ */
+IFACEMETHODIMP RocketLocomotionClass::GetClassID(CLSID *pClassID)
+{    
+    if (pClassID == nullptr) {
+        return E_POINTER;
+    }
+
+    *pClassID = __uuidof(this);
+
+    return S_OK;
+}
+
+
+/**
+ *  Initializes an object from the stream where it was saved previously.
+ * 
+ *  @author: CCHyper
+ */
+IFACEMETHODIMP RocketLocomotionClass::Load(IStream *pStm)
+{
+    HRESULT hr = LocomotionClass::Locomotion_Load(pStm);
+    if (SUCCEEDED(hr)) {
+        // Insert any data to be loaded here.
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Class default constructor.
+ * 
+ *  @author: ZivDero
+ */
+RocketLocomotionClass::RocketLocomotionClass() :
+    LocomotionClass(),
+    DestinationCoord(),
+    MissionTimer(),
+    TrailTimer(),
+    MissionState(RocketMissionState::None),
+    CurrentSpeed(0),
+    NeedToSubmit(true),
+    IsSpawnerElite(false),
+    CurrentPitch(0.0),
+    ApogeeDistance(0)
+{
+}
+
+
+/**
+ *  Sees if object is moving.
+ *
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(bool) RocketLocomotionClass::Is_Moving()
+{
+    return DestinationCoord != Coordinate();
+}
+
+
+/**
+ *  Fetches destination coordinate.
+ *
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(Coordinate) RocketLocomotionClass::Destination()
+{
+    return DestinationCoord;
+}
+
+
+/**
+ *  Fetch voxel draw matrix.
+ * 
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(Matrix3D) RocketLocomotionClass::Draw_Matrix(int *key)
+{
+    Matrix3D matrix;
+    matrix.Make_Identity();
+
+    /**
+     *  Rotate the rocket to its current facing.
+     *  YR subtracts 8 from the facing, equivalent to 90 degrees, but for some reason
+     *  it's necessary to subtract 12 (135 degrees) in YR to achieve the same result.
+     */
+    const float z_angle = Linked_To()->PrimaryFacing.Current().Get_Radian<32>();
+    matrix.Rotate_Z(z_angle);
+
+    if (CurrentPitch != 0.0)
+    {
+        matrix.Rotate_Y(-CurrentPitch);
+
+        /**
+         *  Get this rocket's type.
+         */
+        const auto atype = reinterpret_cast<AircraftClass*>(Linked_To())->Class;
+        const RocketTypeClass* rocket = RocketTypeClass::From_AircraftType(atype);
+
+        if (key)
+        {
+            if (CurrentPitch == rocket->PitchInitial * DEG_TO_RAD(90))
+                *key |= 0x20;
+            else if (CurrentPitch == rocket->PitchFinal * DEG_TO_RAD(90))
+                *key |= 0x40;
+            else
+                *key = -1;
+        }
+    }
+
+    if (key)
+    {
+        *key |= Linked_To()->PrimaryFacing.Current().Get_Facing<32>();
+    }
+
+    return matrix;
+}
+
+
+/**
+ *  Shadow draw point center location.
+ *
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(Point2D) RocketLocomotionClass::Shadow_Point()
+{
+    return { 0, 0 };
+}
+
+
+/**
+ *  Process movement of object.
+ * 
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
+{
+    /**
+     *  Get this rocket's type.
+     */
+    const auto atype = reinterpret_cast<AircraftClass*>(Linked_To())->Class;
+    const RocketTypeClass* rocket = RocketTypeClass::From_AircraftType(atype);
+
+    TechnoClass* spawn_owner = Extension::Fetch<AircraftClassExtension>(Linked_To())->SpawnOwner;
+
+    switch (MissionState)
+    {
+        /**
+         *  The rocket is currently waiting to be launched.
+         */
+    case RocketMissionState::Pause:
+        {
+            CurrentSpeed = 0;
+            IsSpawnerElite = spawn_owner && spawn_owner->Veterancy.Is_Elite();
+
+            /**
+             *  Cruise missiles spawn a "taking off" animation in this state.
+             */
+            if (rocket->IsCruiseMissile)
+            {
+                if (TrailTimer.Expired() && rocket->TakeoffAnim)
+                {
+                    new AnimClass(rocket->TakeoffAnim, Linked_To()->Coord, 2, 1, SHAPE_WIN_REL | SHAPE_CENTER, -10);
+                    TrailTimer = 24;
+                }
+
+                if (NeedToSubmit)
+                {
+                    Linked_To()->Mark(MARK_UP);
+                    NeedToSubmit = false;
+                    Map.Submit(Linked_To());
+                    Linked_To()->Mark(MARK_DOWN);
+                }
+            }
+            else
+            {
+                NeedToSubmit = true;
+            }
+
+            /**
+             *  If we're done waiting, proceed to take off.
+             *  Cruise missiles take off vertically, while regular rockets tilt up first.
+             */
+            if (MissionTimer.Expired())
+            {
+                MissionState = rocket->IsCruiseMissile ? RocketMissionState::VerticalTakeOff : RocketMissionState::GainingAltitude;
+                MissionTimer = rocket->TiltFrames;
+            }
+            
+        }
+        break;
+
+        /**
+         *  The rocket is currently tilting up to its firing position.
+         */
+    case RocketMissionState::Tilt:
+        {
+            CurrentSpeed = 0;
+            IsSpawnerElite = spawn_owner && spawn_owner->Veterancy.Is_Elite();
+
+            /**
+             *  If the rocket is done tilting, play a sound and animation, and proceed to take off.
+             */
+            if (MissionTimer.Expired())
+            {
+                CurrentPitch = rocket->PitchFinal * DEG_TO_RAD(90);
+                MissionState = RocketMissionState::GainingAltitude;
+                if (rocket->TakeoffAnim)
+                    new AnimClass(rocket->TakeoffAnim, Linked_To()->Coord, 2, 1, SHAPE_WIN_REL | SHAPE_CENTER, -10);
+                Sound_Effect(Linked_To()->Techno_Type_Class()->AuxSound1, Linked_To()->Coord);
+            }
+            /**
+             *  Otherwise, keep tilting.
+             */
+            else
+            {
+                const double pitch_initial = rocket->PitchInitial * DEG_TO_RAD(90);
+                const double pitch_final = rocket->PitchFinal * DEG_TO_RAD(90);
+                CurrentPitch = (pitch_final - pitch_initial) * MissionTimer.Percent_Expired() + pitch_initial;
+            }
+            break;
+        }
+
+        /**
+         *  The rocket is currently gaining altitude.
+         */
+    case RocketMissionState::GainingAltitude:
+        {
+            if (!NeedToSubmit)
+            {
+                Linked_To()->Mark(MARK_UP);
+                NeedToSubmit = true;
+                Map.Submit(Linked_To());
+                Linked_To()->Mark(MARK_DOWN);
+            }
+
+            /**
+             *  Accelerate towards the maximum speed.
+             */
+            CurrentSpeed += rocket->Acceleration;
+            CurrentSpeed = std::min(CurrentSpeed, static_cast<double>(Linked_To()->Techno_Type_Class()->MaxSpeed));
+
+            /**
+             *  If the rocket has reached its cruising altitude, proceed to flight.
+             *  Save the distance to the destination for lazy curve rockets.
+             */
+            if (Linked_To()->Get_Height() >= rocket->Altitude)
+            {
+                MissionState = RocketMissionState::Flight;
+                Coordinate center_coord = Linked_To()->Center_Coord();
+                ApogeeDistance = static_cast<int>(Vector2(static_cast<float>(center_coord.X - DestinationCoord.X), static_cast<float>(center_coord.Y - DestinationCoord.Y)).Length());
+            }
+            break;
+        }
+
+        /**
+         *  The rocket is currently in flight.
+         */
+    case RocketMissionState::Flight:
+        {
+            /**
+             *  Check if we're still above ground. If not, explode.
+             */
+            if (Linked_To()->Get_Height() > 0)
+            {
+                /**
+                 *  Keep accelerating towards the maximum speed.
+                 */
+                CurrentSpeed += rocket->Acceleration;
+                CurrentSpeed = std::min(CurrentSpeed, static_cast<double>(Linked_To()->Techno_Type_Class()->MaxSpeed));
+
+                /**
+                 *  Lazy curve rockets curve towards the destination.
+                 */
+                if (rocket->IsLazyCurve && ApogeeDistance)
+                {
+                    /**
+                     *  Since the rocket doesn't dip towards the ground explicitly,
+                     *  we need to check if it's time to explode.
+                     */
+                    if (Time_To_Explode(rocket))
+                        return false;
+
+                    /**
+                     *  Calculate how much to tilt the rocket based on the distance to the destination
+                     *  compared to how far it was when it reached its cruising altitude.
+                     */
+                    const Coordinate center_coord = Linked_To()->Center_Coord();
+                    const double dist = Vector2(static_cast<float>(center_coord.X - DestinationCoord.X), static_cast<float>(center_coord.Y - DestinationCoord.Y)).Length();
+                    const double ratio = dist / ApogeeDistance;
+
+                    CurrentPitch = rocket->PitchFinal * ratio * DEG_TO_RAD(90) + Get_Next_Pitch() * (1 - ratio);
+                }
+                else
+                {
+                    /**
+                     *  Level off the rocket, slowly.
+                     */
+                    if (CurrentPitch > 0.0)
+                    {
+                        CurrentPitch -= rocket->TurnRate;
+                        CurrentPitch = std::max(CurrentPitch, 0.0);
+                    }
+
+                    /**
+                     *  If we're there, proceed to closing in.
+                     */
+                    const Coordinate center_coord = Linked_To()->Center_Coord();
+                    const Coordinate coord(center_coord.X - DestinationCoord.X, center_coord.Y - DestinationCoord.Y, center_coord.Z - Linked_To()->Coord.Z);
+                    if (coord.Length() <= Linked_To()->Coord.Z - DestinationCoord.Z)
+                        MissionState = RocketMissionState::ClosingIn;
+                }
+
+                /**
+                 *  Orient the rocket towards the destination.
+                 */
+                const Coordinate center_coord = Linked_To()->Center_Coord();
+                Linked_To()->PrimaryFacing.Set_Desired(Desired_Facing(DestinationCoord.X, DestinationCoord.Y, center_coord.X, center_coord.Y));
+            }
+            else
+            {
+                /**
+                 *  KABOOM!!!
+                 */
+                Explode();
+                return false;
+            }
+            break;
+        }
+
+    case RocketMissionState::ClosingIn:
+        {
+            /**
+             *  Check if it's time to explode.
+             */
+            if (Time_To_Explode(rocket))
+                return false;
+
+            /**
+             *  Pitch towards the destination.
+             */
+            const double pitch = Get_Next_Pitch() - CurrentPitch;
+
+            if (std::abs(pitch) > rocket->TurnRate)
+                CurrentPitch = pitch < 0 ? CurrentPitch - rocket->TurnRate : CurrentPitch + rocket->TurnRate;
+            else
+                CurrentPitch += pitch;
+
+            break;
+        }
+
+        /**
+         *  Cruise missiles take off vertically.
+         */
+    case RocketMissionState::VerticalTakeOff:
+        {
+            IsSpawnerElite = spawn_owner && spawn_owner->Veterancy.Is_Elite();
+
+            /**
+             *  Spawn the trail animation, as if the rocket is doing its best to lift off.
+             */
+            if (TrailTimer.Expired())
+            {
+                if (rocket->TakeoffAnim)
+                {
+                    new AnimClass(rocket->TakeoffAnim, Linked_To()->Coord, 2, 1, SHAPE_WIN_REL | SHAPE_CENTER, -10);
+                    TrailTimer = 24;
+                }
+            }
+
+            /**
+             *  If we're done taking off, play a sound and proceed to flight.
+             */
+            if (MissionTimer.Expired())
+            {
+                CurrentPitch = rocket->PitchFinal * DEG_TO_RAD(90);
+                Sound_Effect(Linked_To()->Techno_Type_Class()->AuxSound1, Linked_To()->Coord);
+
+                TrailTimer = 0;
+                MissionState = RocketMissionState::GainingAltitude;
+            }
+            /**
+             *  Otherwise, slowly nudge the rocket upwards to simulate taking off.
+             */
+            else
+            {
+                Coordinate coord = Linked_To()->Coord;
+                coord.Z += rocket->RaiseRate;
+                if (Map.In_Radar(Coord_Cell(coord)))
+                    Linked_To()->Set_Coord(coord);
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    /**
+     *  Spawn the rocket's trail.
+     */
+    if (Is_Moving_Now() && TrailTimer.Expired() && rocket->TrailAnim)
+    {
+        new AnimClass(rocket->TrailAnim, Linked_To()->Coord, 2, 1, SHAPE_WIN_REL | SHAPE_CENTER);
+        TrailTimer = 3;
+    }
+
+    /**
+     *  Move the rocket.
+     */
+    if (CurrentSpeed > 0.0)
+    {
+        Coordinate coord = Get_Next_Position(static_cast<int>(CurrentSpeed));
+
+        if (Map.In_Radar(Coord_Cell(coord)))
+            Linked_To()->Set_Coord(coord);
+
+        if (Linked_To()->Strength <= 0)
+            Explode();
+    }
+
+    return Is_Moving();
+}
+
+
+/**
+ *  Instruct to move to location specified.
+ * 
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(void) RocketLocomotionClass::Move_To(Coordinate to)
+{
+    const auto atype = reinterpret_cast<AircraftClass*>(Linked_To())->Class;
+    const RocketTypeClass* rocket = RocketTypeClass::From_AircraftType(atype);
+
+    /**
+     *  Rockets only accept a destination once.
+     */
+    if (!DestinationCoord)
+    {
+        int timer_delay;
+        if (rocket->PauseFrames)
+        {
+            MissionState = RocketMissionState::Pause;
+            timer_delay = rocket->PauseFrames;
+        }
+        else
+        {
+            MissionState = RocketMissionState::Tilt;
+            timer_delay = rocket->TiltFrames;
+        }
+
+        MissionTimer = timer_delay;
+        CurrentPitch = rocket->PitchInitial * DEG_TO_RAD(90);
+        DestinationCoord = to;
+    }
+}
+
+
+/**
+ *  Stop moving at first opportunity.
+ * 
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(void) RocketLocomotionClass::Stop_Moving()
+{
+}
+
+
+/**
+ *  What display layer is it located in.
+ * 
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(LayerType) RocketLocomotionClass::In_Which_Layer()
+{
+    return LAYER_AIR;
+}
+
+
+/**
+ *  Is it actually moving across the ground this very second?
+ * 
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP_(bool) RocketLocomotionClass::Is_Moving_Now()
+{
+    return MissionState >= RocketMissionState::GainingAltitude && MissionState <= RocketMissionState::ClosingIn;
+}
+
+
+/**
+ *  Calculates the next position of the rocket along its current trajectory.
+ *
+ *  @author: ZivDero
+ */
+Coordinate RocketLocomotionClass::Get_Next_Position(double speed) const
+{
+    Coordinate coord;
+
+    const double horizontal_speed = FastMath::Cos(CurrentPitch) * speed;
+    const double horizontal_angle = Linked_To()->PrimaryFacing.Current().Get_Radian<65536>();
+
+    coord.X = static_cast<int>(Linked_To()->Coord.X + FastMath::Cos(horizontal_angle) * horizontal_speed);
+    coord.Y = static_cast<int>(Linked_To()->Coord.Y - FastMath::Sin(horizontal_angle) * horizontal_speed);
+    coord.Z = static_cast<int>(Linked_To()->Coord.Z + FastMath::Sin(CurrentPitch) * speed);
+
+    return coord;
+}
+
+
+/**
+ *  Calculates the next pitch of the rocket along its current trajectory.
+ *
+ *  @author: ZivDero
+ */
+double RocketLocomotionClass::Get_Next_Pitch() const
+{
+    /**
+     *  Calculate how much is there left to go.
+     */
+    const Coordinate left_to_go = DestinationCoord - Linked_To()->Coord;
+    const double length = Vector2(static_cast<float>(left_to_go.X), static_cast<float>(left_to_go.Y)).Length();
+
+    /**
+     *  If we're still not there, calculate the pitch at which we should go.
+     */
+    if (length > 0)
+        return FastMath::Atan(left_to_go.Z / length);
+
+    /**
+     *  Otherwise it's time to go straight down.
+     */
+    return -DEG_TO_RAD(90);
+}
+
+
+void RocketLocomotionClass::Explode()
+{
+    /**
+     *  Get the warhead this rocket carries.
+     */
+    const auto atype = reinterpret_cast<AircraftClass*>(Linked_To())->Class;
+    const RocketTypeClass* rocket = RocketTypeClass::From_AircraftType(atype);
+    const WarheadTypeClass* warhead = IsSpawnerElite ? rocket->EliteWarhead : rocket->Warhead;
+
+    /**
+     *  Calculate where it's moving right now.
+     */
+    Coordinate coord = Get_Next_Position(rocket->BodyLength);
+    Cell cell = Coord_Cell(coord);
+
+    /**
+     *  The rocket uses its spawner's elite status to determine if it should deal elite damage.
+     */
+    int damage = IsSpawnerElite ? rocket->EliteDamage : rocket->Damage;
+
+    /**
+     *  KABOOM!!!
+     */
+    const auto animtype = Combat_Anim(damage, warhead, Map[cell].Land_Type(), &coord);
+    if (animtype)
+        new AnimClass(animtype, coord, 0, 1, SHAPE_WIN_REL | SHAPE_CENTER | SHAPE_FLAT, -15);
+    Combat_Lighting(coord, damage, warhead);
+    Explosion_Damage(coord, damage, Linked_To(), warhead, true);
+    Linked_To()->Remove_This();
+}
+
+
+
+bool RocketLocomotionClass::Time_To_Explode(const RocketTypeClass* rocket)
+{
+    Coordinate coord = Get_Next_Position(rocket->BodyLength);
+
+    /**
+     *  Check if we're there yet.
+     */
+    if (coord.Z > DestinationCoord.Z)
+    {
+        const CellClass* rocket_cell = Linked_To()->Get_Cell_Ptr();
+        if (!rocket_cell || !rocket_cell->Bit2_16 || DestinationCoord.Z != rocket_cell->Center_Coord().Z || coord.Z > DestinationCoord.Z + ROCKET_SPEED)
+        {
+            /**
+             *  Nope, too early.
+             */
+            if (Linked_To()->Get_Height() > 0)
+                return false;
+        }
+    }
+
+    /**
+     *  KABOOM!!!
+     */
+    Explode();
+    return true;
+}

--- a/src/new/locomotion/rocketlocomotion.h
+++ b/src/new/locomotion/rocketlocomotion.h
@@ -1,0 +1,142 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          ROCKETLOCOMOTION.H
+ *
+ *  @authors       CCHyper
+ *
+ *  @brief         Rocket locomotion implementation.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "always.h"
+#include "locomotion.h"
+#include "rockettype.h"
+#include "vinifera_defines.h"
+
+
+enum class RocketMissionState
+{
+    None = 0,
+    Pause = 1,
+    Tilt = 2,
+    GainingAltitude = 3,
+    Flight = 4,
+    ClosingIn = 5,
+    VerticalTakeOff = 6,
+};
+
+#define ROCKET_SPEED 416
+
+class DECLSPEC_UUID(CLSID_ROCKET_LOCOMOTOR)
+RocketLocomotionClass : public LocomotionClass
+{
+public:
+    /**
+     *  IPersist
+     */
+    IFACEMETHOD(GetClassID)(CLSID* pClassID);
+
+    /**
+     *  IPersistStream
+     */
+    IFACEMETHOD(Load)(IStream* pStm);
+
+    /**
+     *  ILocomotion
+     */
+    IFACEMETHOD_(bool, Is_Moving)();
+    IFACEMETHOD_(Coordinate, Destination)();
+    IFACEMETHOD_(Matrix3D, Draw_Matrix)(int *key);
+    IFACEMETHOD_(Point2D, Shadow_Point)();
+    IFACEMETHOD_(bool, Process)();
+    IFACEMETHOD_(void, Move_To)(Coordinate to);
+    IFACEMETHOD_(void, Stop_Moving)();
+    IFACEMETHOD_(LayerType, In_Which_Layer)();
+    IFACEMETHOD_(bool, Is_Moving_Now)();
+
+    RocketLocomotionClass();
+    ~RocketLocomotionClass() override = default;
+
+    /**
+     *  LocomotionClass
+     */
+    virtual int Size_Of(bool firestorm = false) const override { return sizeof(*this); }
+
+private:
+    /**
+     *  RocketLocomotionClass
+     */
+    Coordinate Get_Next_Position(double speed) const;
+    double Get_Next_Pitch() const;
+    void Explode();
+    bool Time_To_Explode(const RocketTypeClass* rocket);
+
+public:
+    RocketLocomotionClass(const RocketLocomotionClass&) = delete;
+    RocketLocomotionClass& operator=(const RocketLocomotionClass&) = delete;
+    
+protected:
+    /**
+     *  This is the desired destination coordinate of the rocket.
+     */
+    Coordinate DestinationCoord;
+
+    /**
+     *  This is the timer used by various mission states of the rocket.
+     */
+    CDRateTimerClass<FrameTimerClass> MissionTimer;
+
+    /**
+     *  This is the timer used for timing the trail animation.
+     */
+    CDTimerClass<FrameTimerClass> TrailTimer;
+
+    /**
+     *  The current state of the rocket.
+     */
+    RocketMissionState MissionState;
+
+    /**
+     *  The current speed of the rocket.
+     */
+    double CurrentSpeed;
+
+    /**
+     *  This boolean gets used to determine if the rocket needs to be submit to DisplayClass.
+     */
+    bool NeedToSubmit;
+
+    /**
+     *  Is this rocket's spawner elite?
+     */
+    bool IsSpawnerElite;
+
+    /**
+     *  The current pitch of the rocket.
+     */
+    double CurrentPitch;
+
+    /**
+     *  The distance to the destination from when the rocket has reached its desired altitude.
+     */
+    int ApogeeDistance;
+};

--- a/src/new/rockettype/rockettype.cpp
+++ b/src/new/rockettype/rockettype.cpp
@@ -8,7 +8,7 @@
  *
  *  @authors       ZivDero
  *
- *  @brief         Class containing condiguration for AircraftType rockets.
+ *  @brief         Class containing configuration for AircraftType rockets.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License

--- a/src/new/rockettype/rockettype.cpp
+++ b/src/new/rockettype/rockettype.cpp
@@ -1,0 +1,397 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          ROCKETTYPE.CPP
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         Class containing condiguration for AircraftType rockets.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "rockettype.h"
+#include "ccini.h"
+#include "vinifera_globals.h"
+#include "tibsun_globals.h"
+#include "tibsun_functions.h"
+#include "asserthandler.h"
+#include "vinifera_saveload.h"
+
+
+ /**
+  *  Basic constructor for rocket objects.
+  *
+  *  @author: ZivDero
+  */
+RocketTypeClass::RocketTypeClass()
+{
+    RocketTypes.Add(this);
+}
+
+
+/**
+ *  Basic constructor for rocket objects.
+ *
+ *  @author: ZivDero
+ */
+RocketTypeClass::RocketTypeClass(const char* name) :
+    IniName(""),
+    PauseFrames(0),
+    TiltFrames(0),
+    PitchInitial(0.0f),
+    PitchFinal(0.0f),
+    TurnRate(0.0f),
+    RaiseRate(0),
+    Acceleration(0.0f),
+    Altitude(0),
+    Damage(0),
+    EliteDamage(0),
+    BodyLength(0),
+    IsLazyCurve(false),
+    Type(nullptr),
+    Warhead(nullptr),
+    EliteWarhead(nullptr)
+{
+    ASSERT_FATAL_PRINT(name != nullptr, "Invalid name for RocketType!");
+
+    std::strncpy(IniName, name, sizeof(IniName));
+
+    RocketTypes.Add(this);
+}
+
+
+/**
+ *  Class destructor.
+ *
+ *  @author: ZivDero
+ */
+RocketTypeClass::~RocketTypeClass()
+{
+    RocketTypes.Delete(this);
+}
+
+
+/**
+ *  Retrieves pointers to the supported interfaces on an object.
+ *
+ *  @author: CCHyper, tomsons26
+ */
+LONG RocketTypeClass::QueryInterface(REFIID riid, LPVOID* ppv)
+{
+    /**
+     *  Always set out parameter to NULL, validating it first.
+     */
+    if (ppv == nullptr) {
+        return E_POINTER;
+    }
+    *ppv = nullptr;
+
+    if (riid == __uuidof(IUnknown)) {
+        *ppv = reinterpret_cast<IUnknown*>(this);
+    }
+
+    if (riid == __uuidof(IStream)) {
+        *ppv = reinterpret_cast<IStream*>(this);
+    }
+
+    if (riid == __uuidof(IPersistStream)) {
+        *ppv = static_cast<IPersistStream*>(this);
+    }
+
+    if (*ppv == nullptr) {
+        return E_NOINTERFACE;
+    }
+
+    /**
+     *  Increment the reference count and return the pointer.
+     */
+    reinterpret_cast<IUnknown*>(*ppv)->AddRef();
+
+    return S_OK;
+}
+
+
+/**
+ *  Increments the reference count for an interface pointer to a COM object.
+ *
+ *  @author: CCHyper
+ */
+ULONG RocketTypeClass::AddRef()
+{
+    //EXT_DEBUG_TRACE("RocketTypeClass::AddRef - 0x%08X\n", (uintptr_t)(this));
+
+    return 1;
+}
+
+
+/**
+ *  Decrements the reference count for an interface on a COM object.
+ *
+ *  @author: CCHyper
+ */
+ULONG RocketTypeClass::Release()
+{
+    //EXT_DEBUG_TRACE("RocketTypeClass::Release - 0x%08X\n", (uintptr_t)(this));
+
+    return 1;
+}
+
+
+/**
+ *  Retrieves the class identifier (CLSID) of the object.
+ *
+ *  @author: CCHyper
+ */
+HRESULT RocketTypeClass::GetClassID(CLSID* lpClassID)
+{
+    //EXT_DEBUG_TRACE("RocketTypeClass::GetClassID - Name: %s (0x%08X)\n", Name(), (uintptr_t)(this));
+
+    if (lpClassID == nullptr) {
+        return E_POINTER;
+    }
+
+    *lpClassID = __uuidof(this);
+
+    return S_OK;
+}
+
+
+/**
+ *  Determines whether an object has changed since it was last saved to its stream.
+ *
+ *  @author: CCHyper
+ */
+HRESULT RocketTypeClass::IsDirty()
+{
+    //EXT_DEBUG_TRACE("RocketTypeClass::IsDirty - 0x%08X\n", (uintptr_t)(this));
+
+    return S_OK;
+}
+
+
+/**
+ *  Loads the object from the stream and requests a new pointer to
+ *  the class we extended post-load.
+ *
+ *  @author: ZivDero, CCHyper, tomsons26
+ */
+HRESULT RocketTypeClass::Load(IStream* pStm)
+{
+    //EXT_DEBUG_TRACE("RocketTypeClass::Load - 0x%08X\n", (uintptr_t)(this));
+
+    if (!pStm) {
+        return E_POINTER;
+    }
+
+    /**
+     *  Load the unique id for this class.
+     */
+    LONG id = 0;
+    HRESULT hr = pStm->Read(&id, sizeof(LONG), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Register this instance to be available for remapping references to.
+     */
+    VINIFERA_SWIZZLE_REGISTER_POINTER(id, this, IniName);
+
+    /**
+     *  Read this class's binary blob data directly into this instance.
+     */
+    hr = pStm->Read(this, sizeof(*this), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Type, "Type");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Warhead, "Warhead");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(EliteWarhead, "EliteWarhead");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(TakeoffAnim, "TakeoffAnim");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(TrailAnim, "TrailAnim");
+
+    return hr;
+}
+
+
+/**
+ *  Saves the object to the stream.
+ *
+ *  @author: CCHyper, tomsons26
+ */
+HRESULT RocketTypeClass::Save(IStream* pStm, BOOL fClearDirty)
+{
+    //EXT_DEBUG_TRACE("RocketTypeClass::Internal_Save - 0x%08X\n", (uintptr_t)(this));
+
+    if (!pStm) {
+        return E_POINTER;
+    }
+
+    /**
+     *  Fetch the save id for this instance.
+     */
+    const LONG id = reinterpret_cast<LONG>(this);
+
+    //DEV_DEBUG_INFO("Writing id = 0x%08X.\n", id);
+
+    HRESULT hr = pStm->Write(&id, sizeof(id), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    /**
+     *  Write this class instance as a binary blob.
+     */
+    hr = pStm->Write(this, sizeof(*this), nullptr);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Retrieves the size of the stream needed to save the object.
+ *
+ *  @author: CCHyper, tomsons26
+ */
+LONG RocketTypeClass::GetSizeMax(ULARGE_INTEGER* pcbSize)
+{
+    //EXT_DEBUG_TRACE("RocketTypeClass::GetSizeMax - 0x%08X\n", (uintptr_t)(this));
+
+    if (!pcbSize) {
+        return E_POINTER;
+    }
+
+    pcbSize->LowPart = sizeof(*this) + sizeof(uint32_t); // Add size of swizzle "id".
+    pcbSize->HighPart = 0;
+
+    return S_OK;
+}
+
+
+/**
+ *  Retrieves the RocketType for given name.
+ *
+ *  @author: ZivDero
+ */
+RocketType RocketTypeClass::From_Name(const char *name)
+{
+    ASSERT(name != nullptr);
+
+    if (name != nullptr) {
+        for (RocketType Rocket = ROCKET_FIRST; Rocket < RocketTypes.Count(); Rocket++) {
+            if (std::strncmp(RocketTypes[Rocket]->IniName, name, sizeof(IniName)) == 0) {
+                return Rocket;
+            }
+        }
+    }
+
+    return ROCKET_NONE;
+}
+
+
+/**
+ *  Returns name for given Rocket type.
+ *
+ *  @author: ZivDero
+ */
+const char *RocketTypeClass::Name_From(RocketType type)
+{
+    ASSERT(type >= ROCKET_FIRST && type < RocketTypes.Count());
+
+    return RocketTypes[type]->IniName;
+}
+
+
+/**
+ *  Find the rocket that has this aircraft as its type.
+ *
+ *  @author: ZivDero
+ */
+const RocketTypeClass* RocketTypeClass::From_AircraftType(const AircraftTypeClass* type)
+{
+    if (!type)
+        return nullptr;
+
+    for (RocketType rocket = ROCKET_FIRST; rocket < RocketTypes.Count(); rocket++) {
+        if (RocketTypes[rocket]->Type == type) {
+            return RocketTypes[rocket];
+        }
+    }
+
+    return nullptr;
+}
+
+
+/**
+ *  Find or create a Rocket of the type specified.
+ *
+ *  @author: ZivDero
+ */
+const RocketTypeClass *RocketTypeClass::Find_Or_Make(const char *name)
+{
+    ASSERT(name != nullptr);
+
+    for (RocketType rocket = ROCKET_FIRST; rocket < RocketTypes.Count(); rocket++) {
+        if (std::strncmp(RocketTypes[rocket]->IniName, name, sizeof(IniName)) == 0) {
+            return RocketTypes[rocket];
+        }
+    }
+
+    RocketTypeClass *ptr = new RocketTypeClass(name);
+    ASSERT(ptr != nullptr);
+    return ptr;
+}
+
+
+/**
+ *  Reads Rocket object data from an INI file.
+ *
+ *  @author: ZivDero
+ */
+bool RocketTypeClass::Read_INI(CCINIClass& ini)
+{
+    if (!ini.Is_Present(IniName)) {
+        return false;
+    }
+
+    PauseFrames = ini.Get_Int(IniName, "PauseFrames", PauseFrames);
+    TiltFrames = ini.Get_Int(IniName, "TiltFrames", TiltFrames);
+    PitchInitial = ini.Get_Double(IniName, "PitchInitial", PitchInitial);
+    PitchFinal = ini.Get_Double(IniName, "PitchFinal", PitchFinal);
+    TurnRate = ini.Get_Double(IniName, "TurnRate", TurnRate);
+    RaiseRate = ini.Get_Int(IniName, "RaiseRate", RaiseRate);
+    Acceleration = ini.Get_Double(IniName, "Acceleration", Acceleration);
+    Altitude = ini.Get_Int(IniName, "Altitude", Altitude);
+    Damage = ini.Get_Int(IniName, "Damage", Damage);
+    EliteDamage = ini.Get_Int(IniName, "EliteDamage", EliteDamage);
+    BodyLength = ini.Get_Int(IniName, "BodyLength", BodyLength);
+    IsLazyCurve = ini.Get_Bool(IniName, "LazyCurve", IsLazyCurve);
+    IsCruiseMissile = ini.Get_Bool(IniName, "CruiseMissile", IsCruiseMissile);
+    Type = ini.Get_Aircraft(IniName, "Type", Type);
+    Warhead = ini.Get_Warhead(IniName, "Warhead", Warhead);
+    EliteWarhead = ini.Get_Warhead(IniName, "EliteWarhead", EliteWarhead);
+    TakeoffAnim = ini.Get_Anim(IniName, "TakeoffAnim", TakeoffAnim);
+    TrailAnim = ini.Get_Anim(IniName, "TrailAnim", TrailAnim);
+
+    return true;
+}

--- a/src/new/rockettype/rockettype.h
+++ b/src/new/rockettype/rockettype.h
@@ -8,7 +8,7 @@
  *
  *  @authors       ZivDero
  *
- *  @brief         Class containing condiguration for spawned rockets.
+ *  @brief         Class containing configuration for AircraftType rockets.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License

--- a/src/new/rockettype/rockettype.h
+++ b/src/new/rockettype/rockettype.h
@@ -1,0 +1,168 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          ROCKETTYPE.H
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         Class containing condiguration for spawned rockets.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once 
+
+#include "always.h"
+#include "tibsun_defines.h"
+#include "vinifera_defines.h"
+#include "verses.h"
+#include "wstring.h"
+
+class CCINIClass;
+
+
+enum RocketType
+{
+    ROCKET_FIRST = 0,
+    ROCKET_NONE = -1
+};
+DEFINE_ENUMERATION_OPERATORS(RocketType);
+
+
+class DECLSPEC_UUID(UUID_ROCKETTYPE)
+RocketTypeClass final : IPersistStream
+{
+public:
+    /**
+     *  IUnknown
+     */
+    IFACEMETHOD(QueryInterface)(REFIID riid, LPVOID* ppvObj);
+    IFACEMETHOD_(ULONG, AddRef)();
+    IFACEMETHOD_(ULONG, Release)();
+
+    /**
+     *  IPersist
+     */
+    IFACEMETHOD(GetClassID)(CLSID* pClassID);
+
+    /**
+     *  IPersistStream
+     */
+    IFACEMETHOD(IsDirty)();
+    IFACEMETHOD(Load)(IStream* pStm);
+    IFACEMETHOD(Save)(IStream* pStm, BOOL fClearDirty);
+    IFACEMETHOD_(LONG, GetSizeMax)(ULARGE_INTEGER* pcbSize);
+
+    RocketTypeClass();
+    RocketTypeClass(const char *name);
+    virtual ~RocketTypeClass();
+
+    char const* Name() const { return IniName; }
+    bool Read_INI(CCINIClass& ini);
+
+    static RocketType From_Name(const char *name);
+    static const char *Name_From(RocketType type);
+
+    static const RocketTypeClass *From_AircraftType(const AircraftTypeClass *type);
+    static const RocketTypeClass *Find_Or_Make(const char *name);
+
+private:
+    /**
+     *  The name of this rocket type, used for identification purposes.
+     */
+    char IniName[256];
+
+public:
+    /**
+     *  How many frames the rocket pauses on the launcher before tilting?
+     */
+    int PauseFrames;
+
+    /**
+     *  How many frames it takes for the rocket to tilt to firing position?
+     */
+    int TiltFrames;
+
+    /**
+     *  Starting pitch of the rocket before tilting up (0 = horizontal, 1 = vertical).
+     */
+    double PitchInitial;
+
+    /**
+     *  Ending pitch of the rocket after tilting up, now it fires.
+     */
+    double PitchFinal;
+
+    /**
+     *  Pitch maneuverability of rocket in air.
+     */
+    double TurnRate;
+
+    /**
+     *  How much the missile will raise each turn on the launcher (for Cruise Missile only)
+     */
+    LEPTON RaiseRate;
+
+    /**
+     *  This much is added to the rocket's velocity each frame during launch.
+     */
+    double Acceleration;
+
+    /**
+     *  Cruising altitude in leptons: at this height rocket BEGINS leveling off.
+     */
+    int Altitude;
+
+    /**
+     *  The rocket does this much damage when it explodes.
+     */
+    int Damage;
+    int EliteDamage;
+
+    /**
+     *  The body of the rocket is this many leptons long.
+     */
+    LEPTON BodyLength;
+
+    /**
+     *  The rocket's path is a big, lazy curve, like the V3 in Red Alert 2.
+     */
+    bool IsLazyCurve;
+
+    /**
+     *  The rocket is a cruise missile and instead of tilting, rises a bit before shooting off vertically, like the Boomer sub missiles in Red Alert 2.
+     */
+    bool IsCruiseMissile;
+
+    /**
+     *  The AircraftType of this rocket.
+     */
+    const AircraftTypeClass* Type;
+
+    /**
+     *  The warhead used when this rocket explodes.
+     */
+    const WarheadTypeClass* Warhead;
+    const WarheadTypeClass* EliteWarhead;
+
+    /**
+     *  Takeoff and trail animations that this rocket uses.
+     */
+    const AnimTypeClass* TakeoffAnim;
+    const AnimTypeClass* TrailAnim;
+};

--- a/src/new/spawnmanager/spawnmanager.cpp
+++ b/src/new/spawnmanager/spawnmanager.cpp
@@ -443,7 +443,7 @@ void SpawnManagerClass::AI()
                     break;
 
                 /**
-                 *  If there's not target, return to base.
+                 *  If there's no target, return to base.
                  */
                 Next_Target();
                 if (Target != nullptr)

--- a/src/new/spawnmanager/spawnmanager.cpp
+++ b/src/new/spawnmanager/spawnmanager.cpp
@@ -446,23 +446,23 @@ void SpawnManagerClass::AI()
                  *  If there's no target, return to base.
                  */
                 Next_Target();
-                if (Target != nullptr)
+                if (!Target)
                 {
                     spawnee->Assign_Destination(Owner);
                     spawnee->Assign_Target(nullptr);
                     spawnee->Assign_Mission(MISSION_MOVE);
                     spawnee->Commence();
                     control->Status = SpawnControlStatus::Returning;
-                    break;
                 }
-
                 /**
                  *  Send the aircraft to attack.
                  */
-                CellClass* owner_cell = Owner->Get_Cell_Ptr();
-                CellClass* adjacent_cell = &owner_cell->Adjacent_Cell(FACING_S);
-                spawnee->Assign_Destination(adjacent_cell);
-                spawnee->Assign_Mission(MISSION_MOVE);
+                else
+                {
+                    CellClass* adjacent_cell = &Owner->Get_Cell_Ptr()->Adjacent_Cell(FACING_S);
+                    spawnee->Assign_Destination(adjacent_cell);
+                    spawnee->Assign_Mission(MISSION_MOVE);
+                }
                 break;
             }
 

--- a/src/new/spawnmanager/spawnmanager.cpp
+++ b/src/new/spawnmanager/spawnmanager.cpp
@@ -518,7 +518,7 @@ void SpawnManagerClass::AI()
                 Cell owner_coord = Owner->Get_Cell();
                 Cell spawnee_coord = spawnee->Get_Cell();
 
-                if (owner_coord == spawnee_coord && spawnee->Coord.Z - Owner->Coord.Z < 20)
+                if (owner_coord == spawnee_coord && std::abs(spawnee->Coord.Z - Owner->Coord.Z) < 20)
                 {
                     spawnee->Limbo();
                     control->Status = SpawnControlStatus::Reloading;

--- a/src/new/spawnmanager/spawnmanager.cpp
+++ b/src/new/spawnmanager/spawnmanager.cpp
@@ -1,0 +1,953 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          SPAWNMANAGER.CPP
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         SpawnManagerClass reimplementation from YR.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include "spawnmanager.h"
+
+#include "aircraft.h"
+#include "aircraftext.h"
+#include "aircrafttype.h"
+#include "aircrafttypeext.h"
+#include "anim.h"
+#include "animtype.h"
+#include "cell.h"
+#include "extension.h"
+#include "ionstorm.h"
+#include "kamikazetracker/kamikazetracker.h"
+#include "tibsun_inline.h"
+#include "tibsun_globals.h"
+#include "vinifera_globals.h"
+#include "weapontype.h"
+#include "weapontypeext.h"
+#include "rockettype.h"
+#include "vinifera_saveload.h"
+
+
+/**
+  *  Retrieves the class identifier (CLSID) of the object.
+  *
+  *  @author: ZivDero
+  */
+IFACEMETHODIMP SpawnManagerClass::GetClassID(CLSID* pClassID)
+{
+    if (pClassID == nullptr) {
+        return E_POINTER;
+    }
+
+    *pClassID = __uuidof(this);
+
+    return S_OK;
+}
+
+/**
+ *  Initializes an object from the stream where it was saved previously.
+ *
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP SpawnManagerClass::Load(IStream* pStm)
+{
+    HRESULT hr = Abstract_Load(pStm);
+    if (FAILED(hr))
+        return hr;
+
+    new (this) SpawnManagerClass(NoInitClass());
+
+    /**
+     *  Read the count of active spawn controls.
+     */
+    hr = pStm->Read(&SpawnCount, sizeof(SpawnCount), nullptr);
+    if (FAILED(hr))
+        return hr;
+
+    new (&SpawnControls) DynamicVectorClass<SpawnControl*>();
+
+    if (SpawnCount <= 0)
+        return hr;
+
+    /**
+     *  Read each of the controls as a binary blob.
+     */
+    for (int index = 0; index < SpawnCount; ++index)
+    {
+        const auto control = new SpawnControl;
+        hr = pStm->Read(control, sizeof(SpawnControl), nullptr);
+        if (FAILED(hr))
+            return hr;
+        SpawnControls.Add(control);
+    }
+
+    for (int i = 0; i < SpawnCount; i++)
+        VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(SpawnControls[i]->Spawnee, "Spawnee");
+
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Owner, "Owner");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(SpawnType, "SpawnType");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Target, "SuspendedTarget");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(QueuedTarget, "Target");
+
+    return hr;
+}
+
+
+/**
+ *  Saves an object to the specified stream.
+ *
+ *  @author: ZivDero
+ */
+IFACEMETHODIMP SpawnManagerClass::Save(IStream* pStm, BOOL fClearDirty)
+{
+    HRESULT hr = Abstract_Save(pStm, fClearDirty);
+    if (FAILED(hr))
+        return hr;
+
+    /**
+     *  Write the count of active spawn controls.
+     */
+    hr = pStm->Write(&SpawnCount, sizeof(SpawnCount), nullptr);
+    if (FAILED(hr))
+        return hr;
+
+    if (SpawnCount <= 0)
+        return hr;
+
+    /**
+     *  Write each of the controls as a binary blob.
+     */
+    for (int index = 0; index < SpawnCount; ++index)
+    {
+        hr = pStm->Write(SpawnControls[index], sizeof(SpawnControl), nullptr);
+        if (FAILED(hr))
+            return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Basic constructor for the SpawnManagerClass.
+ *
+ *  @author: ZivDero
+ */
+SpawnManagerClass::SpawnManagerClass() :
+    Owner(nullptr),
+    SpawnType(nullptr),
+    SpawnCount(0),
+    Target(nullptr),
+    QueuedTarget(nullptr),
+    Status(SpawnManagerStatus::Idle)
+{
+    SpawnManagers.Add(this);
+}
+
+
+/**
+ *  Basic constructor for the SpawnManagerClass.
+ *
+ *  @author: ZivDero
+ */
+SpawnManagerClass::SpawnManagerClass(TechnoClass* owner, const AircraftTypeClass* spawns, int spawn_count, int regen_rate, int reload_rate) :
+    Owner(owner),
+    SpawnType(spawns),
+    SpawnCount(spawn_count),
+    RegenRate(regen_rate),
+    ReloadRate(reload_rate),
+    Target(nullptr),
+    QueuedTarget(nullptr),
+    Status(SpawnManagerStatus::Idle)
+{
+    for (int i = 0; i < SpawnCount; i++)
+    {
+        auto control = new SpawnControl();
+        if (control == nullptr)
+            break;
+
+        auto spawnee = static_cast<AircraftClass*>(SpawnType->Create_One_Of(owner->Owning_House()));
+        control->Spawnee = spawnee;
+
+        if (spawnee != nullptr)
+        {
+            control->IsSpawnedMissile = RocketTypeClass::From_AircraftType(SpawnType) != nullptr;
+            control->Spawnee->Limbo();
+            Extension::Fetch<AircraftClassExtension>(control->Spawnee)->SpawnOwner = Owner;
+            control->Status = SpawnControlStatus::Idle;
+            control->ReloadTimer = 0;
+            SpawnControls.Add(control);
+        }
+    }
+
+    SpawnManagers.Add(this);
+}
+
+
+/**
+ *  Basic destructor for the SpawnManagerClass.
+ *
+ *  @author: ZivDero
+ */
+SpawnManagerClass::~SpawnManagerClass()
+{
+    if (GameActive)
+        Detach_Spawns();
+
+    for (int i = SpawnControls.Count() - 1; i >= 0; i--)
+    {
+        if (SpawnControls[i] != nullptr)
+            delete SpawnControls[i];
+    }
+
+    SpawnManagers.Delete(this);
+}
+
+
+/**
+ *  Returns the RTTI type of the object.
+ *
+ *  @author: ZivDero
+ */
+RTTIType SpawnManagerClass::Kind_Of() const
+{
+    return static_cast<RTTIType>(RTTI_SPAWN_MANAGER);
+}
+
+
+/**
+ *  Returns the size of the object.
+ *
+ *  @author: ZivDero
+ */
+int SpawnManagerClass::Size_Of(bool firestorm) const
+{
+    return sizeof(*this);
+}
+
+
+/**
+ *  Computes the CRC of the object.
+ *
+ *  @author: ZivDero
+ */
+void SpawnManagerClass::Compute_CRC(WWCRCEngine& crc) const
+{
+    AbstractClass::Compute_CRC(crc);
+
+    crc(static_cast<int>(Status));
+
+    if (QueuedTarget != nullptr)
+        crc(QueuedTarget->Get_Heap_ID());
+
+    if (Target != nullptr)
+        crc(Target->Get_Heap_ID());
+
+    crc(SpawnTimer.Value());
+    crc(LogicTimer.Value());
+    crc(SpawnControls.Count());
+    crc(SpawnCount);
+
+    if (SpawnType != nullptr)
+        crc(SpawnType->Get_Heap_ID());
+
+    if (Owner != nullptr)
+        crc(Owner->Get_Heap_ID());
+}
+
+
+/**
+ *  Performs all the main SpawnManager logic.
+ *
+ *  @author: ZivDero
+ */
+void SpawnManagerClass::AI()
+{
+    /**
+     *  The spawner only does logic every 10 frames.
+     */
+    if (!LogicTimer.Expired())
+        return;
+
+    LogicTimer = 10;
+
+    /**
+     *  Iterate all the controls.
+     */
+    for (int i = 0; i < SpawnControls.Count(); i++)
+    {
+        SpawnControl* control = SpawnControls[i];
+        AircraftClass* spawnee = control->Spawnee;
+        const auto owner_ext = Extension::Fetch<TechnoClassExtension>(Owner);
+        const auto owner_type_ext = Extension::Fetch<TechnoTypeClassExtension>(Owner->Techno_Type_Class());
+
+        switch (control->Status)
+        {
+            /**
+             *  The spawn is currently idle.
+             */
+        case SpawnControlStatus::Idle:
+            {
+                /**
+                 *  If we don't have a target, no need to do anything about it.
+                 */
+                if (!Target)
+                    continue;
+
+                /**
+                 *  If it's not yet time to respawn, skip.
+                 */
+                if (!SpawnTimer.Expired())
+                    continue;
+
+                /**
+                 *  If we're on cooldown.
+                 */
+                if (Status == SpawnManagerStatus::Cooldown)
+                    continue;
+
+                /**
+                 *  No spawning during an Ion Storm.
+                 */
+                if (IonStorm_Is_Active())
+                    continue;
+
+                /**
+                 *  If the spawner can move (i. e. is not a building), don't allow spawning while it's on the move.
+                 */
+                if (control->IsSpawnedMissile && Owner->Is_Foot())
+                {
+                    if (static_cast<FootClass*>(Owner)->Locomotion->Is_Moving() || static_cast<FootClass*>(Owner)->Locomotion->Is_Moving_Now())
+                        continue;
+                }
+
+                /**
+                 *  Not quite sure what's up here.
+                 *  Maybe should check the missile instead, huh?
+                 */
+                SpawnTimer = owner_type_ext->IsMissileSpawn ? 9 : 20;
+
+                /**
+                 *  We can spawn 2 missiles using the burst logic.
+                 */
+                const auto weapon = Owner->Get_Weapon(WEAPON_SLOT_PRIMARY)->Weapon;
+                if (control->IsSpawnedMissile && weapon->Burst > 1 && i < weapon->Burst)
+                    Owner->CurrentBurstIndex = i;
+                else
+                    Owner->CurrentBurstIndex = 0;
+
+                /**
+                 *  Update our status.
+                 */
+                control->Status = SpawnControlStatus::Preparing;
+
+                WeaponSlotType weapon_slot = Extension::Fetch<WeaponTypeClassExtension>(Owner->Get_Weapon(WEAPON_SLOT_PRIMARY)->Weapon)->IsSpawner ? WEAPON_SLOT_PRIMARY : WEAPON_SLOT_SECONDARY;
+
+                /**
+                 *  Apply SecondSpawnOffset if this is the second missile in a burst.
+                 */
+                Coordinate fire_coord;
+                if (Owner->CurrentBurstIndex % 2 == 0)
+                    fire_coord = owner_ext->Fire_Coord(weapon_slot);
+                else
+                    fire_coord = owner_ext->Fire_Coord(weapon_slot, owner_type_ext->SecondSpawnOffset);
+
+                Coordinate spawn_coord = Coordinate(fire_coord.X, fire_coord.Y, fire_coord.Z + 10);
+
+                const auto rocket = RocketTypeClass::From_AircraftType(SpawnType);
+                if (rocket && rocket->IsCruiseMissile)
+                {
+                    spawn_coord.X -= 40;
+                    spawn_coord.Y -= 40;
+                }
+
+                /**
+                 *  Place the spawn in the world.
+                 */
+                DirStruct dir = Owner->PrimaryFacing.Current();
+                spawnee->Unlimbo(spawn_coord, dir.Get_Dir());
+
+                /**
+                 *  Cruise missiles spawn their takeoff animation.
+                 */
+                if (rocket && rocket->IsCruiseMissile && rocket->TakeoffAnim)
+                    new AnimClass(rocket->TakeoffAnim, spawnee->Coord, 2, 1, SHAPE_WIN_REL | SHAPE_CENTER, -10);
+
+                /**
+                 *  Reset burst since if we're done with this volley.
+                 */
+                if (i == SpawnControls.Count() - 1)
+                    Owner->CurrentBurstIndex = 0;
+
+                /**
+                 *  Missiles only take a destination once, so they go straight to the target.
+                 */
+                if (control->IsSpawnedMissile)
+                {
+                    Next_Target();
+                    spawnee->Assign_Destination(Target);
+                    spawnee->Assign_Mission(MISSION_MOVE);
+                }
+                /**
+                 *  Aircraft first "organize" next to the spawner.
+                 */
+                else
+                {
+                    CellClass* owner_cell = Owner->Get_Cell_Ptr();
+                    CellClass* adjacent_cell = &owner_cell->Adjacent_Cell(FACING_S);
+                    spawnee->Assign_Destination(adjacent_cell);
+                    spawnee->Assign_Mission(MISSION_MOVE);
+                }
+
+                break;
+            }
+
+            /**
+             *  The rocket is taking off (handled by the locomotor), so wait until it's done, then let it go.
+             */
+        case SpawnControlStatus::Takeoff:
+            {
+                if (control->ReloadTimer.Expired())
+                    Detach(spawnee);
+                break;
+            }
+
+            /**
+             *  The aircraft is preparing to attack.
+             */
+        case SpawnControlStatus::Preparing:
+            {
+                /**
+                 *  Missiles don't do this.
+                 */
+                if (control->IsSpawnedMissile)
+                    break;
+
+                /**
+                 *  If there's not target, return to base.
+                 */
+                Next_Target();
+                if (Target != nullptr)
+                {
+                    spawnee->Assign_Destination(Owner);
+                    spawnee->Assign_Target(nullptr);
+                    spawnee->Assign_Mission(MISSION_MOVE);
+                    spawnee->Commence();
+                    control->Status = SpawnControlStatus::Returning;
+                    break;
+                }
+
+                /**
+                 *  Send the aircraft to attack.
+                 */
+                CellClass* owner_cell = Owner->Get_Cell_Ptr();
+                CellClass* adjacent_cell = &owner_cell->Adjacent_Cell(FACING_S);
+                spawnee->Assign_Destination(adjacent_cell);
+                spawnee->Assign_Mission(MISSION_MOVE);
+                break;
+            }
+
+            /**
+             *  The aircraft is currently attacking.
+             */
+        case SpawnControlStatus::Attacking:
+            {
+                /**
+                 *  If there's still ammo and a target, attack.
+                 */
+                Next_Target();
+                if (spawnee->Ammo > 0 && Target)
+                {
+                    spawnee->Assign_Target(Target);
+                    spawnee->Assign_Mission(MISSION_ATTACK);
+                }
+                /**
+                 *  Otherwise, return to base.
+                 */
+                else
+                {
+                    spawnee->Assign_Destination(Owner);
+                    spawnee->Assign_Target(nullptr);
+                    spawnee->Assign_Mission(MISSION_MOVE);
+                    control->Status = SpawnControlStatus::Returning;
+                }
+                break;
+            }
+
+            /**
+             *  The aircraft is retuning back to the spawner.
+             */
+        case SpawnControlStatus::Returning:
+            {
+                /**
+                 *  Check if we've got ammo and there's a target now.
+                 *  If so, attack it.
+                 */
+                Next_Target();
+                if (spawnee->Ammo > 0 && Target)
+                {
+                    control->Status = SpawnControlStatus::Attacking;
+                    spawnee->Assign_Target(Target);
+                    spawnee->Assign_Mission(MISSION_ATTACK);
+                    break;
+                }
+
+                /**
+                 *  If we've arrived at the spawner, "land" (despawn).
+                 *  Otherwise, keep going towards the spawner.
+                 */
+                Cell owner_coord = Owner->Get_Cell();
+                Cell spawnee_coord = spawnee->Get_Cell();
+
+                if (owner_coord == spawnee_coord && spawnee->Coord.Z - Owner->Coord.Z < 20)
+                {
+                    spawnee->Limbo();
+                    control->Status = SpawnControlStatus::Reloading;
+                    control->ReloadTimer = ReloadRate;
+                }
+                else
+                {
+                    spawnee->Assign_Destination(Owner);
+                    spawnee->Assign_Target(nullptr);
+                    spawnee->Assign_Mission(MISSION_MOVE);
+                }
+
+                break;
+            }
+
+            /**
+             *  The aircraft has expended its ammo and is reloading.
+             */
+        case SpawnControlStatus::Reloading:
+            {
+                /**
+                 *  Wait until the reload timer expires.
+                 */
+                if (!control->ReloadTimer.Expired())
+                    break;
+
+                /**
+                 *  Then reset the spawn to max ammo and health.
+                 */
+                control->Status = SpawnControlStatus::Idle;
+                spawnee->Ammo = spawnee->Class->MaxAmmo;
+                spawnee->Strength = spawnee->Class->MaxStrength;
+                break;
+            }
+
+            /**
+             *  The spawn has been destroyed and is respawning.
+             */
+        case SpawnControlStatus::Dead:
+            {
+                /**
+                 *  Wait until the reload timer expires.
+                 */
+                if (!control->ReloadTimer.Expired())
+                    break;
+
+                /**
+                 *  Create a new spawn and set it to idle.
+                 */
+                control->Spawnee = static_cast<AircraftClass*>(SpawnType->Create_One_Of(Owner->Owning_House()));
+                control->IsSpawnedMissile = RocketTypeClass::From_AircraftType(SpawnType) != nullptr;
+                control->Spawnee->Limbo();
+                Extension::Fetch<AircraftClassExtension>(control->Spawnee)->SpawnOwner = Owner;
+                control->Status = SpawnControlStatus::Idle;
+                break;
+            }
+        }
+    }
+
+    /**
+     *  If the spawner is currently idling, check if there's a target.
+     *  If there is one, and it's in range, attack it.
+     */
+    if (Status == SpawnManagerStatus::Idle)
+    {
+        Next_Target();
+        if (Target)
+        {
+            WeaponSlotType weapon = Owner->What_Weapon_Should_I_Use(Target);
+            if (Owner->In_Range_Of(Target, weapon))
+                Status = SpawnManagerStatus::Launching;
+            else
+                Abandon_Target();
+        }
+    }
+    else if (Status == SpawnManagerStatus::Launching)
+    {
+        /**
+         *  If we're launching spawns, but there isn't a target anymore, stop it.
+         */
+        if (Target == nullptr)
+        {
+            Abandon_Target();
+            return;
+        }
+
+        /**
+         *  Check to make sure all of our spawns are currently preparing to launch.
+         *  This should only happen when the spawns are missiles, I believe.
+         */
+        for (int i = 0; i < SpawnControls.Count(); i++)
+        {
+            const SpawnControl* control = SpawnControls[i];
+            if (control->Status != SpawnControlStatus::Preparing && control->Status != SpawnControlStatus::Dead)
+                return;
+        }
+
+        /**
+         *  Process all our missiles.
+         */
+        bool is_missile_launcher = false;
+        for (int i = 0; i < SpawnControls.Count(); i++)
+        {
+            SpawnControl* control = SpawnControls[i];
+            AircraftClass* spawnee = control->Spawnee;
+
+            /**
+             *  Don't process dead spawns.
+             */
+            if (control->Status == SpawnControlStatus::Preparing)
+            {
+                /**
+                 *  If the spawn is a missile, add it to the kamikaze tracker and set it to take off.
+                 *  Also set the reload timer to the missile's takeoff time.
+                 */
+                if (Extension::Fetch<AircraftTypeClassExtension>(spawnee->Techno_Type_Class())->IsMissileSpawn)
+                {
+                    is_missile_launcher = true;
+                    KamikazeTracker->Add(spawnee, Target);
+                    KamikazeTracker->UpdateTimer = 2;
+
+                    if (control->IsSpawnedMissile)
+                    {
+                        control->Status = SpawnControlStatus::Takeoff;
+                        const auto atype = control->Spawnee->Class;
+                        const RocketTypeClass* rocket = RocketTypeClass::From_AircraftType(atype);
+                        control->ReloadTimer = rocket->IsCruiseMissile ? 0 : rocket->PauseFrames + rocket->TiltFrames;
+                    }
+                    else
+                    {
+                        Detach(spawnee);
+                    }
+                }
+                /**
+                 *  On the off chance it's not a missile, just set it to attack.
+                 */
+                else
+                {
+                    control->Status = SpawnControlStatus::Attacking;
+                    spawnee->Assign_Target(Target);
+                    spawnee->Assign_Mission(MISSION_ATTACK);
+                }
+            }
+        }
+
+        /**
+         *  If this is a missile launcher,
+         *  abandon the target.
+         */
+        if (is_missile_launcher)
+            Abandon_Target();
+
+        /**
+         *  Phew, time to go on cooldown.
+         */
+        Status = SpawnManagerStatus::Cooldown;
+    }
+    /**
+     *  If we're on cooldown, check if any of the spawns are currently attacking or returning.
+     *  If they are, change the status to idle instead.
+     */
+    else if (Status == SpawnManagerStatus::Cooldown)
+    {
+        bool is_idle = true;
+        for (int i = 0; i < SpawnControls.Count(); i++)
+        {
+            SpawnControl* control = SpawnControls[i];
+            if (control->Status == SpawnControlStatus::Attacking || control->Status == SpawnControlStatus::Returning)
+            {
+                is_idle = false;
+                break;
+            }
+        }
+
+        if (is_idle)
+            Status = SpawnManagerStatus::Idle;
+    }
+}
+
+
+/**
+ *  Removes any spawns that are not currently in flight, and sends the rest into kamikaze mode.
+ *
+ *  @author: ZivDero
+ */
+void SpawnManagerClass::Detach_Spawns()
+{
+    int regen_rate = Owner->Strength > 0 && Owner->IsActive ? 0 : RegenRate;
+
+    /**
+     *  Iterate all the spawns.
+     */
+    for (int i = 0; i < SpawnControls.Count(); i++)
+    {
+        /**
+         *  Don't need to do anything about dead spawns.
+         */
+        SpawnControl* control = SpawnControls[i];
+        if (control->Status == SpawnControlStatus::Dead)
+            continue;
+
+        /**
+         *  If it's currently docked, just kill it off. It's already limboed.
+         */
+        if (control->Status == SpawnControlStatus::Idle || control->Status == SpawnControlStatus::Reloading)
+        {
+            control->Status = SpawnControlStatus::Dead;
+            control->Spawnee->Remove_This();
+        }
+        else
+        {
+            /**
+             *  If it's a rocket taking off, detach it and remove it from the world.
+             */
+            if (control->Status == SpawnControlStatus::Takeoff)
+            {
+                KamikazeTracker->Detach(control->Spawnee);
+                control->Status = SpawnControlStatus::Dead;
+                control->Spawnee->Remove_This();
+            }
+            /**
+             *  Otherwise it's probably currently in flight, so just detach it.
+             */
+            else
+            {
+                control->Status = SpawnControlStatus::Dead;
+                KamikazeTracker->Add(control->Spawnee, Target);
+            }
+        }
+
+        /**
+         *  Set the spawn to regenerate.
+         */
+        control->Spawnee = nullptr;
+        control->ReloadTimer = regen_rate;
+    }
+}
+
+
+/**
+ *  Assigns a new target.
+ *
+ *  @author: ZivDero
+ */
+void SpawnManagerClass::Queue_Target(TARGET target)
+{
+    if (target != Target)
+        QueuedTarget = target;
+}
+
+
+/**
+ *  Managers the kamikaze spawns.
+ *
+ *  @author: ZivDero
+ */
+void SpawnManagerClass::Abandon_Target()
+{
+    /**
+     *  Loop all the spawns. If any of them are currently preparing to attack, drop them.
+     */
+    for (int i = 0; i < SpawnControls.Count(); ++i)
+    {
+        SpawnControl* control = SpawnControls[i];
+        if (control->Status == SpawnControlStatus::Preparing)
+        {
+            const auto extension = Extension::Fetch<AircraftTypeClassExtension>(control->Spawnee->Techno_Type_Class());
+            if (extension->IsMissileSpawn)
+            {
+                KamikazeTracker->Add(control->Spawnee, Target);
+                KamikazeTracker->UpdateTimer = 2;
+                Detach(control->Spawnee);
+            }
+        }
+    }
+
+    /**
+     *  Set the status to idle and remove any targets.
+     */
+    Status = SpawnManagerStatus::Idle;
+    QueuedTarget = nullptr;
+    Target = nullptr;
+}
+
+
+/**
+ *  Suspends the current target.
+ *
+ *  @author: ZivDero
+ */
+bool SpawnManagerClass::Next_Target()
+{
+    if (QueuedTarget == nullptr)
+        return false;
+
+    Target = QueuedTarget;
+    QueuedTarget = nullptr;
+    return true;
+}
+
+
+/**
+ *  Detaches an object from the SpawnManager.
+ *
+ *  @author: ZivDero
+ */
+void SpawnManagerClass::Detach(TARGET target)
+{
+    /**
+     *  If it's the suspended target, remove it.
+     *  If we don't have any more targets, stop attacking.
+     */
+    if (Target == target)
+    {
+        Target = nullptr;
+
+        if (!QueuedTarget)
+            Abandon_Target();
+    }
+    /**
+     *  If it's the current target, remove it.
+     */
+    else if (QueuedTarget == target)
+    {
+        QueuedTarget = nullptr;
+    }
+    else
+    {
+        /**
+         *  Check if it's one of the spawns. If so, remove it.
+         */
+        for (int i = 0; i < SpawnControls.Count(); i++)
+        {
+            const auto control = SpawnControls[i];
+            if (control->Spawnee == target)
+            {
+                if (control->Spawnee->Strength <= 0 || control->Spawnee->IsKamikaze || control->IsSpawnedMissile)
+                {
+                    control->Spawnee = nullptr;
+                    control->Status = SpawnControlStatus::Dead;
+                    control->ReloadTimer = RegenRate;
+                }
+
+                break;
+            }
+        }
+
+        /**
+         *  lastly, check if it's maybe the owner of the spawner itself.
+         */
+        if (Owner == target)
+        {
+            Detach_Spawns();
+            Abandon_Target();
+        }
+    }
+}
+
+
+/**
+ *  Returns the count of currently active spawns.
+ *
+ *  @author: ZivDero
+ */
+int SpawnManagerClass::Active_Count()
+{
+    int count = 0;
+    for (int i = 0; i < SpawnControls.Count(); i++)
+    {
+        if (SpawnControls[i]->Status != SpawnControlStatus::Dead)
+            count++;
+    }
+    return count;
+}
+
+
+/**
+ *  Returns the count of currently docked spawns.
+ *
+ *  @author: ZivDero
+ */
+int SpawnManagerClass::Docked_Count()
+{
+    int count = 0;
+    for (int i = 0; i < SpawnControls.Count(); i++)
+    {
+        if (SpawnControls[i]->Status == SpawnControlStatus::Reloading ||
+            SpawnControls[i]->Status == SpawnControlStatus::Idle)
+            count++;
+    }
+    return count;
+}
+
+
+/**
+ *  Returns the count of spawns currently preparing to take off.
+ *
+ *  @author: ZivDero
+ */
+int SpawnManagerClass::Preparing_Count()
+{
+    int count = 0;
+    for (int i = 0; i < SpawnControls.Count(); i++)
+    {
+        if (SpawnControls[i]->Status == SpawnControlStatus::Takeoff)
+            count++;
+
+        if (SpawnControls[i]->Status == SpawnControlStatus::Preparing)
+        {
+            const AircraftClass* spawnee = SpawnControls[i]->Spawnee;
+            if (spawnee && !spawnee->IsInLimbo
+                && Extension::Fetch<AircraftTypeClassExtension>(spawnee->Techno_Type_Class())->IsMissileSpawn)
+            {
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+/**
+ *  Removes all SpawnManagers from the game world.
+ *
+ *  @author: ZivDero
+ */
+void SpawnManagerClass::Clear_All()
+{
+    for (int i = 0; i < SpawnManagers.Count(); ++i)
+        delete SpawnManagers[i];
+    
+    SpawnManagers.Clear();
+}

--- a/src/new/spawnmanager/spawnmanager.h
+++ b/src/new/spawnmanager/spawnmanager.h
@@ -1,0 +1,164 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          SPAWNMANAGER.H
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         SpawnManagerClass reimplementation from YR.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "vinifera_defines.h"
+#include "foot.h"
+#include "ttimer.h"
+
+class SpawnManagerClass;
+class AircraftTypeClass;
+class TechnoClass;
+class FrameTimerClass;
+class AircraftClass;
+
+enum class SpawnManagerStatus {
+    Idle = 0,		// no target or out of range
+    Launching = 1,	// a launch in progress
+    Cooldown = 2	// waiting for launch to complete
+};
+
+enum class SpawnControlStatus {
+    Idle = 0,		// docked, waiting for target
+    Takeoff = 1,	// missile tilting and launch
+    Preparing = 2,	// gathering, waiting
+    Attacking = 3,	// attacking until no ammo
+    Returning = 4,	// return to carrier
+    //Unused_5,		// not used
+    Reloading = 6,	// docked, reloading ammo and health
+    Dead = 7		// respawning
+};
+
+
+class DECLSPEC_UUID(CLSID_SPAWN_MANAGER_CLASS)
+    SpawnManagerClass : public AbstractClass
+{
+public:
+    struct SpawnControl
+    {
+        AircraftClass* Spawnee;
+        SpawnControlStatus Status;
+        CDTimerClass<FrameTimerClass> ReloadTimer;
+        bool IsSpawnedMissile;
+    };
+
+    /**
+    *  IPersist
+    */
+    IFACEMETHOD(GetClassID)(CLSID* pClassID);
+
+    /**
+    *  IPersistStream
+    */
+    IFACEMETHOD(Load)(IStream* pStm);
+    IFACEMETHOD(Save)(IStream* pStm, BOOL fClearDirty);
+
+public:
+    SpawnManagerClass();
+    SpawnManagerClass(TechnoClass* owner, const AircraftTypeClass* spawns, int spawn_count, int regen_rate, int reload_rate);
+    SpawnManagerClass(const NoInitClass& noinit) : SpawnControls(noinit), LogicTimer(noinit), SpawnTimer(noinit) {}
+    virtual ~SpawnManagerClass() override;
+
+    /**
+     *  AbstractClass
+     */
+    virtual RTTIType Kind_Of() const override;
+    virtual int Size_Of(bool firestorm = false) const override;
+    virtual void Compute_CRC(WWCRCEngine& crc) const override;
+    virtual void AI() override;
+
+    void Detach_Spawns();
+    void Queue_Target(TARGET target);
+    void Abandon_Target();
+    bool Next_Target();
+    void Detach(TARGET target);
+    int Active_Count();
+    int Docked_Count();
+    int Preparing_Count();
+
+    static void Clear_All();
+
+    SpawnManagerClass(const SpawnManagerClass&) = delete;
+    SpawnManagerClass& operator= (const SpawnManagerClass&) = delete;
+
+public:
+    /**
+     *  The Techno that owns this spawn manager.
+     */
+    TechnoClass* Owner;
+
+    /**
+     *  The AircraftType that this spawn manager spawns.
+     */
+    const AircraftTypeClass* SpawnType;
+
+    /**
+     *  How many spawns this spawn manager can have.
+     */
+    int SpawnCount;
+
+    /**
+     *  How long it takes for a spawn to regenerate.
+     */
+    int RegenRate;
+
+    /**
+     *  How long it takes for a spawn to reload.
+     */
+    int ReloadRate;
+
+    /**
+     *  This vector holds the spawn manager.
+     */
+    DynamicVectorClass<SpawnControl*> SpawnControls;
+
+    /**
+     *  The timer that controls how often the spawn manager should execute its AI function.
+     */
+    CDTimerClass<FrameTimerClass> LogicTimer;
+
+    /**
+     *  The timer that controls how often the spawn manager should spawn a new spawn.
+     */
+    CDTimerClass<FrameTimerClass> SpawnTimer;
+
+    /**
+     *  The spawn manager's target.
+     */
+    TARGET Target;
+
+    /**
+     *  The next target the spawn manager should attack.
+     */
+    TARGET QueuedTarget;
+
+    /**
+     *  The current status of the spawn manager.
+     */
+    SpawnManagerStatus Status;
+};

--- a/src/new/spawnmanager/spawnmanager_hooks.cpp
+++ b/src/new/spawnmanager/spawnmanager_hooks.cpp
@@ -79,15 +79,8 @@ DECLARE_PATCH(_DriveLocomotionClass_Start_Of_Move_Spawn_Manager_Patch)
 
     _asm pushad
 
-    if (linked_to->EMPFramesRemaining > 0)
-    {
-        _asm popad
-        // return 1;
-        JMP(0x0047FE39);
-    }
-
     extension = Extension::Fetch<TechnoClassExtension>(linked_to);
-    if (extension->SpawnManager && extension->SpawnManager->Preparing_Count())
+    if (linked_to->EMPFramesRemaining > 0 || extension->SpawnManager && extension->SpawnManager->Preparing_Count())
     {
         _asm popad
         // return 1;
@@ -107,7 +100,7 @@ DECLARE_PATCH(_DriveLocomotionClass_Start_Of_Move_Spawn_Manager_Patch)
  */
 DECLARE_PATCH(_LogicClass_AI_Kamikaze_AI_Patch)
 {
-    // Stolen instrution
+    // Stolen instruction
     VeinholeMonsterClass::Update_All();
 
     KamikazeTracker->AI();

--- a/src/new/spawnmanager/spawnmanager_hooks.cpp
+++ b/src/new/spawnmanager/spawnmanager_hooks.cpp
@@ -1,0 +1,127 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          SPAWNMANAGER_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for SpawnManagerClass
+ *                 and KamikazeTrackerClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include "spawnmanager_hooks.h"
+
+#include "extension.h"
+#include "hooker.h"
+#include "hooker_macros.h"
+#include "spawnmanager.h"
+#include "techno.h"
+#include "technoext.h"
+#include "kamikazetracker.h"
+#include "veinholemonster.h"
+#include "vinifera_globals.h"
+
+
+/**
+ *  Patch to make the spawn manager abandon its target when ordered to idle.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_EventClass_Execute_IDLE_Spawn_Manager_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass*, techno, esi);
+    static TechnoClassExtension* extension;
+
+    extension = Extension::Fetch<TechnoClassExtension>(techno);
+    if (extension->SpawnManager)
+        extension->SpawnManager->Abandon_Target();
+
+    static RTTIType rtti = techno->Kind_Of();
+    if (rtti == RTTI_UNIT)
+    {
+        JMP(0x00494AC5);
+    }
+    else
+    {
+        JMP(0x00495110);
+    }
+
+}
+
+
+/**
+ *  Patch to block vehicles from moving if they're currently preparing to spawn.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_DriveLocomotionClass_Start_Of_Move_Spawn_Manager_Patch)
+{
+    GET_REGISTER_STATIC(TechnoClass*, linked_to, eax);
+    static TechnoClassExtension* extension;
+
+    _asm pushad
+
+    if (linked_to->EMPFramesRemaining > 0)
+    {
+        _asm popad
+        // return 1;
+        JMP(0x0047FE39);
+    }
+
+    extension = Extension::Fetch<TechnoClassExtension>(linked_to);
+    if (extension->SpawnManager && extension->SpawnManager->Preparing_Count())
+    {
+        _asm popad
+        // return 1;
+        JMP(0x0047FE39);
+    }
+
+    // Continue execution
+    _asm popad
+    JMP_REG(edx, 0x0047FE45);
+}
+
+
+/**
+ *  Patch to perform kamikaze AI.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_LogicClass_AI_Kamikaze_AI_Patch)
+{
+    // Stolen instrution
+    VeinholeMonsterClass::Update_All();
+
+    KamikazeTracker->AI();
+
+    JMP(0x00507005);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void SpawnManager_Hooks()
+{
+    Patch_Jump(0x00494AB5, &_EventClass_Execute_IDLE_Spawn_Manager_Patch);
+    Patch_Jump(0x0047FE2F, &_DriveLocomotionClass_Start_Of_Move_Spawn_Manager_Patch);
+    Patch_Jump(0x00507000, &_LogicClass_AI_Kamikaze_AI_Patch);
+}

--- a/src/new/spawnmanager/spawnmanager_hooks.h
+++ b/src/new/spawnmanager/spawnmanager_hooks.h
@@ -1,0 +1,30 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          SPAWNMANAGER_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for SpawnManagerClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+void SpawnManager_Hooks();

--- a/src/util/miscutil.cpp
+++ b/src/util/miscutil.cpp
@@ -40,6 +40,11 @@
 #include <locale>
 #include <codecvt>
 
+#include "ccfile.h"
+#include "objectext.h"
+#include "motionlib.h"
+#include "voxellib.h"
+
 
 const char *Get_Text_Time()
 {
@@ -563,4 +568,45 @@ const char *Filename_From_Path(const char *filename)
     _makepath(path, nullptr, nullptr, name, ext);
 
     return path;
+}
+
+
+/**
+ *  Loads a voxel object from files.
+ *
+ *  @author: ZivDero
+ */
+bool Load_Voxel(VoxelObject& voxel, const char* graphic_name, bool required)
+{
+    char buffer[260];
+    bool failed = false;
+
+    _makepath(buffer, nullptr, nullptr, graphic_name, ".VXL");
+    CCFileClass bodyvxl(buffer);
+
+    if (bodyvxl.Is_Available())
+    {
+        delete voxel.VoxelLibrary;
+        voxel.VoxelLibrary = new VoxelLibraryClass(&bodyvxl);
+
+        if (!voxel.VoxelLibrary || voxel.VoxelLibrary->Load_Failed())
+            failed = true;
+
+        _makepath(buffer, nullptr, nullptr, graphic_name, ".HVA");
+        CCFileClass bodyhva(buffer);
+
+        delete voxel.MotionLibrary;
+        voxel.MotionLibrary = new MotionLibraryClass(&bodyhva);
+
+        if (!voxel.MotionLibrary || voxel.MotionLibrary->Load_Failed())
+            failed = true;
+        else
+            voxel.MotionLibrary->Scale(voxel.VoxelLibrary->Get_Layer_Info(0, 0)->Scale);
+    }
+    else if (required)
+    {
+        failed = true;
+    }
+
+    return !failed;
 }

--- a/src/util/miscutil.h
+++ b/src/util/miscutil.h
@@ -32,6 +32,7 @@
 #include <time.h>
 
 
+struct VoxelObject;
 typedef int clockid_t;
 
 
@@ -71,3 +72,5 @@ bool Is_Full_Path(const char *path);
 const char *Get_User_Documents_Path();
 
 const char *Filename_From_Path(const char *filename);
+
+bool Load_Voxel(VoxelObject& voxel, const char* graphic_name, bool required = false);

--- a/src/vinifera/vinifera_defines.h
+++ b/src/vinifera/vinifera_defines.h
@@ -56,13 +56,20 @@
 
 
 /**
- *  CLSID's for all new locomotors.
+ *  CLSIDs for all new locomotors.
  */
 #define		CLSID_TEST_LOCOMOTOR	"501DEF92-C7ED-448E-8FEB-7908DCE73377"
+#define		CLSID_ROCKET_LOCOMOTOR	"B7B49766-E576-11d3-9BD9-00104B972FE8"
 
 
 /**
- *  UUID's for all extension classes.
+ *  CLSIDs for new classes.
+ */
+#define		CLSID_SPAWN_MANAGER_CLASS	"157ADEE5-D344-48B9-811B-3FA01EF3CCD4"
+
+
+/**
+ *  UUIDs for all extension classes.
  */
 #define UUID_UNIT_EXTENSION                 "17621513-3BDA-4FBD-A591-1A0B6DA0F4B9"
 #define UUID_AIRCRAFT_EXTENSION             "04B6C8D5-6D12-41C3-BF4B-B52F25928CF3"
@@ -130,12 +137,22 @@
 
 
 /**
- *  UUID's for all other new classes.
+ *  UUIDs for all other new classes.
  */
 #define UUID_ARMORTYPE                      "EE8D505F-12BB-4313-AEDC-4AEA30A5BA03"
+#define UUID_ROCKETTYPE                      "FAE72300-A93C-476C-A6DB-CB2B62ADCECD"
 
 
 /**
  *  The maximum amount of waypoints available for a scenario to use.
  */
 #define NEW_WAYPOINT_COUNT         SHRT_MAX      // "AVLG"
+
+
+typedef enum ViniferaRTTIType
+{
+    RTTI_SPAWN_MANAGER = RTTI_COUNT,
+
+    VINIFERA_RTTI_COUNT
+};
+DEFINE_ENUMERATION_OPERATORS(ViniferaRTTIType);

--- a/src/vinifera/vinifera_functions.cpp
+++ b/src/vinifera/vinifera_functions.cpp
@@ -46,6 +46,8 @@
 #include "tacticalext.h"
 #include "tclassfactory.h"
 #include "testlocomotion.h"
+#include "kamikazetracker.h"
+#include "spawnmanager.h"
 #include "extension.h"
 #include "theatertype.h"
 #include "armortype.h"
@@ -54,6 +56,7 @@
 #include "asserthandler.h"
 #include <string>
 
+#include "rocketlocomotion.h"
 #include "setup_hooks.h"
 
 
@@ -629,6 +632,8 @@ bool Vinifera_Startup()
     //CnCNet5::IsActive = true; // Enable when new Client system is implemented.
 #endif
 
+    KamikazeTracker = new KamikazeTrackerClass;
+
     return true;
 }
 
@@ -658,6 +663,8 @@ bool Vinifera_Shutdown()
      */
     TheaterTypes.Clear();
     ArmorTypes.Clear();
+    RocketTypes.Clear();
+    SpawnManagerClass::Clear_All();
 
     /**
      *  Cleanup global extension instances.
@@ -672,6 +679,9 @@ bool Vinifera_Shutdown()
      *  Cleanup additional extension instances.
      */
     ThemeControlExtensions.Clear();
+
+    delete KamikazeTracker;
+    KamikazeTracker = nullptr;
 
     DEV_DEBUG_INFO("Shutdown - New Count: %d, Delete Count: %d\n", Vinifera_New_Count, Vinifera_Delete_Count);
 
@@ -760,11 +770,23 @@ bool Vinifera_Register_Com_Objects()
 {
     DEBUG_INFO("Registering new com objects...\n");
 
-    //DEBUG_INFO("  TestLocomotionClass\n");
+    /**
+     *  New locomotors.
+     */
     REGISTER_CLASS(TestLocomotionClass);
+    REGISTER_CLASS(RocketLocomotionClass);
+
+    /**
+     *  New types.
+     */
     REGISTER_CLASS(ArmorTypeClass);
+    REGISTER_CLASS(RocketTypeClass);
+
+    /**
+     *  Other new entities.
+     */
+    REGISTER_CLASS(SpawnManagerClass);
     
-    //DEBUG_INFO("  Extension classes\n");
     Extension::Register_Class_Factories();
 
     DEBUG_INFO("  ...OK!\n");

--- a/src/vinifera/vinifera_globals.cpp
+++ b/src/vinifera/vinifera_globals.cpp
@@ -72,6 +72,10 @@ DynamicVectorClass<MFCC *> ViniferaMoviesMixes;
 DynamicVectorClass<EBoltClass *> EBolts;
 DynamicVectorClass<TheaterTypeClass *> TheaterTypes;
 DynamicVectorClass<ArmorTypeClass *> ArmorTypes;
+DynamicVectorClass<SpawnManagerClass *> SpawnManagers;
+DynamicVectorClass<RocketTypeClass*> RocketTypes;
+
+KamikazeTrackerClass* KamikazeTracker = nullptr;
 
 MFCC *GenericMix = nullptr;
 MFCC *IsoGenericMix = nullptr;

--- a/src/vinifera/vinifera_globals.h
+++ b/src/vinifera/vinifera_globals.h
@@ -32,9 +32,12 @@
 #include "ccfile.h"
 
 
+class KamikazeTrackerClass;
+class SpawnManagerClass;
 class EBoltClass;
 class TheaterTypeClass;
 class ArmorTypeClass;
+class RocketTypeClass;
 
 
 extern bool Vinifera_DeveloperMode;
@@ -93,6 +96,8 @@ extern DynamicVectorClass<MFCC *> ViniferaMoviesMixes;
 extern MFCC *GenericMix;
 extern MFCC *IsoGenericMix;
 
+extern KamikazeTrackerClass *KamikazeTracker;
+
 
 /**
  *  Global vectors and heaps.
@@ -100,6 +105,8 @@ extern MFCC *IsoGenericMix;
 extern DynamicVectorClass<EBoltClass *> EBolts;
 extern DynamicVectorClass<TheaterTypeClass *> TheaterTypes;
 extern DynamicVectorClass<ArmorTypeClass *> ArmorTypes;
+extern DynamicVectorClass<SpawnManagerClass *> SpawnManagers;
+extern DynamicVectorClass<RocketTypeClass *> RocketTypes;
 
 
 /**

--- a/src/vinifera/vinifera_hooks.cpp
+++ b/src/vinifera/vinifera_hooks.cpp
@@ -49,6 +49,7 @@
 #include "debughandler.h"
 #include "asserthandler.h"
 #include "ebolt.h"
+#include "kamikazetracker.h"
 
 
 /**
@@ -60,6 +61,9 @@
 static void _Detach_This_From_All_Intercept(TARGET target, bool all)
 {
     Extension::Detach_This_From_All(target, all);
+
+    if (target->What_Am_I() == RTTI_AIRCRAFT)
+        KamikazeTracker->Detach(reinterpret_cast<AircraftClass const*>(target));
 
     Detach_This_From_All(target, all);
 }

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -691,14 +691,14 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
     { DEBUG_INFO("Loading RadarEvents...\n"); if (!RadarEventClass::Load_All(pStm)) { DEBUG_ERROR("\t***** FAILED!\n");  return false; } }
 
     /**
-     *  Save new Vinifera objects stored in vectors.
+     *  Load new Vinifera objects stored in vectors.
      */
     if (FAILED(Vinifera_Load_Vector(pStm, ArmorTypes, "ArmorTypes"))) { return false; }
     if (FAILED(Vinifera_Load_Vector(pStm, RocketTypes, "RocketTypes"))) { return false; }
     if (FAILED(Vinifera_Load_Vector(pStm, SpawnManagers, "SpawnManagers"))) { return false; }
 
     /**
-     *  Save new Verses.
+     *  Load new Verses.
      */
     if (FAILED(Verses::Load(pStm))) { return false; }
 


### PR DESCRIPTION
This PR reimplements SpawnManagerClass from Red Alert 2, used for aircraft carriers and rocket launchers.

In `RULES.INI`:
```ini
[SOMETECHNO]        ; TechnoType
Spawns=             ; AircraftType, the type that this Techno spawns.
SpawnsNumber=0      ; integer, the number of aircraft that this Techno spawns.
SpawnRegenRate=0    ; integer, the time it takes for a spawn to regenerate after death.
SpawnReloadRate=0   ; integer, the time it takes for a spawn to reload its ammo and restore its strength.
```

- Additionally, it's possible to specify an alternative voxel model to use when the spawner has no spawns docked.

In `RULES.INI`:
```ini
[SOMETECHNO]        ; TechnoType
NoSpawnAlt=no       ; boolean, should this Techno use an alternate voxel model when it's out of spawns?
                    ; When true, the model named SOMETECHNOWO will be used when it's out of spawns.
```

```{note}
`NoSpawnAlt` is only available for Technos that use voxel models.
```

```{note}
Unlike in Red Alert 2, the voxel model used by `NoSpawnAlt` is loaded into a separate area of memory from the turet model. This means that Technos that have `NoSpawnAlt=yes` set **can** have turrets.
```

- For the unit to create spawns upon attack, a flag needs to be set on its weapon.

In `RULES.INI`:
```ini
[SOMEWEAPON]  ; WeaponType
Spawner=no    ; boolean, does this weapon spawn aircraft when firing?
```

#### Rockets

- For rocket launchers to function, RocketTypes need to be defined.

In `RULES.INI`:
```ini
[RocketTypes]
0=SOMEROCKET

[SOMEROCKET]            ; RocketType
PauseFrames=0           ; integer, how many frames the rocket pauses on the launcher before tilting.
TiltFrames=60           ; integer, how many frames it takes for the rocket to tilt to firing position.
PitchInitial=0.21       ; float, starting pitch of the rocket before tilting up (0 = horizontal, 1 = vertical).
PitchFinal=0.5          ; float, ending pitch of the rocket after tilting up before it fires.
TurnRate=0.05           ; float, pitch maneuverability of rocket in air.
RaiseRate=1             ; integer, how much the missile will raise each turn on the launcher (for Cruise Missiles only).
Acceleration=0.4        ; float, this much is added to the rocket's velocity each frame during launch.
Altitude=768            ; integer, cruising altitude in leptons (1/256 of a cell): at this height rocket begins leveling off.
Damage=200              ; integer, the rocker does this much damage when it explodes.
EliteDamage=400         ; integer, the rocker does this much damage when it explodes when the spawner is elite.
BodyLength=256          ; integer, the length of  thebody of the rocket in leptons (1/256 of a cell).
LazyCurve=yes           ; boolean, is the rocket's path a big, lazy curve, like the V3 is Red Alert 2.
CruiseMissile=no        ; boolean, is this rocket a Cruise Missile, like Boomer missiles in Yuri's Revenge.
Type=                   ; AircraftType, the type this rocket is associated with.
Warhead=                ; WarheadType, the warhead that this rocket's explosion uses.
EliteWarhead=           ; WarheadType, the warhead that this rocket's explosion uses when the spawner is elite.
TakeoffAnim=            ; AnimType, the takeoff animation used by this rocket.
TrailAnim=              ; AnimType, the trail animation used by this rocket.
```

```{note}
The rocket object is an AircraftType, like in Red Alert 2. When determining its characteristics, the rocket will use the first RocketType whose `Type=` is equal to the type of the rocket itself.
```

- Additionally, for rocket launchers that launch two rockets at a time, a second spawn offset can de defined.

In `ART.INI`:
```ini
[SOMETECHNO]             ; TechnoType
SecondSpawnOffset=0,0,0  ; 3 integers, an offset to be added to the firing FLH for the second missile's location.
```