### PR TITLE
Add PipWrap

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -172,4 +172,5 @@ This page lists all the individual contributions to the project by their author.
   - Add a developer command to dump all heaps to the log.
   - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius.
   - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties.
+  - Add `PipWrap`
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -339,6 +339,21 @@ In `RULES.INI`:
 SpecialPipIndex=-1  ; integer, index of the pip to draw in place of the medic pip.
 ```
 
+### PipWrap
+
+- Vinifera ports PipWrap from Red Alert 2. If PipWrap is set to a positive integer greater than 0, that number of ammo pips will be rendered, incrementing the frame number for each time the pip count overflows PipWrap.
+- For usage notes, please see [the ModEnc article](https://modenc.renegadeprojects.com/PipWrap).
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]        ; TechnoType
+PipWrap=0           ; integer, the number of ammo pips to draw using pip wrap.
+```
+
+```{note}
+For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at index 7 (0-based) is still used by ammo when `PipWrap=0`, pips starting from index 8 are used by `PipWrap`.
+```
+
 ## Terrain
 
 ### Light Sources

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -351,7 +351,7 @@ PipWrap=0           ; integer, the number of ammo pips to draw using pip wrap.
 ```
 
 ```{note}
-For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at index 7 (0-based) is still used by ammo when `PipWrap=0`, pips starting from index 8 are used by `PipWrap`.
+For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at index 7 (1-based) is still used by ammo when `PipWrap=0`, pips starting from index 8 are used by `PipWrap`.
 ```
 
 ## Terrain

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -140,19 +140,9 @@ New:
 - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius (by ZivDero)
 - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties (by ZivDero)
 - Add `TransformsInto` and `TransformRequiresFullCharge` to UnitTypes (by Rampastring)
-- Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0` (by Rampastring)
-- Fix a bug where the game could read Infantry DoControls out of bounds, potentially causing a desync error in multiplayer (by Rampastring)
-- Fix a bug where pre-placed powered-down superweapon buildings had their superweapons enabled on scenario start (by Rampastring)
-- Fix the economy score in the score screen. Dead players also have a score and the score is a percentage of the credits spent by the player who spent the most credits (by Rampastring)
-- Fix a bug where the AI would sell off buildings with `Artillary=yes`, `TickTank=yes` or `IsJuggernaut=yes` that had `UndeploysInto=none` when they were fired at by something outside of their weapon range (by Rampastring)
-- Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters (by Rampastring)
-- Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team (by Rampastring)
 - Add developer command to dump all existing triggers, tags, and local and global variables to the log output (by Rampastring)
-- Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air (by Rampastring)
-- Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action (by Rampastring)
-- Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading (by Rampastring)
-- Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key (by Rampastring)
-- Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=` (by Rampastring)
+- Add `PipWrap` (by ZivDero)
+
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)
@@ -198,6 +188,18 @@ Vanilla fixes:
 - Fix a bug where attempting to start construction when low funds would put the queue on hold (by ZivDero)
 - Port the fix for the (Whiteboy bug)[https://modenc.renegadeprojects.com/Whiteboy-Bug] (by ZivDero)
 - Fix a bug where the objects would sometimes receive a minimum of 1 damage even if MinDamage was set to 0 (by ZivDero)
+- Fix a bug where aircraft are unable to attack shrouded targets in campaign games and instead get stuck in mid-air (by Rampastring)
+- Fix a bug where the player was able to input keyboard commands while input was locked through a trigger action (by Rampastring)
+- Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading (by Rampastring)
+- Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key (by Rampastring)
+- Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=` (by Rampastring)
+- Fix a bug where players were only able to queue up to `(BuildLimit - 1)` objects when an object has `BuildLimit > 0` (by Rampastring)
+- Fix a bug where the game could read Infantry DoControls out of bounds, potentially causing a desync error in multiplayer (by Rampastring)
+- Fix a bug where pre-placed powered-down superweapon buildings had their superweapons enabled on scenario start (by Rampastring)
+- Fix the economy score in the score screen. Dead players also have a score and the score is a percentage of the credits spent by the player who spent the most credits (by Rampastring)
+- Fix a bug where the AI would sell off buildings with `Artillary=yes`, `TickTank=yes` or `IsJuggernaut=yes` that had `UndeploysInto=none` when they were fired at by something outside of their weapon range (by Rampastring)
+- Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters (by Rampastring)
+- Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team (by Rampastring)
 
 </details>
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -266,6 +266,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     VoiceDeploy = ini.Get_VocTypes(ini_name, "VoiceDeploy", VoiceDeploy);
     VoiceHarvest = ini.Get_VocTypes(ini_name, "VoiceHarvest", VoiceHarvest);
     SpecialPipIndex = ini.Get_Int(ini_name, "SpecialPipIndex", SpecialPipIndex);
+    PipWrap = ini.Get_Int(ini_name, "PipWrap", PipWrap);
 
     if (ini.Is_Present(ini_name, "Description"))
         ini.Get_String(ini_name, "Description", Description, std::size(Description));

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -155,6 +155,11 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
         int SpecialPipIndex;
 
         /**
+         *  If set to a value greater than 0, this many ammo pips will be drawn, wrapping around incrementing the frame index each time.
+         */
+        int PipWrap;
+
+        /**
          *  The rate at which this unit animates when it is standing idle (not moving).
          */
         unsigned IdleRate;


### PR DESCRIPTION
- This PR ports PipWrap from Red Alert 2. If PipWrap is set to a positive integer greater than 0, that number of ammo pips will be rendered, incrementing the frame number for each time the pip count overflows PipWrap.
- For usage notes, please see [the ModEnc article](https://modenc.renegadeprojects.com/PipWrap).

In `RULES.INI`:
```ini
[SOMETECHNO]        ; TechnoType
PipWrap=0           ; integer, the number of ammo pips to draw using pip wrap.
```

```{note}
For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at index 7 (0-based) is still used by ammo when `PipWrap=0`, pips starting from index 8 are used by `PipWrap`.
```