### PR TITLE
Fix bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -143,6 +143,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where the AI would sell off buildings with `Artillary=yes`, `TickTank=yes` or `IsJuggernaut=yes` that had `UndeploysInto=none` when they were fired at by something outside of their weapon range.
   - Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters.
   - Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team.
+  - Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -52,3 +52,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the AI would sell off buildings with `Artillary=yes`, `TickTank=yes` or `IsJuggernaut=yes` that had `UndeploysInto=none` when they were fired at by something outside of their weapon range.
 - Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters.
 - Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team.
+- Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -148,6 +148,7 @@ New:
 - Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters (by Rampastring)
 - Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team (by Rampastring)
 - Add developer command to dump all existing triggers, tags, and local and global variables to the log output (by Rampastring)
+- Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -333,4 +333,14 @@ void AircraftClassExtension_Hooks()
     Patch_Jump(0x0040C054, &_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_FIRE_OK_Patch);
     Patch_Jump(0x0040BF9D, &_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_FIRE_FACING_Patch);
     Patch_Jump(0x0040C0AC, &_AircraftClass_Mission_Attack_IsCurleyShuffle_FIRE_AT_TARGET2_Can_Fire_DEFAULT_Patch);
+
+    /**
+     *  #issue-1091
+     *
+     *  Fix bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air.
+     *
+     *  Author: Rampastring
+     */
+    Patch_Jump(0x0040D0C5, (uintptr_t)0x0040D0EA);
+
 }


### PR DESCRIPTION
Fixes #1091