### PR TITLE
Fix pre-placed powered-down superweapon buildings having their superweapon enabled on scenario start

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -137,6 +137,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0`. (Fix ported from Ares)
   - Fix an issue where losers were not marked as defeated in multiplayer when using `TACTION_WIN` or `TACTION_LOSE` to end the game.
   - Fix a bug where the game could read Infantry DoControls out of bounds, potentially causing a desync error in multiplayer.
+  - Fix a bug where pre-placed powered-down superweapon buildings had their superweapons enabled on scenario start.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -47,3 +47,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the objects would sometimes receive a minimum of 1 damage even if MinDamage was set to 0.
 - Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0`.
 - Fix a bug where the game could read Infantry DoControls out of bounds, potentially causing a desync error in multiplayer.
+- Fix a bug where pre-placed powered-down superweapon buildings had their superweapons enabled on scenario start.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -142,6 +142,7 @@ New:
 - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes (by Rampastring)
 - Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0` (by Rampastring)
 - Fix a bug where the game could read Infantry DoControls out of bounds, potentially causing a desync error in multiplayer (by Rampastring)
+- Fix a bug where pre-placed powered-down superweapon buildings had their superweapons enabled on scenario start (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)


### PR DESCRIPTION
Fixes #994 