### PR TITLE
Fix bug where a harvester could be ordered to dock with a refinery that isn't listed in the harvester's `Dock=` key

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -146,6 +146,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air.
   - Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action.
   - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
+  - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -55,3 +55,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air.
 - Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action.
 - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
+- Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -151,6 +151,7 @@ New:
 - Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air (by Rampastring)
 - Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action (by Rampastring)
 - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading (by Rampastring)
+- Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)


### PR DESCRIPTION
Related to issue #129