### PR TITLE
Implements various controls to show and customise NavCom queue lines.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -128,6 +128,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement various controls to customise the band box selection.
   - Implement various controls to customise action lines.
   - Implement various controls to customise target lasers line.
+  - Implement various controls to show and customise NavCom queue lines.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **MarkJFox**:
@@ -177,5 +178,5 @@ This page lists all the individual contributions to the project by their author.
   - Make harvesters drop the Tiberium type they're carrying on death, instead of Tiberium Riparius.
   - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties.
   - Add `PipWrap`.
-  - Adjustments to the band box, action line, target laser customization features.
+  - Adjustments to the band box, action line, target laser and NavCom queue line customization features.
 

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -278,12 +278,12 @@ MaxPips=5,5,5,10,8  ; list of integers - Ammo, Tiberium, Passengers, Power, Char
 In `UI.INI`:
 ```ini
 [Ingame]
-BandBoxDropShadow=no                 ; boolean, should the tactical rubber band box be drawn with a drop shadow?
-BandBoxThick=no                      ; boolean, should the tactical rubber band box be drawn with a thick border?
-BandBoxColor=255,255,255             ; RGB color, color draw the tactical rubber band box with.
-BandBoxDropShadowColor=0,0,0         ; RGB color, color to draw the tactical rubber band box's shadow with.
-BandBoxTintTransparency=0            ; integer, transparency of the tactical rubber band.
-BandBoxTintColors=0,0,0,255,255,255  ; two RGB colors, "dark" and "light" tint colors, interpolated based on the map's ambient light level.
+BandBoxDropShadow=no                     ; boolean, should the tactical rubber band box be drawn with a drop shadow?
+BandBoxThick=no                          ; boolean, should the tactical rubber band box be drawn with a thick border?
+BandBoxColor=255,255,255                 ; RGB color, color draw the tactical rubber band box with.
+BandBoxDropShadowColor=0,0,0             ; RGB color, color to draw the tactical rubber band box's shadow with.
+BandBoxTintTransparency=0                ; integer, transparency of the tactical rubber band.
+BandBoxTintColors=(0,0,0),(255,255,255)  ; two RGB colors, "dark" and "light" tint colors, interpolated based on the map's ambient light level.
 ```
 
 - Vinifera allows customizing some properties of the movement, target and target laser lines.
@@ -311,6 +311,19 @@ TargetLaserThick=no                ; boolean, should target lasers be drawn with
 TargetLaserColor=173,0,0           ; RGB color, color to draw the target lasers with.
 TargetLaserDropShadowColor=0,0,0   ; RGB color, color to draw target lasers' drop shadow with.
 TargetLaserTime=15                 ; integer, time in frames the target laser should be drawn for when the unit fires.
+```
+
+- Additionally, you can also enable lines to be drawn indicating the unit's current navigation queue.
+
+In `UI.INI`:
+```ini
+[Ingame]
+ShowNavComQueueLines=no               ; boolean, should NavCom queue lines be displayed?
+NavComQueueLineDashed=no              ; boolean, should NavCom queue lines be drawn with dashes?
+NavComQueueLineDropShadow=no          ; boolean, should NavCom queue lines be drawn with a drop shadow?
+NavComQueueLineThick=no               ; boolean, should NavCom queue lines be drawn with a thick line?
+NavComQueueLineColor=173,0,0          ; RGB color, color to draw the NavCom queue lines with.
+NavComQueueLineDropShadowColor=0,0,0  ; RGB color, color to draw the NavCom queue lines' drop shadow with.
 ```
 
 ## Miscellaneous

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -322,7 +322,7 @@ ShowNavComQueueLines=no               ; boolean, should NavCom queue lines be di
 NavComQueueLineDashed=no              ; boolean, should NavCom queue lines be drawn with dashes?
 NavComQueueLineDropShadow=no          ; boolean, should NavCom queue lines be drawn with a drop shadow?
 NavComQueueLineThick=no               ; boolean, should NavCom queue lines be drawn with a thick line?
-NavComQueueLineColor=173,0,0          ; RGB color, color to draw the NavCom queue lines with.
+NavComQueueLineColor=74,77,255        ; RGB color, color to draw the NavCom queue lines with.
 NavComQueueLineDropShadowColor=0,0,0  ; RGB color, color to draw the NavCom queue lines' drop shadow with.
 ```
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -146,6 +146,7 @@ New:
 - Implement various controls to customise the band box selection (by CCHyper/tomsons26)
 - Implement various controls to customise action lines (by CCHyper/tomsons26)
 - Implement various controls to customise target lasers line (by CCHyper/tomsons26)
+- Implement various controls to show and customise NavCom queue lines (by CCHyper/tomsons26)
 
 
 Vanilla fixes:

--- a/src/extensions/foot/footext_hooks.cpp
+++ b/src/extensions/foot/footext_hooks.cpp
@@ -58,9 +58,201 @@
  */
 class FootClassExt final : public FootClass
 {
-    public:
-        void _Draw_Action_Line() const;
+public:
+    void _Draw_Action_Line() const;
+    void _Draw_NavComQueue_Lines() const;
 };
+
+
+/**
+ *  Draws a line for the current NavCom queue.
+ * 
+ *  @author: CCHyper
+ */
+void FootClassExt::_Draw_NavComQueue_Lines() const
+{
+    if (!NavQueue.Count()) {
+        return;
+    }
+
+    /**
+     *  Fetch the line properties.
+     */
+    const bool is_dashed = UIControls->IsMovementLineDashed;
+    const bool is_thick = UIControls->IsMovementLineThick;
+    const bool is_dropshadow = UIControls->IsMovementLineDropShadow;
+
+    const unsigned line_color = DSurface::RGB_To_Pixel(
+        UIControls->MovementLineColor.R,
+        UIControls->MovementLineColor.G,
+        UIControls->MovementLineColor.B);
+
+    const unsigned drop_color = DSurface::RGB_To_Pixel(
+        UIControls->MovementLineDropShadowColor.R,
+        UIControls->MovementLineDropShadowColor.G,
+        UIControls->MovementLineDropShadowColor.B);
+
+    int point_size = 3;
+    Point2D point_offset(-1, -1);
+
+    if (is_thick) {
+        point_size = 4;
+        point_offset = Point2D(-2, -2);
+    }
+
+    /**
+     *  Line animation rate.
+     */
+    const int rate = 128;
+
+    /**
+     *  Fetch the queue line start and end coord.
+     */
+    Coordinate start_coord;
+    Coordinate end_coord;
+
+    start_coord = Get_Coord();
+
+    TARGET navtarget = field_260.Count() ? field_260.Fetch_Tail() : NavCom;
+    end_coord = navtarget->Center_Coord();
+    Cell target_cell = Coord_Cell(end_coord);
+
+    if (Map.In_Radar(target_cell) && Map[end_coord].Bit2_16) {
+        end_coord.Z = BRIDGE_HEIGHT + Map.Get_Cell_Height(end_coord);
+    }
+
+    /**
+     *  Convert the world coord to screen pixel.
+     */
+    Point2D start_point;
+    Point2D end_point;
+    TacticalMap->Coord_To_Pixel(start_coord, start_point);
+    TacticalMap->Coord_To_Pixel(end_coord, end_point);
+
+    /**
+     *  Offset pixel position relative to tactical viewport.
+     */
+    start_point += Point2D(TacticalRect.X, TacticalRect.Y);
+    end_point += Point2D(TacticalRect.X, TacticalRect.Y);
+
+    /**
+     *  Draw the queue line.
+     */
+    if (Clip_Line(&start_point, &end_point, &TacticalRect)) {
+
+        Point2D drop_start_point = start_point;
+        Point2D drop_end_point = end_point;
+
+        drop_start_point.Y += 1;
+        drop_end_point.Y += 1;
+
+        if (is_dashed) {
+
+            /**
+             *  4 pixels on, 4 off, 4 pixels on, 4 off.
+             */
+            static bool _pattern[] = { true, true, true, true, false, false, false, false, true, true, true, true, false, false, false, false };
+
+            /**
+             *  Adjust the offset of the line pattern.
+             */
+            int time = timeGetTime();
+            int offset = (-time / rate) & (std::size(_pattern) - 1);
+
+            /**
+             *  Draw the drop shadow line.
+             */
+            if (is_dropshadow) {
+
+                if (is_thick) {
+                    drop_start_point.Y += 1;
+                    drop_end_point.Y += 1;
+                }
+
+                CompositeSurface->Draw_Dashed_Line(drop_start_point, drop_end_point, drop_color, _pattern, offset);
+
+                if (is_thick) {
+                    drop_start_point.Y += 1;
+                    drop_end_point.Y += 1;
+                    CompositeSurface->Draw_Dashed_Line(drop_start_point, drop_end_point, drop_color, _pattern, offset);
+                }
+
+            }
+
+            /**
+             *  Draw the dashed queue line.
+             */
+            CompositeSurface->Draw_Dashed_Line(start_point, end_point, line_color, _pattern, offset);
+
+            if (is_thick) {
+                start_point.Y += 1;
+                end_point.Y += 1;
+                CompositeSurface->Draw_Dashed_Line(start_point, end_point, line_color, _pattern, offset);
+            }
+
+        }
+        else {
+
+            /**
+             *  Draw the drop shadow line.
+             */
+            if (is_dropshadow) {
+
+                if (is_thick) {
+                    drop_start_point.Y += 1;
+                    drop_end_point.Y += 1;
+                }
+
+                CompositeSurface->Draw_Line(drop_start_point, drop_end_point, drop_color);
+
+                if (is_thick) {
+                    drop_start_point.Y += 1;
+                    drop_end_point.Y += 1;
+                    CompositeSurface->Draw_Line(drop_start_point, drop_end_point, drop_color);
+                }
+
+            }
+
+            /**
+             *  Draw the queue line.
+             */
+            CompositeSurface->Draw_Line(start_point, end_point, line_color);
+
+            if (is_thick) {
+                start_point.Y += 1;
+                end_point.Y += 1;
+                CompositeSurface->Draw_Line(start_point, end_point, line_color);
+            }
+
+        }
+
+    }
+
+    /**
+     *  Draw the queue line start and end squares.
+     */
+    if (is_dropshadow) {
+
+        const int drop_point_size = is_thick ? (point_size + 3) : (point_size + 2);
+        const Point2D drop_point_offset = is_thick ? (point_offset + Point2D(-2, -2)) : (point_offset + Point2D(-1, -1));
+
+        if (is_thick) {
+            point_size -= 1;
+        }
+
+        Rect drop_start_point_rect = TacticalRect.Intersect_With(Rect(start_point + drop_point_offset, drop_point_size, drop_point_size));
+        CompositeSurface->Fill_Rect(drop_start_point_rect, drop_color);
+
+        Rect drop_end_point_rect = TacticalRect.Intersect_With(Rect(end_point + drop_point_offset, drop_point_size, drop_point_size));
+        CompositeSurface->Fill_Rect(drop_end_point_rect, drop_color);
+    }
+
+    Rect start_point_rect = TacticalRect.Intersect_With(Rect(start_point + point_offset, point_size, point_size));
+    CompositeSurface->Fill_Rect(start_point_rect, line_color);
+
+    Rect end_point_rect = TacticalRect.Intersect_With(Rect(end_point + point_offset, point_size, point_size));
+    CompositeSurface->Fill_Rect(end_point_rect, line_color);
+}
 
 
 /**
@@ -85,28 +277,28 @@ void FootClassExt::_Draw_Action_Line() const
     const bool is_thick = TarCom ? UIControls->IsTargetLineThick : UIControls->IsMovementLineThick;
     const bool is_dropshadow = TarCom ? UIControls->IsTargetLineDropShadow : UIControls->IsMovementLineDropShadow;
 
-    unsigned tarcom_color = DSurface::RGB_To_Pixel(
+    const unsigned tarcom_color = DSurface::RGB_To_Pixel(
         UIControls->TargetLineColor.R,
         UIControls->TargetLineColor.G,
         UIControls->TargetLineColor.B);
 
-    unsigned tarcom_drop_color = DSurface::RGB_To_Pixel(
+    const unsigned tarcom_drop_color = DSurface::RGB_To_Pixel(
         UIControls->TargetLineDropShadowColor.R,
         UIControls->TargetLineDropShadowColor.G,
         UIControls->TargetLineDropShadowColor.B);
 
-    unsigned navcom_color = DSurface::RGB_To_Pixel(
+    const unsigned navcom_color = DSurface::RGB_To_Pixel(
         UIControls->MovementLineColor.R,
         UIControls->MovementLineColor.G,
         UIControls->MovementLineColor.B);
 
-    unsigned navcom_drop_color = DSurface::RGB_To_Pixel(
+    const unsigned navcom_drop_color = DSurface::RGB_To_Pixel(
         UIControls->MovementLineDropShadowColor.R,
         UIControls->MovementLineDropShadowColor.G,
         UIControls->MovementLineDropShadowColor.B);
 
-    unsigned line_color = TarCom ? tarcom_color : navcom_color;
-    unsigned drop_color = TarCom ? tarcom_drop_color : navcom_drop_color;
+    const unsigned line_color = TarCom ? tarcom_color : navcom_color;
+    const unsigned drop_color = TarCom ? tarcom_drop_color : navcom_drop_color;
 
     int point_size = 4;
     Point2D point_offset(-2, -2);
@@ -145,6 +337,11 @@ void FootClassExt::_Draw_Action_Line() const
         if (Map.In_Radar(target_cell) && Map[end_coord].Bit2_16) {
             end_coord.Z = BRIDGE_HEIGHT + Map.Get_Cell_Height(end_coord);
         }
+
+        if (UIControls->IsShowNavComQueueLines) {
+            _Draw_NavComQueue_Lines();
+        }
+
     }
 
     /**

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -961,8 +961,8 @@ void TechnoClassExt::_Draw_Target_Laser() const
      */
     if (is_dropshadow) {
 
-        int drop_point_size = is_thick ? (point_size + 3) : (point_size + 2);
-        Point2D drop_point_offset = is_thick ? (point_offset + Point2D(-2, -2)) : (point_offset + Point2D(-1, -1));
+        const int drop_point_size = is_thick ? (point_size + 3) : (point_size + 2);
+        const Point2D drop_point_offset = is_thick ? (point_offset + Point2D(-2, -2)) : (point_offset + Point2D(-1, -1));
 
         if (is_thick) {
             point_size -= 1;

--- a/src/new/ui/uicontrol.cpp
+++ b/src/new/ui/uicontrol.cpp
@@ -94,7 +94,7 @@ UIControlsClass::UIControlsClass() :
     IsNavComQueueLineDashed(false),
     IsNavComQueueLineDropShadow(false),
     IsNavComQueueLineThick(false),
-    NavComQueueLineColor{ 173, 0, 0 }, // COLOR_LTBLUE
+    NavComQueueLineColor{ 74, 77, 255 }, // COLOR_LTBLUE
     NavComQueueLineDropShadowColor{ 0, 0, 0 }
 {
     BandBoxTintColors.Add(RGBStruct{ 0, 0, 0 });

--- a/src/new/ui/uicontrol.cpp
+++ b/src/new/ui/uicontrol.cpp
@@ -89,7 +89,13 @@ UIControlsClass::UIControlsClass() :
     IsTargetLaserThick(false),
     TargetLaserColor{ 173, 0, 0 }, // COLOR_RED
     TargetLaserDropShadowColor{ 0, 0, 0 },
-    TargetLaserTime(15)
+    TargetLaserTime(15),
+    IsShowNavComQueueLines(false),
+    IsNavComQueueLineDashed(false),
+    IsNavComQueueLineDropShadow(false),
+    IsNavComQueueLineThick(false),
+    NavComQueueLineColor{ 173, 0, 0 }, // COLOR_LTBLUE
+    NavComQueueLineDropShadowColor{ 0, 0, 0 }
 {
     BandBoxTintColors.Add(RGBStruct{ 0, 0, 0 });
     BandBoxTintColors.Add(RGBStruct{ 255, 255, 255 });
@@ -177,6 +183,13 @@ bool UIControlsClass::Read_INI(CCINIClass &ini)
     TargetLaserColor = ini.Get_RGB(INGAME, "TargetLaserColor", TargetLaserColor);
     TargetLaserDropShadowColor = ini.Get_RGB(INGAME, "TargetLaserDropShadowColor", TargetLaserDropShadowColor);
     TargetLaserTime = ini.Get_Int(INGAME, "TargetLaserTime", TargetLaserTime);
+
+    IsShowNavComQueueLines = ini.Get_Bool(INGAME, "ShowNavComQueueLines", IsShowNavComQueueLines);
+    IsNavComQueueLineDashed = ini.Get_Bool(INGAME, "NavComQueueLineDashed", IsNavComQueueLineDashed);
+    IsNavComQueueLineDropShadow = ini.Get_Bool(INGAME, "NavComQueueLineDropShadow", IsNavComQueueLineDropShadow);
+    IsNavComQueueLineThick = ini.Get_Bool(INGAME, "NavComQueueLineThick", IsNavComQueueLineThick);
+    NavComQueueLineColor = ini.Get_RGB(INGAME, "NavComQueueLineColor", NavComQueueLineColor);
+    NavComQueueLineDropShadowColor = ini.Get_RGB(INGAME, "NavComQueueLineDropShadowColor", NavComQueueLineDropShadowColor);
 
     return true;
 }

--- a/src/new/ui/uicontrol.h
+++ b/src/new/ui/uicontrol.h
@@ -274,6 +274,36 @@ class UIControlsClass
          *  Time in frames the target laser should be drawn for when the unit fires.
          */
         unsigned TargetLaserTime;
+
+        /**
+         *  Should NavCom queue lines be displayed?
+         */
+        bool IsShowNavComQueueLines;
+
+        /**
+         *  Should NavCom queue lines be drawn with dashes?
+         */
+        bool IsNavComQueueLineDashed;
+
+        /**
+         *  Should NavCom queue lines be drawn with a drop shadow?
+         */
+        bool IsNavComQueueLineDropShadow;
+
+        /**
+         *  Should NavCom queue lines be drawn with a thick line?
+         */
+        bool IsNavComQueueLineThick;
+
+        /**
+         *  Color to draw the NavCom queue lines with.
+         */
+        RGBStruct NavComQueueLineColor;
+
+        /**
+         *  Color to draw the NavCom queue lines' drop shadow with.
+         */
+        RGBStruct NavComQueueLineDropShadowColor;
 };
 
 extern UIControlsClass *UIControls;


### PR DESCRIPTION
- You can enable lines to be drawn indicating the unit's current navigation queue.

In `UI.INI`:
```ini
[Ingame]
ShowNavComQueueLines=no               ; boolean, should NavCom queue lines be displayed?
NavComQueueLineDashed=no              ; boolean, should NavCom queue lines be drawn with dashes?
NavComQueueLineDropShadow=no          ; boolean, should NavCom queue lines be drawn with a drop shadow?
NavComQueueLineThick=no               ; boolean, should NavCom queue lines be drawn with a thick line?
NavComQueueLineColor=74,77,255        ; RGB color, color to draw the NavCom queue lines with.
NavComQueueLineDropShadowColor=0,0,0  ; RGB color, color to draw the NavCom queue lines' drop shadow with.
```