### PR TITLE
Fix players being able to queue one unit too few when a unit has `BuildLimit > 1`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -132,9 +132,10 @@ This page lists all the individual contributions to the project by their author.
   - Add `IceStrength` to Rules, and `IceDestructionEnabled` scenario option.
   - Add `ImmuneToEMP` to TechnoTypes.
   - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes.
-  - Make it possible to assign rally points to service depots.
-  - Fix an issue where losers were not marked as defeated in multiplayer when using TACTION_WIN or TACTION_LOSE to end the game
   - Add extended descriptions in tooltips for objects on the sidebar.
+  - Make it possible to assign rally points to service depots.
+  - Fix an issue where players were unable only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0`. (Fix ported from Ares)
+  - Fix an issue where losers were not marked as defeated in multiplayer when using `TACTION_WIN` or `TACTION_LOSE` to end the game.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -45,3 +45,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where attempting to start construction when low funds would put the queue on hold.
 - Fix a bug where having 75 cameos in a single sidebar strip would crash the game.
 - Fix a bug where the objects would sometimes receive a minimum of 1 damage even if MinDamage was set to 0.
+- Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0`.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -140,6 +140,7 @@ New:
 - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius (by ZivDero)
 - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties (by ZivDero)
 - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes (by Rampastring)
+- Fix an issue where players were unable only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0` (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -140,7 +140,7 @@ New:
 - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius (by ZivDero)
 - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties (by ZivDero)
 - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes (by Rampastring)
-- Fix an issue where players were unable only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0` (by Rampastring)
+- Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0` (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -361,7 +361,7 @@ return_true:
 
 
 /**
- *  #issue-715
+ *  #issue-611, #issue-715
  *
  *  Gets the number of queued objects when determining whether a cameo
  *  should be disabled.
@@ -386,6 +386,18 @@ int _HouseClass_ShouldDisableCameo_Get_Queued_Count(FactoryClass* factory, Techn
     }
 
     /**
+     *  #issue-611
+     *
+     *  If the object has a build limit, then reduce count by 1.
+     *  In this state, the object is taken into account twice: in the object trackers
+     *  and in the factory, resulting in the player being able to queue one object less
+     *  than BuildLimit allows.
+     */
+    if (technotype->BuildLimit > 0) {
+        count--;
+    }
+
+    /**
     *  #issue-715
     *
     *  If the object can transform into another object through our special logic,
@@ -405,9 +417,12 @@ int _HouseClass_ShouldDisableCameo_Get_Queued_Count(FactoryClass* factory, Techn
 
 
 /**
- *  #issue-715
+ *  #issue-611 #issue-715
  *
- *  Updates the build limit logic with unit queuing to
+ *  Fixes the game allowing the player to queue one unit too few
+ *  when a unit has BuildLimit > 1.
+ *
+ *  Also updates the build limit logic with unit queuing to
  *  take our unit transformation logic into account.
  */
 DECLARE_PATCH(_HouseClass_ShouldDisableCameo_BuildLimit_Fix)


### PR DESCRIPTION
Fixes #611