### PR TITLE
Implement various controls to customise the band box selection.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -125,6 +125,7 @@ This page lists all the individual contributions to the project by their author.
   - Change starting unit placement to be the same as Red Alert 2.
   - Add the framework for new ArmorTypes.
   - Implement developer mode command to reload Rules and Art files.
+  - Implement various controls to customise the band box selection.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **MarkJFox**:

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -40,7 +40,7 @@ In `SUN.INI`:
 SortDefensesAsLast=yes  ; boolean, are base defenses sorted to the end of the sidebar by default.
 ```
 
-### Desciptions
+### Descriptions
 
 - Tooltips displayed when hovering over icons on the sidebar have been expanded.
 - By default, hovering over an icon will display the object's name and price. Additionally, a description can be specified for TechnoTypes, which will appear after the price.
@@ -183,7 +183,7 @@ This system only supports 8-bit PNG. All other formats such as Greyscale, Palett
 Attached is a set of the original loading screens with a minor edit and saved as PNG for testing;
 [PNG_Loading_Screens.zip](https://github.com/Vinifera-Developers/Vinifera/files/7392707/PNG_Loading_Screens.zip)
 
-## Sidebar / Battle UI
+## Tactical UI
 
 ### Super Weapon Timers
 
@@ -271,7 +271,20 @@ In `RULES.INI`:
 MaxPips=5,5,5,10,8  ; list of integers - Ammo, Tiberium, Passengers, Power, Charge.
 ```
 
-## Tooltips
+### Selection Band Box
+
+- Vinifera allows customizing some properties of the abnd box used for unit drag-selection.
+
+In `UI.INI`:
+```ini
+[Ingame]
+BandBoxDropShadow=no                 ; boolean, should the tactical rubber band box be drawn with a drop shadow?
+BandBoxThick=no                      ; boolean, should the tactical rubber band box be drawn with a thick border?
+BandBoxColor=255,255,255             ; RGB color, color draw the tactical rubber band box with.
+BandBoxDropShadowColor=0,0,0         ; RGB color, color to draw the tactical rubber band box's shadow with.
+BandBoxTintTransparency=0            ; integer, transparency of the tactical rubber band.
+BandBoxTintColors=0,0,0,255,255,255  ; two RGB colors, "dark" and "light" tint colors, interpolated based on the map's ambient light level.
+```
 
 ## Miscellaneous
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -143,6 +143,7 @@ New:
 - Add developer command to dump all existing triggers, tags, and local and global variables to the log output (by Rampastring)
 - Add `PipWrap` (by ZivDero)
 - Implement developer mode command to reload Rules and Art files (by CCHyper)
+- Implement various controls to customise the band box selection (by CCHyper)
 
 
 Vanilla fixes:

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -52,120 +52,136 @@
 #include "uicontrol.h"
 
 
-static bool Tactical_Draw_Band(int band_x, int band_y, int band_w, int band_h)
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ *
+ *  @note: This must not contain a constructor or destructor.
+ *
+ *  @note: All functions must not be virtual and must also be prefixed
+ *         with "_" to prevent accidental virtualization.
+ */
+class TacticalExt : public Tactical
 {
-    Rect band_rect(band_x, band_y, band_w+1, band_h+1);
+public:
+    void _Draw_Band_Box();
+};
 
-    /**
-     *  Is the map ambient dark? If so, we adjust the colour slightly.
-     */
-    if (UIControls->BandBoxTintTransparency > 0) {
 
-        Rect tint_rect = band_rect;
-        const unsigned trans = UIControls->BandBoxTintTransparency;
+/**
+ *  Reimplements Tactical::Draw_Band_Box.
+ *  
+ *  @author: CCHyper, ZivDero
+ */
+void TacticalExt::_Draw_Band_Box()
+{
+    if (Band.X || Band.Y)
+    {
+        int x = Band.X;
+        int y = Band.Y;
+        int width = Band.Width;
+        int height = Band.Height;
 
-        /**
-         *  Draw the rubber band tint rect.
-         * 
-         *  Fill_Rect_Trans() doesnt not take a relative rect, so we need
-         *  to need to adjust it with the TacticalRect manually.
-         */
-        tint_rect.Move(TacticalRect.X, TacticalRect.Y);
+        if (width < x) {
+            std::swap(width, x);
+        }
 
-        RGBClass tint_dark = UIControls->BandBoxTintColors[0];
-        RGBClass tint_light = UIControls->BandBoxTintColors[1];
+        if (height < y) {
+            std::swap(height, y);
+        }
 
-        /**
-         *  Interpolate between the two colors to find the correct tint
-         *  for the current map ambient level.
-         */
-        const float adjust = static_cast<float>(Scen->AmbientCurrent) / 100.0f;
-        const RGBClass tint_color = RGBClass::Interpolate(tint_dark, tint_light, adjust);
-
-        LogicSurface->Fill_Rect_Trans(tint_rect, tint_color, trans);
-    }
-
-    /**
-     *  Draw the drop shadow.
-     */
-    if (UIControls->IsBandBoxDropShadow) {
-
-        Rect drop_rect = band_rect;
-        drop_rect.X += 1;
-        drop_rect.Y += 1;
-
-        const unsigned drop_color = DSurface::RGB_To_Pixel(
-                                    UIControls->BandBoxDropShadowColor.R,
-                                    UIControls->BandBoxDropShadowColor.G,
-                                    UIControls->BandBoxDropShadowColor.B);
+        Rect band_rect(x, y, width - x + 1, height - y + 1);
 
         /**
-         *  
+         *  Is the map ambient dark? If so, we adjust the colour slightly.
          */
-        if (UIControls->IsBandBoxThick) {
+        if (UIControls->BandBoxTintTransparency > 0) {
 
+            Rect tint_rect = band_rect;
+            const unsigned trans = UIControls->BandBoxTintTransparency;
+
+            /**
+             *  Draw the rubber band tint rect.
+             *
+             *  Fill_Rect_Trans() doesn't not take a relative rect, so we need
+             *  to need to align it with the TacticalRect manually.
+             */
+            tint_rect.Move(TacticalRect.X, TacticalRect.Y);
+
+            RGBClass tint_dark = UIControls->BandBoxTintColors[0];
+            RGBClass tint_light = UIControls->BandBoxTintColors[1];
+
+            /**
+             *  Interpolate between the two colors to find the correct tint
+             *  for the current map ambient level.
+             */
+            const float adjust = static_cast<float>(Scen->AmbientCurrent) / 100.0f;
+            const RGBClass tint_color = RGBClass::Interpolate(tint_dark, tint_light, adjust);
+
+            LogicSurface->Fill_Rect_Trans(tint_rect, tint_color, trans);
+        }
+
+        /**
+         *  Draw the drop shadow.
+         */
+        if (UIControls->IsBandBoxDropShadow) {
+
+            Rect drop_rect = band_rect;
             drop_rect.X += 1;
             drop_rect.Y += 1;
 
-            LogicSurface->Draw_Rect(TacticalRect, drop_rect, drop_color);
+            const unsigned drop_color = DSurface::RGB_To_Pixel(
+                UIControls->BandBoxDropShadowColor.R,
+                UIControls->BandBoxDropShadowColor.G,
+                UIControls->BandBoxDropShadowColor.B);
 
-            Rect thick_rect = drop_rect;
+            /**
+             *  Draw the band box.
+             */
+            if (UIControls->IsBandBoxThick) {
+
+                drop_rect.X += 1;
+                drop_rect.Y += 1;
+
+                LogicSurface->Draw_Rect(TacticalRect, drop_rect, drop_color);
+
+                Rect thick_rect = drop_rect;
+                thick_rect.X += 1;
+                thick_rect.Y += 1;
+                thick_rect.Width -= 2;
+                thick_rect.Height -= 2;
+
+                LogicSurface->Draw_Rect(TacticalRect, thick_rect, drop_color);
+
+            }
+            else {
+                LogicSurface->Draw_Rect(TacticalRect, drop_rect, drop_color);
+            }
+
+        }
+
+        /**
+         *  Draw the custom rubber band rect.
+         */
+        const unsigned band_color = DSurface::RGB_To_Pixel(
+            UIControls->BandBoxColor.R,
+            UIControls->BandBoxColor.G,
+            UIControls->BandBoxColor.B);
+
+        LogicSurface->Draw_Rect(TacticalRect, band_rect, band_color);
+
+        /**
+         *  If the band box is thick, draw an extra outline.
+         */
+        if (UIControls->IsBandBoxThick) {
+            Rect thick_rect = band_rect;
             thick_rect.X += 1;
             thick_rect.Y += 1;
             thick_rect.Width -= 2;
             thick_rect.Height -= 2;
-
-            LogicSurface->Draw_Rect(TacticalRect, thick_rect, drop_color);
-
-        } else {
-            LogicSurface->Draw_Rect(TacticalRect, drop_rect, drop_color);
+            LogicSurface->Draw_Rect(TacticalRect, thick_rect, band_color);
         }
-
     }
-    
-    /**
-     *  Draw the custom rubber band rect.
-     */
-    const unsigned band_color = DSurface::RGB_To_Pixel(
-                                UIControls->BandBoxColor.R,
-                                UIControls->BandBoxColor.G,
-                                UIControls->BandBoxColor.B);
-
-    LogicSurface->Draw_Rect(TacticalRect, band_rect, band_color);
-
-    /**
-     *  
-     */
-    if (UIControls->IsBandBoxThick) {
-        Rect thick_rect = band_rect;
-        thick_rect.X += 1;
-        thick_rect.Y += 1;
-        thick_rect.Width -= 2;
-        thick_rect.Height -= 2;
-        LogicSurface->Draw_Rect(TacticalRect, thick_rect, band_color);
-    }
-
-    return true;
-}
-
-
-/**
- *  f
- * 
- *  
- * 
- *  @author: CCHyper
- */
-DECLARE_PATCH(_Tactical_Draw_Band_Tint_Patch)
-{
-    GET_REGISTER_STATIC(int, band_rect_x, edx);
-    GET_REGISTER_STATIC(int, band_rect_y, esi);
-    GET_REGISTER_STATIC(int, band_rect_w, eax);
-    GET_REGISTER_STATIC(int, band_rect_h, ebp);
-
-    Tactical_Draw_Band(band_rect_x, band_rect_y, band_rect_w, band_rect_h);
-
-    JMP(0x00616601);
 }
 
 
@@ -557,6 +573,5 @@ void TacticalExtension_Hooks()
      */
     Patch_Dword(0x006171C8+1, (TPF_CENTER|TPF_EFNT|TPF_FULLSHADOW));
     Patch_Jump(0x00616FDA, &_Tactical_Draw_Waypoint_Paths_Text_Color_Patch);
-
-    Patch_Jump(0x006165B2, &_Tactical_Draw_Band_Tint_Patch);
+    Patch_Jump(0x00616560, &TacticalExt::_Draw_Band_Box);
 }

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -76,14 +76,14 @@
 
 
 /**
-  *  A fake class for implementing new member functions which allow
-  *  access to the "this" pointer of the intended class.
-  *
-  *  @note: This must not contain a constructor or destructor.
-  *
-  *  @note: All functions must not be virtual and must also be prefixed
-  *         with "_" to prevent accidental virtualization.
-  */
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ *
+ *  @note: This must not contain a constructor or destructor.
+ *
+ *  @note: All functions must not be virtual and must also be prefixed
+ *         with "_" to prevent accidental virtualization.
+ */
 class TechnoClassExt : public TechnoClass
 {
 public:

--- a/src/new/ui/uicontrol.cpp
+++ b/src/new/ui/uicontrol.cpp
@@ -74,8 +74,8 @@ UIControlsClass::UIControlsClass() :
     BandBoxTintTransparency(0),
     BandBoxTintColors()
 {
-    BandBoxTintColors.Add(RGBStruct{ 0,0,0 });
-    BandBoxTintColors.Add(RGBStruct{ 255,255,255 });
+    BandBoxTintColors.Add(RGBStruct{ 0, 0, 0 });
+    BandBoxTintColors.Add(RGBStruct{ 255, 255, 255 });
 }
 
 

--- a/src/new/ui/uicontrol.cpp
+++ b/src/new/ui/uicontrol.cpp
@@ -66,8 +66,16 @@ UIControlsClass::UIControlsClass() :
     UnitSpecialPipOffset(0, -8),
     InfantrySpecialPipOffset(0, -8),
     BuildingSpecialPipOffset(0, -8),
-    AircraftSpecialPipOffset(0, -8)
+    AircraftSpecialPipOffset(0, -8),
+    IsBandBoxDropShadow(false),
+    IsBandBoxThick(false),
+    BandBoxColor{ 255, 255, 255 },
+    BandBoxDropShadowColor{ 0, 0, 0 },
+    BandBoxTintTransparency(0),
+    BandBoxTintColors()
 {
+    BandBoxTintColors.Add(RGBStruct{ 0,0,0 });
+    BandBoxTintColors.Add(RGBStruct{ 255,255,255 });
 }
 
 
@@ -76,7 +84,8 @@ UIControlsClass::UIControlsClass() :
  *  
  *  @author: CCHyper
  */
-UIControlsClass::UIControlsClass(const NoInitClass &noinit)
+UIControlsClass::UIControlsClass(const NoInitClass &noinit) :
+    BandBoxTintColors(noinit)
 {
 }
 
@@ -122,6 +131,15 @@ bool UIControlsClass::Read_INI(CCINIClass &ini)
     InfantrySpecialPipOffset = ini.Get_Point(INGAME, "InfantrySpecialPipOffset", InfantrySpecialPipOffset);
     BuildingSpecialPipOffset = ini.Get_Point(INGAME, "BuildingSpecialPipOffset", BuildingSpecialPipOffset);
     AircraftSpecialPipOffset = ini.Get_Point(INGAME, "AircraftSpecialPipOffset", AircraftSpecialPipOffset);
+
+    IsBandBoxDropShadow = ini.Get_Bool(INGAME, "BandBoxDropShadow", IsBandBoxDropShadow);
+    IsBandBoxThick = ini.Get_Bool(INGAME, "BandBoxThick", IsBandBoxThick);
+    BandBoxColor = ini.Get_RGB(INGAME, "BandBoxColor", BandBoxColor);
+    BandBoxDropShadowColor = ini.Get_RGB(INGAME, "BandBoxDropShadowColor", BandBoxDropShadowColor);
+    BandBoxTintTransparency = ini.Get_Int_Clamp(INGAME, "BandBoxTintTransparency", 0, 100, BandBoxTintTransparency);
+    BandBoxTintColors = ini.Get_RGBs(INGAME, "BandBoxTintColors", BandBoxTintColors);
+
+    ASSERT_PRINT(BandBoxTintColors.Count() == 2, "BandBoxTintColors must contain two valid entries!");
 
     return true;
 }

--- a/src/new/ui/uicontrol.h
+++ b/src/new/ui/uicontrol.h
@@ -30,6 +30,7 @@
 #include "always.h"
 #include "tibsun_defines.h"
 #include "tpoint.h"
+#include "typelist.h"
 
 
 struct IStream;
@@ -158,6 +159,36 @@ class UIControlsClass
         TPoint2D<int> InfantrySpecialPipOffset;
         TPoint2D<int> BuildingSpecialPipOffset;
         TPoint2D<int> AircraftSpecialPipOffset;
+
+        /**
+         *  Should the tactical rubber band box be drawn with a drop shadow?
+         */
+        bool IsBandBoxDropShadow;
+
+        /**
+         *
+         */
+        bool IsBandBoxThick;
+
+        /**
+         *
+         */
+        RGBStruct BandBoxColor;
+
+        /**
+         *
+         */
+        RGBStruct BandBoxDropShadowColor;
+
+        /**
+         *  Transparency of the tactical rubber band.
+         */
+        unsigned BandBoxTintTransparency;
+
+        /**
+         *
+         */
+        TypeList<RGBStruct> BandBoxTintColors;
 };
 
 extern UIControlsClass *UIControls;

--- a/src/new/ui/uicontrol.h
+++ b/src/new/ui/uicontrol.h
@@ -166,17 +166,17 @@ class UIControlsClass
         bool IsBandBoxDropShadow;
 
         /**
-         *
+         *  Should the tactical rubber band box be drawn thick?
          */
         bool IsBandBoxThick;
 
         /**
-         *
+         *  Color to draw the tactical rubber band box with.
          */
         RGBStruct BandBoxColor;
 
         /**
-         *
+         *  Color to draw the tactical rubber band box's shadow with.
          */
         RGBStruct BandBoxDropShadowColor;
 
@@ -186,7 +186,7 @@ class UIControlsClass
         unsigned BandBoxTintTransparency;
 
         /**
-         *
+         *  Two tint colors, interpolated between based on the current ambient light level.
          */
         TypeList<RGBStruct> BandBoxTintColors;
 };

--- a/src/new/ui/uicontrol.h
+++ b/src/new/ui/uicontrol.h
@@ -166,7 +166,7 @@ class UIControlsClass
         bool IsBandBoxDropShadow;
 
         /**
-         *  Should the tactical rubber band box be drawn thick?
+         *  Should the tactical rubber band box be drawn with a thick border?
          */
         bool IsBandBoxThick;
 


### PR DESCRIPTION
Implement various controls to customise the band box selection.

In `UI.INI`:
```ini
[Ingame]
BandBoxDropShadow=no                 ; boolean, should the tactical rubber band box be drawn with a drop shadow?
BandBoxThick=no                      ; boolean, should the tactical rubber band box be drawn with a thick border?
BandBoxColor=255,255,255             ; RGB color, color draw the tactical rubber band box with.
BandBoxDropShadowColor=0,0,0         ; RGB color, color to draw the tactical rubber band box's shadow with.
BandBoxTintTransparency=0            ; integer, transparency of the tactical rubber band.
BandBoxTintColors=0,0,0,255,255,255  ; two RGB colors, "dark" and "light" tint colors, interpolated based on the map's ambient light level.
```

Feature by @CCHyper, rebased and updated by me.