### PR TITLE
Fix bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -147,6 +147,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action.
   - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
   - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
+  - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -56,3 +56,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action.
 - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
 - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
+- Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -152,6 +152,7 @@ New:
 - Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action (by Rampastring)
 - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading (by Rampastring)
 - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key (by Rampastring)
+- Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=` (by Rampastring)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1665,6 +1665,28 @@ has_deploy_ability:
 
 
 /**
+ *  #issue-1033
+ *
+ *  Fixes a bug where AmbientDamage does not take FirepowerBias into account.
+ *
+ *  @author: Rampastring
+ */
+DECLARE_PATCH(_TechnoClass_Railgun_Damage_Apply_Damage_Modifier_Patch)
+{
+    GET_REGISTER_STATIC(int, damage, ecx);
+    GET_STACK_STATIC(TechnoClass*, this_ptr, esp, 0x74);
+
+    damage = damage * (this_ptr->FirepowerBias * this_ptr->House->FirepowerBias);
+    _asm { mov  ecx, dword ptr ds : damage }
+    _asm { mov[esp + 0x4C], ecx }
+
+    // Restore code that we destroyed by jumping to our code and continue damage applying logic
+    _asm { mov  edx, [esp + 0x14] }
+    JMP(0x006396D9);
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void TechnoClassExtension_Hooks()
@@ -1698,4 +1720,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00632F4C, &_TechnoClass_Take_Damage_Drop_Tiberium_Type_Patch);
     Patch_Jump(0x006320C2, &_TechnoClass_2A0_Is_Allowed_To_Deploy_Unit_Transform_Patch);
     Patch_Call(0x00637FF5, &TechnoClassExt::_Cell_Distance_Squared); // Patch Find_Docking_Bay to call our own distance function that avoids overflows
+    Patch_Jump(0x006396D1, &_TechnoClass_Railgun_Damage_Apply_Damage_Modifier_Patch);
 }


### PR DESCRIPTION
Related to #1033, but fixes the bug only for railguns