### PR TITLE
Add developer command for dumping active trigger, tag, and local and global variable info to the debug log

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -133,6 +133,7 @@ This page lists all the individual contributions to the project by their author.
   - Add `ImmuneToEMP` to TechnoTypes.
   - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes.
   - Add extended descriptions in tooltips for objects on the sidebar.
+  - Add developer command to dump all existing triggers, tags, and local and global variables to the log output.
   - Make it possible to assign rally points to service depots.
   - Fix the economy score in the score screen. Dead players also have a score and the score is a percentage of the credits spent by the player who spent the most credits.
   - Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0`. (Fix ported from Ares)

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -182,6 +182,10 @@ This option tells the game to exit when you press Cancel or Back from the dialog
 
 - Dumps all the type heaps to an output log.
 
+#### `[ ]` Dump Trigger Info
+
+- Dumps all existing triggers, tags, and local and global variables to the log output.
+
 #### `[ ]` Instant Build (Player)
 
 - Toggles the instant build cheat for the player.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -147,6 +147,7 @@ New:
 - Fix a bug where the AI would sell off buildings with `Artillary=yes`, `TickTank=yes` or `IsJuggernaut=yes` that had `UndeploysInto=none` when they were fired at by something outside of their weapon range (by Rampastring)
 - Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters (by Rampastring)
 - Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team (by Rampastring)
+- Add developer command to dump all existing triggers, tags, and local and global variables to the log output (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -62,7 +62,11 @@
 #include "scenarioini.h"
 #include "scenario.h"
 #include "sidebarext.h"
+#include "tag.h"
+#include "tagtype.h"
 #include "terraintype.h"
+#include "trigger.h"
+#include "triggertype.h"
 #include "smudgetype.h"
 #include "overlaytype.h"
 #include "armortype.h"
@@ -1460,6 +1464,80 @@ bool DumpHeapCRCCommandClass::Process()
         DEBUG_INFO("\n");
     }
     
+    DEBUG_INFO("\nFinished!\n\n");
+
+    return true;
+}
+
+
+/**
+ *  Produces a log dump of active trigger instances.
+ *
+ *  @author: Rampastring
+ */
+const char* DumpTriggersCommandClass::Get_Name() const
+{
+    return "DumpTriggers";
+}
+
+const char* DumpTriggersCommandClass::Get_UI_Name() const
+{
+    return "Dump Trigger Info";
+}
+
+const char* DumpTriggersCommandClass::Get_Category() const
+{
+    return CATEGORY_DEVELOPER;
+}
+
+const char* DumpTriggersCommandClass::Get_Description() const
+{
+    return "Dumps all existing triggers, tags, and local and global variables to the log output.";
+}
+
+bool DumpTriggersCommandClass::Process()
+{
+    DEBUG_INFO("\nAbout to dump trigger information...\n\n");
+
+    for (int i = 0; i < Triggers.Count(); i++)
+    {
+        TriggerClass* trigger = Triggers[i];
+
+        DEBUG_INFO("Trigger %d: %s\n", i, trigger->Class->FullName);
+        DEBUG_INFO("    IsDestroyed: %d\n", trigger->IsDestroyed);
+        DEBUG_INFO("    IsTripped: %d\n", trigger->IsTripped);
+        DEBUG_INFO("    IsEnabled: %d\n", trigger->IsEnabled);
+
+        while (trigger->Next != nullptr) {
+            trigger = trigger->Next;
+
+            DEBUG_INFO("    Next: %s\n", trigger->Class->FullName);
+            DEBUG_INFO("        IsDestroyed: %d\n", trigger->IsDestroyed);
+            DEBUG_INFO("        IsTripped: %d\n", trigger->IsTripped);
+            DEBUG_INFO("        IsEnabled: %d\n", trigger->IsEnabled);
+        }
+    }
+
+    DEBUG_INFO("\n\nAbout to dump tag information...\n\n");
+
+    for (int i = 0; i < Tags.Count(); i++)
+    {
+        TagClass* tag = Tags[i];
+
+        DEBUG_INFO("Tag %d: %s\n", i, tag->Class->FullName);
+        DEBUG_INFO("    AttachCount: %d\n", tag->AttachCount);
+        DEBUG_INFO("    Location: %d,%d\n", tag->Location.X, tag->Location.Y);
+        DEBUG_INFO("    IsDestroyed: %d\n", tag->IsDestroyed);
+        DEBUG_INFO("    IsSprung: %d\n", tag->IsSprung);
+    }
+
+    DEBUG_INFO("\n\nAbout to dump local variable information...\n\n");
+
+    for (int i = 0; i < ARRAY_SIZE(Scen->LocalFlags); i++)
+    {
+        DEBUG_INFO("LocalFlag %d: %s, enabled: %d\n", i, Scen->LocalFlags[i].Name, Scen->LocalFlags[i].Value);
+    }
+
     DEBUG_INFO("\nFinished!\n\n");
 
     return true;

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -502,6 +502,25 @@ class DumpHeapCRCCommandClass : public ViniferaCommandClass
 
 
 /**
+ *  Produces a log dump of existing trigger instances
+ */
+class DumpTriggersCommandClass : public ViniferaCommandClass
+{
+public:
+    DumpTriggersCommandClass() : ViniferaCommandClass() { IsDeveloper = true; }
+    virtual ~DumpTriggersCommandClass() {}
+
+    virtual const char* Get_Name() const override;
+    virtual const char* Get_UI_Name() const override;
+    virtual const char* Get_Category() const override;
+    virtual const char* Get_Description() const override;
+    virtual bool Process() override;
+
+    virtual KeyNumType Default_Key() const override { return KeyNumType(KN_NONE); }
+};
+
+
+/**
  *  Toggles the instant build cheat for the player.
  */
 class InstantBuildCommandClass : public ViniferaCommandClass

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -288,6 +288,9 @@ void Init_Vinifera_Commands()
         cmdptr = new DumpHeapCRCCommandClass;
         Commands.Add(cmdptr);
 
+        cmdptr = new DumpTriggersCommandClass;
+        Commands.Add(cmdptr);
+
         cmdptr = new InstantBuildCommandClass;
         Commands.Add(cmdptr);
 


### PR DESCRIPTION
Implements #818 