### PR TITLE
Add customizable UI colors

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -156,6 +156,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
   - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
   - Implement `FilterFromBandBoxSelection`.
+  - Add the possibility to customize the UI and Tooltip colors per-side.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:
@@ -181,4 +182,5 @@ This page lists all the individual contributions to the project by their author.
   - Add `PipWrap`.
   - Adjustments to the band box, action line, target laser and NavCom queue line customization features.
   - Implement `FilterFromBandBoxSelection`.
+  - Add the possibility to customize the UI and Tooltip colors per-side.
 

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -330,6 +330,17 @@ NavComQueueLineDropShadowColor=0,0,0  ; RGB color, color to draw the NavCom queu
 
 ![drag-and-move](https://github.com/user-attachments/assets/b17163e7-81f3-4132-983f-e33809cd8d1b)
 
+## Customizable Colors
+
+- Vinifera adds the option to customize what colors are used in the user interface per-side.
+
+In `RULES.INI`:
+```ini
+[SOMESIDE]          ; SideType
+UIColor=LightGold   ; ColorScheme, the color to be used when drawing some UI elements.
+ToolTipColor=Green  ; ColorScheme, the color to be used when drawing tooltips.
+```
+
 ## Miscellaneous
 
 - Vinifera adds support for 8-bit (paletted and non-paletted) PCX and 8-bit PNG cameos. This system auto-detects and prioritises the PNG or PCX file if found, no additional settings are required.

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -337,9 +337,11 @@ NavComQueueLineDropShadowColor=0,0,0  ; RGB color, color to draw the NavCom queu
 In `RULES.INI`:
 ```ini
 [SOMESIDE]          ; SideType
-UIColor=LightGold   ; ColorScheme, the color to be used when drawing some UI elements.
+UIColor=LightGold   ; ColorScheme, the color to be used when drawing UI elements.
 ToolTipColor=Green  ; ColorScheme, the color to be used when drawing tooltips.
 ```
+
+![image](https://github.com/user-attachments/assets/f4219655-2d28-49d2-9537-25f2fe4ae102)
 
 ## Miscellaneous
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -148,6 +148,7 @@ New:
 - Implement various controls to customise target lasers line (by CCHyper/tomsons26)
 - Implement various controls to show and customise NavCom queue lines (by CCHyper/tomsons26)
 - Implement `FilterFromBandBoxSelection` (by ZivDero/Rampastring)
+- Add the possibility to customize the UI and Tooltip colors per-side (by Rampastring/ZivDero)
 
 
 Vanilla fixes:

--- a/src/extensions/credit/creditext_hooks.cpp
+++ b/src/extensions/credit/creditext_hooks.cpp
@@ -1,0 +1,133 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CREDITEXT_HOOKS.CPP
+ *
+ *  @author        Rampastring
+ *
+ *  @brief         Contains the hooks for the extended CreditClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include "tibsun_globals.h"
+
+#include "colorscheme.h"
+#include "dsurface.h"
+#include "extension_globals.h"
+#include "house.h"
+#include "housetype.h"
+#include "rgb.h"
+#include "scenarioext.h"
+#include "sideext.h"
+
+
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Modifies the color of the "Options" text based on the player's side.
+ */
+DECLARE_PATCH(_TabClass_Draw_It_Faction_Specific_Options_Button_Color_Scheme_Patch)
+{
+    static ColorSchemeType colorschemetype;
+    static ColorScheme* colorscheme;
+
+    colorschemetype = Extension::Fetch<SideClassExtension>(Sides[PlayerPtr->Class->Side])->UIColor;
+    colorscheme = ColorSchemes[colorschemetype];
+
+    _asm mov edx, colorscheme 
+    _asm mov ecx, LogicSurface
+    _asm mov ecx, [ecx]
+    JMP(0x0060E5B4);
+}
+
+
+/**
+ *  Modifies the color of the credits display based on the player's side.
+ */
+DECLARE_PATCH(_CreditClass_Graphic_Logic_Faction_Specific_Color_Scheme_Patch)
+{
+    _asm push ecx
+    _asm push 4108h
+    _asm push 0
+
+    static ColorSchemeType colorschemetype;
+    static ColorScheme* colorscheme;
+
+    colorschemetype = Extension::Fetch<SideClassExtension>(Sides[PlayerPtr->Class->Side])->UIColor;
+    colorscheme = ColorSchemes[colorschemetype];
+
+    _asm mov eax, colorscheme
+    JMP_REG(ecx, 0x004714F0);
+}
+
+
+void Draw_Tooltip_Rectangle(DSurface* surface, Rect& drawrect)
+{
+    surface->Fill_Rect(drawrect, 0);
+
+    const ColorSchemeType colorschemetype = Extension::Fetch<SideClassExtension>(Sides[PlayerPtr->Class->Side])->ToolTipColor;
+    const ColorScheme* colorscheme = ColorSchemes[colorschemetype];
+
+    RGBClass rgb = colorscheme->HSV.operator RGBClass();
+    surface->Draw_Rect(drawrect, DSurface::RGB_To_Pixel(rgb));
+}
+
+
+DECLARE_PATCH(_CCToolTip_Draw_Faction_Specific_Color_Scheme_Rect_Patch)
+{
+    GET_REGISTER_STATIC(DSurface*, surface, esi);
+    GET_REGISTER_STATIC(Rect*, drawrect, eax);
+
+    Draw_Tooltip_Rectangle(surface, *drawrect);
+    
+    JMP(0x0044E6D4);
+}
+
+
+DECLARE_PATCH(_CCToolTip_Draw_Faction_Specific_Color_Scheme_Text_Patch)
+{
+    static ColorSchemeType colorschemetype;
+    static ColorScheme* colorscheme;
+
+    colorschemetype = Extension::Fetch<SideClassExtension>(Sides[PlayerPtr->Class->Side])->ToolTipColor;
+    colorscheme = ColorSchemes[colorschemetype];
+
+    _asm mov eax, colorscheme
+    JMP_REG(ecx, 0x0044E6F8);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void CreditClassExtension_Hooks()
+{
+    Patch_Jump(0x0060E5AE, &_TabClass_Draw_It_Faction_Specific_Options_Button_Color_Scheme_Patch);
+    Patch_Jump(0x004714E6, &_CreditClass_Graphic_Logic_Faction_Specific_Color_Scheme_Patch);
+
+    Patch_Jump(0x0044E682, &_CCToolTip_Draw_Faction_Specific_Color_Scheme_Rect_Patch);
+    Patch_Jump(0x0044E6F3, &_CCToolTip_Draw_Faction_Specific_Color_Scheme_Text_Patch);
+}

--- a/src/extensions/credit/creditext_hooks.cpp
+++ b/src/extensions/credit/creditext_hooks.cpp
@@ -48,6 +48,8 @@
 
 /**
  *  Modifies the color of the "Options" text based on the player's side.
+ *
+ *  @author: Rampastring, ZivDero
  */
 DECLARE_PATCH(_TabClass_Draw_It_Faction_Specific_Options_Button_Color_Scheme_Patch)
 {
@@ -66,6 +68,8 @@ DECLARE_PATCH(_TabClass_Draw_It_Faction_Specific_Options_Button_Color_Scheme_Pat
 
 /**
  *  Modifies the color of the credits display based on the player's side.
+ *
+ *  @author: Rampastring, ZivDero
  */
 DECLARE_PATCH(_CreditClass_Graphic_Logic_Faction_Specific_Color_Scheme_Patch)
 {
@@ -84,6 +88,11 @@ DECLARE_PATCH(_CreditClass_Graphic_Logic_Faction_Specific_Color_Scheme_Patch)
 }
 
 
+/**
+ *  Draws the tooltip rectangle using a color based on the player's side.
+ *
+ *  @author: Rampastring, ZivDero
+ */
 void Draw_Tooltip_Rectangle(DSurface* surface, Rect& drawrect)
 {
     surface->Fill_Rect(drawrect, 0);
@@ -96,6 +105,11 @@ void Draw_Tooltip_Rectangle(DSurface* surface, Rect& drawrect)
 }
 
 
+/**
+ *  Patch to replace the call to draw the tooptip rectangle.
+ *
+ *  @author: Rampastring
+ */
 DECLARE_PATCH(_CCToolTip_Draw_Faction_Specific_Color_Scheme_Rect_Patch)
 {
     GET_REGISTER_STATIC(DSurface*, surface, esi);
@@ -107,6 +121,11 @@ DECLARE_PATCH(_CCToolTip_Draw_Faction_Specific_Color_Scheme_Rect_Patch)
 }
 
 
+/**
+ *  Modifies the color of the tooltip text color based on the player's side.
+ *
+ *  @author: Rampastring, ZivDero
+ */
 DECLARE_PATCH(_CCToolTip_Draw_Faction_Specific_Color_Scheme_Text_Patch)
 {
     static ColorSchemeType colorschemetype;

--- a/src/extensions/credit/creditext_hooks.h
+++ b/src/extensions/credit/creditext_hooks.h
@@ -1,0 +1,34 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          BULLETEXT_HOOKS.H
+ *
+ *  @author        Rampastring
+ *
+ *  @brief         Contains the hooks for the extended CreditClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void CreditClassExtension_Hooks();

--- a/src/extensions/extension_hooks.cpp
+++ b/src/extensions/extension_hooks.cpp
@@ -48,6 +48,7 @@
 #include "campaignext_hooks.h"
 #include "cargoext_hooks.h"
 #include "cellext_hooks.h"
+#include "creditext_hooks.h"
 #include "factoryext_hooks.h"
 #include "houseext_hooks.h"
 #include "housetypeext_hooks.h"
@@ -138,6 +139,7 @@
 #include "fetchres_hooks.h"
 
 #include "theatertype_hooks.h"
+#include "storageext_hooks.h"
 
 #include "vinifera_globals.h"
 #include "tibsun_functions.h"
@@ -148,7 +150,6 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
-#include "storage/storageext_hooks.h"
 
 
 void Extension_Hooks()
@@ -184,6 +185,7 @@ void Extension_Hooks()
     CampaignClassExtension_Hooks();
     CargoClassExtension_Hooks();
     CellClassExtension_Hooks();
+    CreditClassExtension_Hooks();
     FactoryClassExtension_Hooks();
     HouseClassExtension_Hooks();
     HouseTypeClassExtension_Hooks();

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -60,6 +60,7 @@
 #include "particlesystypeext.h"
 #include "voxelanimtypeext.h"
 #include "tiberiumext.h"
+#include "sideext.h"
 
 #include "extension.h"
 #include "extension_globals.h"
@@ -552,6 +553,11 @@ bool RulesClassExtension::Objects(CCINIClass &ini)
     for (int mission = 0; mission < MISSION_COUNT; mission++) {
         MissionControl[mission].Mission = static_cast<MissionType>(mission);
         MissionControl[mission].Read_INI(ini);
+    }
+
+    DEBUG_INFO("Rules: Processing SideExtensions (Count: %d)...\n", SideExtensions.Count());
+    for (int index = 0; index < SideExtensions.Count(); ++index) {
+        SideExtensions[index]->Read_INI(ini);
     }
 
     return true;

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -30,6 +30,7 @@
 #include "ccini.h"
 #include "extension.h"
 #include "asserthandler.h"
+#include "colorscheme.h"
 #include "debughandler.h"
 
 
@@ -39,7 +40,9 @@
  *  @author: CCHyper
  */
 SideClassExtension::SideClassExtension(const SideClass *this_ptr) :
-    AbstractTypeClassExtension(this_ptr)
+    AbstractTypeClassExtension(this_ptr),
+    UIColor(COLORSCHEME_NONE),
+    ToolTipColor(COLORSCHEME_NONE)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("SideClassExtension::SideClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -182,6 +185,17 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
-    
+
+    if (!IsInitialized) {
+
+        UIColor = ColorScheme::From_Name("LightGold");
+        ToolTipColor = ColorScheme::From_Name("Green");
+    }
+
+    UIColor = ini.Get_ColorSchemeType(ini_name, "UIColor", UIColor);
+    ToolTipColor = ini.Get_ColorSchemeType(ini_name, "ToolTipColor", ToolTipColor);
+
+    IsInitialized = true;
+
     return true;
 }

--- a/src/extensions/side/sideext.h
+++ b/src/extensions/side/sideext.h
@@ -62,4 +62,14 @@ SideClassExtension final : public AbstractTypeClassExtension
         virtual bool Read_INI(CCINIClass &ini) override;
 
     public:
+
+        /**
+         *  Color scheme to be used in the UI of this side.
+         */
+        ColorSchemeType UIColor;
+
+        /**
+         *  Color scheme to be used for the tooltips of this side.
+         */
+        ColorSchemeType ToolTipColor;
 };

--- a/src/extensions/sidebar/sidebarext.cpp
+++ b/src/extensions/sidebar/sidebarext.cpp
@@ -49,6 +49,8 @@
 #include "vox.h"
 #include "wwmouse.h"
 #include "techno.h"
+#include "sideext.h"
+#include "housetype.h"
 
 
 GadgetClass* SidebarClassExtension::LastHovered;
@@ -577,7 +579,8 @@ bool SidebarClassExtension::TabButtonClass::Draw_Me(bool forced)
     if (MousedOver && !Scen->UserInputLocked && !IsDisabled && !IsSelected)
     {
         Rect hover_rect(X + DrawX, Y + DrawY, Width - 1, Height - 1);
-        SidebarSurface->Draw_Rect(hover_rect, DSurface::RGB_To_Pixel(ColorSchemes[0]->HSV.operator RGBClass()));
+        const ColorSchemeType colorschemetype = Extension::Fetch<SideClassExtension>(Sides[PlayerPtr->Class->Side])->UIColor;
+        SidebarSurface->Draw_Rect(hover_rect, DSurface::RGB_To_Pixel(ColorSchemes[colorschemetype]->HSV.operator RGBClass()));
     }
 
     IsDrawn = true;

--- a/src/extensions/sidebar/sidebarext_hooks.cpp
+++ b/src/extensions/sidebar/sidebarext_hooks.cpp
@@ -60,6 +60,7 @@
 #include "voc.h"
 #include "vox.h"
 #include "wwmouse.h"
+#include "sideext.h"
 
 #include "debughandler.h"
 #include "fatal.h"
@@ -1717,7 +1718,8 @@ void StripClassExt::_Draw_It(bool complete)
                 if (overbutton && !Scen->UserInputLocked && !darken)
                 {
                     Rect cameo_hover_rect(x, SidebarRect.Y + y, OBJECT_WIDTH, OBJECT_HEIGHT - 3);
-                    SidebarSurface->Draw_Rect(cameo_hover_rect, DSurface::RGB_To_Pixel(ColorSchemes[0]->HSV.operator RGBClass()));
+                    const ColorSchemeType colorschemetype = Extension::Fetch<SideClassExtension>(Sides[PlayerPtr->Class->Side])->UIColor;
+                    SidebarSurface->Draw_Rect(cameo_hover_rect, DSurface::RGB_To_Pixel(ColorSchemes[colorschemetype]->HSV.operator RGBClass()));
                 }
 
 

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -226,7 +226,7 @@ static bool Should_Exclude_From_Selection(ObjectClass* obj)
      *  Exclude objects that aren't a selectable combatant per rules.
      */
     if (obj->Is_Techno()) {
-        return Extension::Fetch<TechnoTypeClassExtension>(obj->Techno_Type_Class())->FilterFromBandBoxSelection;
+        return Extension::Fetch<TechnoTypeClassExtension>(obj->Techno_Type_Class())->IsFilterFromBandBoxSelection;
     }
 
     return false;
@@ -278,7 +278,7 @@ static bool Has_NonCombatants_Selected()
 {
     for (int i = 0; i < CurrentObjects.Count(); i++)
     {
-        if (CurrentObjects[i]->Is_Techno() && Extension::Fetch<TechnoTypeClassExtension>(CurrentObjects[i]->Techno_Type_Class())->FilterFromBandBoxSelection)
+        if (CurrentObjects[i]->Is_Techno() && Extension::Fetch<TechnoTypeClassExtension>(CurrentObjects[i]->Techno_Type_Class())->IsFilterFromBandBoxSelection)
             return true;
     }
 
@@ -377,7 +377,7 @@ static void Vinifera_Bandbox_Select(ObjectClass* obj)
         return;
 
     /**
-     *  Don't select buildings, unless it undeploys into something other than
+     *  Don't select buildings, unless it undeploys and is something other than
      *  a construction yard or a war factory (for example, a deploying artillery).
      */
     if (building && (!building->Class->UndeploysInto || building->Class->IsConstructionYard || building->Class->IsMobileWar))
@@ -399,7 +399,7 @@ static void Vinifera_Bandbox_Select(ObjectClass* obj)
          && !WWKeyboard->Down(VK_ALT))
      {
          const auto ext = Extension::Fetch<TechnoTypeClassExtension>(techno->Techno_Type_Class());
-         if (ext->FilterFromBandBoxSelection)
+         if (ext->IsFilterFromBandBoxSelection)
              return;
      }
 

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1018,7 +1018,6 @@ void TechnoClassExt::_Draw_Text_Overlay(Point2D& point1, Point2D& point2, Rect& 
 }
 
 
-
 /**
  *  #issue-977
  *

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -71,7 +71,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     CameoImageSurface(nullptr),
     IsSortCameoAsBaseDefense(false),
     Description(""),
-    FilterFromBandBoxSelection(false)
+    IsFilterFromBandBoxSelection(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -285,7 +285,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     IsSortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", IsSortCameoAsBaseDefense);
-    FilterFromBandBoxSelection = ini.Get_Bool(ini_name, "FilterFromBandBoxSelection", FilterFromBandBoxSelection);
+    IsFilterFromBandBoxSelection = ini.Get_Bool(ini_name, "FilterFromBandBoxSelection", IsFilterFromBandBoxSelection);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -183,5 +183,5 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
          *  If this property is set to true, this object will not be selected when band box selecting
          *  if any objects in the selection have it set to false (e. g., harvesters and MCVs won't be selected with tanks).
          */
-        bool FilterFromBandBoxSelection;
+        bool IsFilterFromBandBoxSelection;
 };


### PR DESCRIPTION
- This PR adds the option to customize what colors are used in the user interface per-side.

In `RULES.INI`:
```ini
[SOMESIDE]          ; SideType
UIColor=LightGold   ; ColorScheme, the color to be used when drawing some UI elements.
ToolTipColor=Green  ; ColorScheme, the color to be used when drawing tooltips.
```

![image](https://github.com/user-attachments/assets/f4219655-2d28-49d2-9537-25f2fe4ae102)
