### PR TITLE
Add band box selection filtering

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -155,6 +155,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
   - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
   - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
+  - Implement `IsSelectableCombatant`.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:
@@ -179,4 +180,5 @@ This page lists all the individual contributions to the project by their author.
   - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties.
   - Add `PipWrap`.
   - Adjustments to the band box, action line, target laser and NavCom queue line customization features.
+  - Implement `IsSelectableCombatant`.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -155,7 +155,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
   - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
   - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
-  - Implement `IsSelectableCombatant`.
+  - Implement `IsCombatant`.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:
@@ -180,5 +180,5 @@ This page lists all the individual contributions to the project by their author.
   - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties.
   - Add `PipWrap`.
   - Adjustments to the band box, action line, target laser and NavCom queue line customization features.
-  - Implement `IsSelectableCombatant`.
+  - Implement `IsCombatant`.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -155,7 +155,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
   - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
   - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
-  - Implement `IsCombatant`.
+  - Implement `FilterFromBandBoxSelection`.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:
@@ -180,5 +180,5 @@ This page lists all the individual contributions to the project by their author.
   - Make it so that it is no longer required to list all Tiberiums in a map to override some Tiberium's properties.
   - Add `PipWrap`.
   - Adjustments to the band box, action line, target laser and NavCom queue line customization features.
-  - Implement `IsCombatant`.
+  - Implement `FilterFromBandBoxSelection`.
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -354,6 +354,27 @@ PipWrap=0           ; integer, the number of ammo pips to draw using pip wrap.
 For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at index 7 (1-based) is still used by ammo when `PipWrap=0`, pips starting from index 8 are used by `PipWrap`.
 ```
 
+### IsSelectableCombatant
+
+- Vinifera adds the ability to exclude some TechnoTypes from band selection.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]               ; TechnoType
+IsSelectableCombatant=yes  ; boolean, should this Techno be considered a combatant for the purposes of selection?
+```
+
+- Technos with `IsSelectableCombatant=no` will only be selected if the current selection contains any units with `IsSelectableCombatant=no`, or the player is making a new selection and only Technos with `IsSelectableCombatant=no` are in the selection box.
+- By holding `ALT` it is possible to temporarily ignore this logic and select all types of objects.
+
+- It is also possible to disable this behavior in `SUN.INI`.
+
+In `SUN.INI`:
+```ini
+[Options]
+FilterBandBoxSelection=yes  ; boolean, should the banding box selection be filtered?
+```
+
 ## Terrain
 
 ### Light Sources

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -354,17 +354,17 @@ PipWrap=0           ; integer, the number of ammo pips to draw using pip wrap.
 For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at index 7 (1-based) is still used by ammo when `PipWrap=0`, pips starting from index 8 are used by `PipWrap`.
 ```
 
-### IsSelectableCombatant
+### Selection Filtering
 
 - Vinifera adds the ability to exclude some TechnoTypes from band selection.
 
 In `RULES.INI`:
 ```ini
 [SOMETECHNO]               ; TechnoType
-IsSelectableCombatant=yes  ; boolean, should this Techno be considered a combatant for the purposes of selection?
+IsCombatant=yes  ; boolean, should this Techno be considered a combatant for the purposes of selection?
 ```
 
-- Technos with `IsSelectableCombatant=no` will only be selected if the current selection contains any units with `IsSelectableCombatant=no`, or the player is making a new selection and only Technos with `IsSelectableCombatant=no` are in the selection box.
+- Technos with `IsCombatant=no` will only be selected if the current selection contains any units with `IsCombatant=no`, or the player is making a new selection and only Technos with `IsCombatant=no` are in the selection box.
 - By holding `ALT` it is possible to temporarily ignore this logic and select all types of objects.
 
 - It is also possible to disable this behavior in `SUN.INI`.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -360,7 +360,7 @@ For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at 
 
 In `RULES.INI`:
 ```ini
-[SOMETECHNO]               ; TechnoType
+[SOMETECHNO]     ; TechnoType
 IsCombatant=yes  ; boolean, should this Techno be considered a combatant for the purposes of selection?
 ```
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -360,11 +360,11 @@ For `PipWrap` to function, new pips need to be added to `pips2.shp`. The pip at 
 
 In `RULES.INI`:
 ```ini
-[SOMETECHNO]     ; TechnoType
-IsCombatant=yes  ; boolean, should this Techno be considered a combatant for the purposes of selection?
+[SOMETECHNO]                    ; TechnoType
+FilterFromBandBoxSelection=yes  ; boolean, should this Techno be considered a combatant for the purposes of selection?
 ```
 
-- Technos with `IsCombatant=no` will only be selected if the current selection contains any units with `IsCombatant=no`, or the player is making a new selection and only Technos with `IsCombatant=no` are in the selection box.
+- Technos with `FilterFromBandBoxSelection=no` will only be selected if the current selection contains any units with `FilterFromBandBoxSelection=no`, or the player is making a new selection and only Technos with `FilterFromBandBoxSelection=no` are in the selection box.
 - By holding `ALT` it is possible to temporarily ignore this logic and select all types of objects.
 
 - It is also possible to disable this behavior in `SUN.INI`.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -147,7 +147,7 @@ New:
 - Implement various controls to customise action lines (by CCHyper/tomsons26)
 - Implement various controls to customise target lasers line (by CCHyper/tomsons26)
 - Implement various controls to show and customise NavCom queue lines (by CCHyper/tomsons26)
-- Implement `IsSelectableCombatant` (by ZivDero/Rampastring)
+- Implement `IsCombatant` (by ZivDero/Rampastring)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -147,7 +147,7 @@ New:
 - Implement various controls to customise action lines (by CCHyper/tomsons26)
 - Implement various controls to customise target lasers line (by CCHyper/tomsons26)
 - Implement various controls to show and customise NavCom queue lines (by CCHyper/tomsons26)
-- Implement `IsCombatant` (by ZivDero/Rampastring)
+- Implement `FilterFromBandBoxSelection` (by ZivDero/Rampastring)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -147,6 +147,7 @@ New:
 - Implement various controls to customise action lines (by CCHyper/tomsons26)
 - Implement various controls to customise target lasers line (by CCHyper/tomsons26)
 - Implement various controls to show and customise NavCom queue lines (by CCHyper/tomsons26)
+- Implement `IsSelectableCombatant` (by ZivDero/Rampastring)
 
 
 Vanilla fixes:

--- a/src/extensions/options/optionsext.cpp
+++ b/src/extensions/options/optionsext.cpp
@@ -44,7 +44,8 @@
  */
 OptionsClassExtension::OptionsClassExtension(const OptionsClass *this_ptr) :
     GlobalExtensionClass(this_ptr),
-    SortDefensesAsLast(true)
+    SortDefensesAsLast(true),
+    FilterBandBoxSelection(true)
 {
     //EXT_DEBUG_TRACE("OptionsClassExtension::OptionsClassExtension - 0x%08X\n", (uintptr_t)(This()));
 }
@@ -163,6 +164,7 @@ void OptionsClassExtension::Load_Settings()
         sun_ini.Load(file, false);
 
         SortDefensesAsLast = sun_ini.Get_Bool("Options", "SortDefensesAsLast", SortDefensesAsLast);
+        FilterBandBoxSelection = sun_ini.Get_Bool("Options", "FilterBandBoxSelection", FilterBandBoxSelection);
     }
 
     /**

--- a/src/extensions/options/optionsext.h
+++ b/src/extensions/options/optionsext.h
@@ -69,4 +69,9 @@ class OptionsClassExtension final : public GlobalExtensionClass<OptionsClass>
          *  Should cameos of defenses (including walls and gates) be sorted to the bottom of the sidebar?
          */
         bool SortDefensesAsLast;
+
+        /**
+         *  Are harvesters and MCVs excluded from a band-box selection that includes combat units?
+         */
+        bool FilterBandBoxSelection;
 };

--- a/src/extensions/sidebar/sidebarext_hooks.cpp
+++ b/src/extensions/sidebar/sidebarext_hooks.cpp
@@ -1120,8 +1120,8 @@ static int __cdecl BuildType_Comparison(const void* p1, const void* p2)
                 BCAT_DEFENSE
             };
 
-            int building_category1 = (b1->IsWall || b1->IsFirestormWall || b1->IsLaserFencePost || b1->IsLaserFence) ? BCAT_WALL : (b1->IsGate ? BCAT_GATE : (ext1->SortCameoAsBaseDefense ? BCAT_DEFENSE : BCAT_NORMAL));
-            int building_category2 = (b2->IsWall || b2->IsFirestormWall || b2->IsLaserFencePost || b2->IsLaserFence) ? BCAT_WALL : (b2->IsGate ? BCAT_GATE : (ext2->SortCameoAsBaseDefense ? BCAT_DEFENSE : BCAT_NORMAL));
+            int building_category1 = (b1->IsWall || b1->IsFirestormWall || b1->IsLaserFencePost || b1->IsLaserFence) ? BCAT_WALL : (b1->IsGate ? BCAT_GATE : (ext1->IsSortCameoAsBaseDefense ? BCAT_DEFENSE : BCAT_NORMAL));
+            int building_category2 = (b2->IsWall || b2->IsFirestormWall || b2->IsLaserFencePost || b2->IsLaserFence) ? BCAT_WALL : (b2->IsGate ? BCAT_GATE : (ext2->IsSortCameoAsBaseDefense ? BCAT_DEFENSE : BCAT_NORMAL));
 
             // Compare based on category priority
             if (building_category1 != building_category2)

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -400,7 +400,7 @@ static void Vinifera_Bandbox_Select(ObjectClass* obj)
      if (techno && OptionsExtension->FilterBandBoxSelection)
      {
          const auto ext = Extension::Fetch<TechnoTypeClassExtension>(techno->Techno_Type_Class());
-         if (!ext->IsSelectableCombatant && TacticalExt::SelectedCount > 0 && !TacticalExt::SelectionContainsNonCombatants)
+         if (!ext->IsSelectableCombatant && TacticalExt::SelectedCount > 0 && !TacticalExt::SelectionContainsNonCombatants && !WWKeyboard->Down(VK_ALT))
          {
              return;
          }
@@ -413,7 +413,7 @@ static void Vinifera_Bandbox_Select(ObjectClass* obj)
         /**
          *  If this is a new selection, filter it at the end.
          */
-        if (TacticalExt::SelectedCount == 0)
+        if (TacticalExt::SelectedCount == 0 && !WWKeyboard->Down(VK_ALT))
             TacticalExt::FilterSelection = true;
     }
 }

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -348,7 +348,7 @@ void TacticalExt::_Select_These(Rect& rect, void (*selection_func)(ObjectClass* 
 
     /**
      *  If player-controlled units are non-additively selected,
-     *  remove non-combatans if they aren't the only types of units selected
+     *  remove non-combatants if they aren't the only types of units selected
      */
     if (FilterSelection)
         Filter_Selection();

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -73,7 +73,7 @@ class TacticalExt : public Tactical
 {
 public:
     void _Draw_Band_Box();
-    void _Select_These(Rect& rect, void (*Selection_Func)(ObjectClass* obj));
+    void _Select_These(Rect& rect, void (*selection_func)(ObjectClass* obj));
 
 public:
 
@@ -291,7 +291,7 @@ static bool Has_NonCombatants_Selected()
  *
  *  @author: ZivDero
  */
-void TacticalExt::_Select_These(Rect& rect, void (*Selection_Func)(ObjectClass* obj))
+void TacticalExt::_Select_These(Rect& rect, void (*selection_func)(ObjectClass* obj))
 {
     SelectionContainsNonCombatants = Has_NonCombatants_Selected();
     SelectedCount = CurrentObjects.Count();
@@ -309,9 +309,9 @@ void TacticalExt::_Select_These(Rect& rect, void (*Selection_Func)(ObjectClass* 
                 Point2D position = dirty.Position - field_5C;
                 if (rect.Is_Within(position))
                 {
-                    if (Selection_Func)
+                    if (selection_func)
                     {
-                        Selection_Func(dirty.Object);
+                        selection_func(dirty.Object);
                     }
                     else
                     {

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -226,7 +226,7 @@ static bool Should_Exclude_From_Selection(ObjectClass* obj)
      *  Exclude objects that aren't a selectable combatant per rules.
      */
     if (obj->Is_Techno()) {
-        return !Extension::Fetch<TechnoTypeClassExtension>(obj->Techno_Type_Class())->IsSelectableCombatant;
+        return !Extension::Fetch<TechnoTypeClassExtension>(obj->Techno_Type_Class())->IsCombatant;
     }
 
     return false;
@@ -278,7 +278,7 @@ static bool Has_NonCombatants_Selected()
 {
     for (int i = 0; i < CurrentObjects.Count(); i++)
     {
-        if (CurrentObjects[i]->Is_Techno() && !Extension::Fetch<TechnoTypeClassExtension>(CurrentObjects[i]->Techno_Type_Class())->IsSelectableCombatant)
+        if (CurrentObjects[i]->Is_Techno() && !Extension::Fetch<TechnoTypeClassExtension>(CurrentObjects[i]->Techno_Type_Class())->IsCombatant)
             return true;
     }
 
@@ -381,7 +381,7 @@ static void Vinifera_Bandbox_Select(ObjectClass* obj)
 
     /**
      *  Don't select buildings, unless it undeploys into something other than
-     *  a construction yard or a war factory (for example, a mobile EMP).
+     *  a construction yard or a war factory (for example, a deploying artillery).
      */
     if (building && (!building->Class->UndeploysInto || building->Class->IsConstructionYard || building->Class->IsMobileWar))
         return;
@@ -396,14 +396,14 @@ static void Vinifera_Bandbox_Select(ObjectClass* obj)
      *  If this is a Techno that's not a combatant, and the selection isn't new and doesn't
      *  already contain non-combatants, don't select it.
      */
-     TechnoClass* techno = Target_As_Techno(obj);
-     if (techno && OptionsExtension->FilterBandBoxSelection)
+     const TechnoClass* techno = Target_As_Techno(obj);
+     if (techno && OptionsExtension->FilterBandBoxSelection
+         && TacticalExt::SelectedCount > 0 && !TacticalExt::SelectionContainsNonCombatants
+         && !WWKeyboard->Down(VK_ALT))
      {
          const auto ext = Extension::Fetch<TechnoTypeClassExtension>(techno->Techno_Type_Class());
-         if (!ext->IsSelectableCombatant && TacticalExt::SelectedCount > 0 && !TacticalExt::SelectionContainsNonCombatants && !WWKeyboard->Down(VK_ALT))
-         {
+         if (!ext->IsCombatant)
              return;
-         }
      }
 
     if (obj->Select())

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -226,7 +226,7 @@ static bool Should_Exclude_From_Selection(ObjectClass* obj)
      *  Exclude objects that aren't a selectable combatant per rules.
      */
     if (obj->Is_Techno()) {
-        return !Extension::Fetch<TechnoTypeClassExtension>(obj->Techno_Type_Class())->IsCombatant;
+        return !Extension::Fetch<TechnoTypeClassExtension>(obj->Techno_Type_Class())->FilterFromBandBoxSelection;
     }
 
     return false;
@@ -278,7 +278,7 @@ static bool Has_NonCombatants_Selected()
 {
     for (int i = 0; i < CurrentObjects.Count(); i++)
     {
-        if (CurrentObjects[i]->Is_Techno() && !Extension::Fetch<TechnoTypeClassExtension>(CurrentObjects[i]->Techno_Type_Class())->IsCombatant)
+        if (CurrentObjects[i]->Is_Techno() && !Extension::Fetch<TechnoTypeClassExtension>(CurrentObjects[i]->Techno_Type_Class())->FilterFromBandBoxSelection)
             return true;
     }
 
@@ -402,7 +402,7 @@ static void Vinifera_Bandbox_Select(ObjectClass* obj)
          && !WWKeyboard->Down(VK_ALT))
      {
          const auto ext = Extension::Fetch<TechnoTypeClassExtension>(techno->Techno_Type_Class());
-         if (!ext->IsCombatant)
+         if (!ext->FilterFromBandBoxSelection)
              return;
      }
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -69,8 +69,9 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     PipWrap(0),
     IdleRate(0),
     CameoImageSurface(nullptr),
-    SortCameoAsBaseDefense(false),
-    Description("")
+    IsSortCameoAsBaseDefense(false),
+    Description(""),
+    IsSelectableCombatant(true)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -283,7 +284,8 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
         CameoImageSurface = imagesurface;
     }
 
-    SortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", SortCameoAsBaseDefense);
+    IsSortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", IsSortCameoAsBaseDefense);
+    IsSelectableCombatant = ini.Get_Bool(ini_name, "IsSelectableCombatant", IsSelectableCombatant);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -71,7 +71,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     CameoImageSurface(nullptr),
     IsSortCameoAsBaseDefense(false),
     Description(""),
-    IsSelectableCombatant(true)
+    IsCombatant(true)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -285,7 +285,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     IsSortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", IsSortCameoAsBaseDefense);
-    IsSelectableCombatant = ini.Get_Bool(ini_name, "IsSelectableCombatant", IsSelectableCombatant);
+    IsCombatant = ini.Get_Bool(ini_name, "IsCombatant", IsCombatant);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -71,7 +71,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     CameoImageSurface(nullptr),
     IsSortCameoAsBaseDefense(false),
     Description(""),
-    IsCombatant(true)
+    FilterFromBandBoxSelection(true)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -285,7 +285,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     IsSortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", IsSortCameoAsBaseDefense);
-    IsCombatant = ini.Get_Bool(ini_name, "IsCombatant", IsCombatant);
+    FilterFromBandBoxSelection = ini.Get_Bool(ini_name, "FilterFromBandBoxSelection", FilterFromBandBoxSelection);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -172,10 +172,16 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
         /**
          *  Should this be considered a base defense when sorting cameos on the sidebar?
          */
-        bool SortCameoAsBaseDefense;
+        bool IsSortCameoAsBaseDefense;
 
         /**
          *  Description for the extended sidebar tooltip.
          */
         char Description[200];
+
+        /**
+         *  If this property is set to false, this object will not be selected when band box selecting
+         *  if any objects in the selection have it set to true (e. g., harvesters and MCVs won't be selected with tanks).
+         */
+        bool IsSelectableCombatant;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -183,5 +183,5 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
          *  If this property is set to false, this object will not be selected when band box selecting
          *  if any objects in the selection have it set to true (e. g., harvesters and MCVs won't be selected with tanks).
          */
-        bool IsCombatant;
+        bool FilterFromBandBoxSelection;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -183,5 +183,5 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
          *  If this property is set to false, this object will not be selected when band box selecting
          *  if any objects in the selection have it set to true (e. g., harvesters and MCVs won't be selected with tanks).
          */
-        bool IsSelectableCombatant;
+        bool IsCombatant;
 };


### PR DESCRIPTION
- Vinifera adds the ability to exclude some TechnoTypes from band selection.

In `RULES.INI`:
```ini
[SOMETECHNO]               ; TechnoType
IsSelectableCombatant=yes  ; boolean, should this Techno be considered a combatant for the purposes of selection?
```

- Technos with `IsSelectableCombatant=no` will only be selected if the current selection contains any units with `IsSelectableCombatant=no`, or the player is making a new selection and only Technos with `IsSelectableCombatant=no` are in the selection box.
- By holding `ALT` it is possible to temporarily ignore this logic and select all types of objects.

- It is also possible to disable this behavior in `SUN.INI`.

In `SUN.INI`:
```ini
[Options]
FilterBandBoxSelection=yes  ; boolean, should the banding box selection be filtered?
```

Resolves #825 