### PR TITLE
Add per-side crew customization

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -183,4 +183,5 @@ This page lists all the individual contributions to the project by their author.
   - Adjustments to the band box, action line, target laser and NavCom queue line customization features.
   - Implement `FilterFromBandBoxSelection`.
   - Add the possibility to customize the UI and Tooltip colors per-side.
+  - Add per-side crew customization.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -185,4 +185,5 @@ This page lists all the individual contributions to the project by their author.
   - Add the possibility to customize the UI and Tooltip colors per-side.
   - Add per-side crew customization.
   - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed.
+  - Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -184,4 +184,5 @@ This page lists all the individual contributions to the project by their author.
   - Implement `FilterFromBandBoxSelection`.
   - Add the possibility to customize the UI and Tooltip colors per-side.
   - Add per-side crew customization.
+  - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed.
 

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -58,3 +58,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
 - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
 - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed.
+- Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -57,3 +57,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where a vehicle transport could end up attached to its own cargo, causing the transport to disappear upon unloading.
 - Fix a bug where a harvester could be ordered to dock with a refinery that wasn't listed in the harvester's `Dock=` key.
 - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
+- Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -74,6 +74,16 @@ ProduceCashResetOnCapture=no  ; boolean, reset the buildings available budget wh
 ProduceCashStartupOneTime=no  ; boolean, is the bonus on capture a "one one" special (further captures will not get the bonus)?
 ```
 
+### Crew
+
+- Vinifera allows customizing the chance that an engineer will exit a building upon its deconstruction.
+
+In `RULES.INI`:
+```ini
+[SOMEBUILDING]    ; BuildingType
+EngineerChance=0  ; integer (%), what is the chance that an engineer will exit this building as its crew. Defaults to 25 for `Factory=BuildingType`, 0 otherwise.
+```
+
 ## Ice
 
 - Ice strength can now be customized.
@@ -125,6 +135,34 @@ In `RULES.INI`:
 [SOMEBULLET]  ; BulletType
 SpawnDelay=3  ; unsigned integer, the number of frames between each of the spawned trailer animations.
 ```
+
+## Sides
+
+## Crew
+
+- Vinifera adds the option to customize the crew a side uses.
+
+In `RULES.INI`:
+```ini
+[SOMESIDE]        ; Side
+Crew=             ; InfantryType, this side's crew. Defaults to `[General]->Crew`
+Engineer=         ; InfantryType, this side's engineer. Defaults to `[General]->Engineer`
+Technician=       ; InfantryType, this side's technician. Defaults to `[General]->Technician`
+SurvivorDivisor=  ; integer, this side's survivor divisor. Defaults to `[General]->SurvivorDivisor`
+```
+
+## Colors
+
+- Vinifera adds the option to customize what colors are used in the user interface per-side.
+
+In `RULES.INI`:
+```ini
+[SOMESIDE]          ; SideT
+UIColor=LightGold   ; ColorScheme, the color to be used when drawing UI elements.
+ToolTipColor=Green  ; ColorScheme, the color to be used when drawing tooltips.
+```
+
+![image](https://github.com/user-attachments/assets/f4219655-2d28-49d2-9537-25f2fe4ae102)
 
 ## Technos
 
@@ -188,6 +226,20 @@ Organic=no                  ; boolean, whether an infantry using this warhead ca
 
 ```{warning}
 It is recommended to set both `Retaliate.X` and `PassiveAcquire.X` to `no` if `ForceFire.X` is disabled. Otherwise, units may lock onto targets they are not permitted to fire at and continue to target them until they receive another order.
+```
+
+### Crew
+
+- Vinifera allows customizing how many crew will exit a unit upon its death. Crew will only exit if `Crewed=yes`, even if `CrewCount` is set to a number grater than 0.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]  ; TechnoType
+CrewCount=1   ; integer, how many crew will exit this unit.
+```
+
+```{note}
+This tag does not apply to buildings.
 ```
 
 ### AILegalTarget

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -148,6 +148,7 @@ In `RULES.INI`:
 Crew=             ; InfantryType, this side's crew. Defaults to `[General]->Crew`
 Engineer=         ; InfantryType, this side's engineer. Defaults to `[General]->Engineer`
 Technician=       ; InfantryType, this side's technician. Defaults to `[General]->Technician`
+Disguise=         ; InfantryType, the type this side will see other players' spies as. Defaults to `[General]->Disguise`
 SurvivorDivisor=  ; integer, this side's survivor divisor. Defaults to `[General]->SurvivorDivisor`
 ```
 
@@ -230,7 +231,7 @@ It is recommended to set both `Retaliate.X` and `PassiveAcquire.X` to `no` if `F
 
 ### Crew
 
-- Vinifera allows customizing how many crew will exit a unit upon its death. Crew will only exit if `Crewed=yes`, even if `CrewCount` is set to a number grater than 0.
+- Vinifera allows customizing how many crew will exit a unit upon its death. Crew will only exit if `Crewed=yes`, even if `CrewCount` is set to a number greater than 0.
 
 In `RULES.INI`:
 ```ini

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -84,6 +84,10 @@ In `RULES.INI`:
 EngineerChance=0  ; integer (%), what is the chance that an engineer will exit this building as its crew. Defaults to 25 for `Factory=BuildingType`, 0 otherwise.
 ```
 
+```{warning}
+It is not recommended to set `EngineerChance=100`, as this may put the game into an infinite loop when it insists an infantry other than an engineer exits the building.
+```
+
 ## Ice
 
 - Ice strength can now be customized.

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -330,19 +330,6 @@ NavComQueueLineDropShadowColor=0,0,0  ; RGB color, color to draw the NavCom queu
 
 ![drag-and-move](https://github.com/user-attachments/assets/b17163e7-81f3-4132-983f-e33809cd8d1b)
 
-## Customizable Colors
-
-- Vinifera adds the option to customize what colors are used in the user interface per-side.
-
-In `RULES.INI`:
-```ini
-[SOMESIDE]          ; SideType
-UIColor=LightGold   ; ColorScheme, the color to be used when drawing UI elements.
-ToolTipColor=Green  ; ColorScheme, the color to be used when drawing tooltips.
-```
-
-![image](https://github.com/user-attachments/assets/f4219655-2d28-49d2-9537-25f2fe4ae102)
-
 ## Miscellaneous
 
 - Vinifera adds support for 8-bit (paletted and non-paletted) PCX and 8-bit PNG cameos. This system auto-detects and prioritises the PNG or PCX file if found, no additional settings are required.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -208,6 +208,7 @@ Vanilla fixes:
 - Fix a bug where the AI would sell off buildings with `Artillary=yes`, `TickTank=yes` or `IsJuggernaut=yes` that had `UndeploysInto=none` when they were fired at by something outside of their weapon range (by Rampastring)
 - Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters (by Rampastring)
 - Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team (by Rampastring)
+- Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed (by ZivDero)
 
 </details>
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -209,6 +209,7 @@ Vanilla fixes:
 - Fix a bug where harvesters on large maps could prefer unloading at refineries that were the longest distance away from the harvesters (by Rampastring)
 - Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team (by Rampastring)
 - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed (by ZivDero)
+- Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying (by ZivDero)
 
 </details>
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -149,6 +149,7 @@ New:
 - Implement various controls to show and customise NavCom queue lines (by CCHyper/tomsons26)
 - Implement `FilterFromBandBoxSelection` (by ZivDero/Rampastring)
 - Add the possibility to customize the UI and Tooltip colors per-side (by Rampastring/ZivDero)
+- Add per-side crew customization (by ZivDero)
 
 
 Vanilla fixes:

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -176,9 +176,7 @@ const InfantryTypeClass* BuildingClassExt::_Crew_Type() const
      */
     const int engineer_chance = Extension::Fetch<BuildingTypeClassExtension>(Class)->EngineerChance;
     if (!IsCaptured && Random_Pick(0, 99) < engineer_chance && Class->ToBuild == RTTI_BUILDINGTYPE)
-    {
         return SideClassExtension::Get_Engineer(House);
-    }
 
     return TechnoClass::Crew_Type();
 }

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -195,7 +195,7 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
 
     if (!IsInitialized) {
         IsEligibleForAllyBuilding = This()->IsConstructionYard;
-        EngineerChance = This()->ToBuild == RTTI_BUILDINGTYPE;
+        EngineerChance = This()->ToBuild == RTTI_BUILDINGTYPE ? 25 : 0;
     }
 
     GateUpSound = ini.Get_VocType(ini_name, "GateUpSound", GateUpSound);

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -50,7 +50,8 @@ BuildingTypeClassExtension::BuildingTypeClassExtension(const BuildingTypeClass *
     ProduceCashBudget(0),
     IsStartupCashOneTime(false),
     IsResetBudgetOnCapture(false),
-    IsEligibleForAllyBuilding(false)
+    IsEligibleForAllyBuilding(false),
+    EngineerChance(0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("BuildingTypeClassExtension::BuildingTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -194,6 +195,7 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
 
     if (!IsInitialized) {
         IsEligibleForAllyBuilding = This()->IsConstructionYard;
+        EngineerChance = This()->ToBuild == RTTI_BUILDINGTYPE;
     }
 
     GateUpSound = ini.Get_VocType(ini_name, "GateUpSound", GateUpSound);

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -106,4 +106,9 @@ BuildingTypeClassExtension final : public TechnoTypeClassExtension
          *  Is this building eligible for proximity checks by players who are its owner's allies?
          */
         bool IsEligibleForAllyBuilding;
+
+        /**
+         *  The percent chance for an engineer to exit this building as its crew.
+         */
+        int EngineerChance;
 };

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -116,6 +116,7 @@ HRESULT SideClassExtension::Load(IStream *pStm)
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Crew, "Crew");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Engineer, "Engineer");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Technician, "Technician");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Disguise, "Disguise");
     
     return hr;
 }
@@ -208,6 +209,7 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
     Crew = ini.Get_Infantry(ini_name, "Crew", Crew);
     Engineer = ini.Get_Infantry(ini_name, "Engineer", Engineer);
     Technician = ini.Get_Infantry(ini_name, "Technician", Technician);
+    Disguise = ini.Get_Infantry(ini_name, "Disguise", Disguise);
     SurvivorDivisor = ini.Get_Int(ini_name, "SurvivorDivisor", SurvivorDivisor);
 
     IsInitialized = true;
@@ -215,6 +217,12 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
     return true;
 }
 
+
+/**
+ *  Returns the crew type for the given side.
+ *
+ *  @author: ZivDero
+ */
 const InfantryTypeClass* SideClassExtension::Get_Crew(SideType side)
 {
     if (side == SIDE_NONE)
@@ -224,6 +232,11 @@ const InfantryTypeClass* SideClassExtension::Get_Crew(SideType side)
 }
 
 
+/**
+ *  Returns the engineer type for the given side.
+ *
+ *  @author: ZivDero
+ */
 const InfantryTypeClass* SideClassExtension::Get_Engineer(SideType side)
 {
     if (side == SIDE_NONE)
@@ -233,6 +246,11 @@ const InfantryTypeClass* SideClassExtension::Get_Engineer(SideType side)
 }
 
 
+/**
+ *  Returns the technician type for the given side.
+ *
+ *  @author: ZivDero
+ */
 const InfantryTypeClass* SideClassExtension::Get_Technician(SideType side)
 {
     if (side == SIDE_NONE)
@@ -242,6 +260,25 @@ const InfantryTypeClass* SideClassExtension::Get_Technician(SideType side)
 }
 
 
+/**
+ *  Returns the disguise type for the given side.
+ *
+ *  @author: ZivDero
+ */
+const InfantryTypeClass* SideClassExtension::Get_Disguise(SideType side)
+{
+    if (side == SIDE_NONE)
+        return Rule->Disguise;
+
+    return Extension::Fetch<SideClassExtension>(Sides[side])->Disguise;
+}
+
+
+/**
+ *  Returns the survivor divisor for the given side.
+ *
+ *  @author: ZivDero
+ */
 int SideClassExtension::Get_Survivor_Divisor(SideType side)
 {
     if (side == SIDE_NONE)

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -31,7 +31,9 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "colorscheme.h"
+#include "rules.h"
 #include "debughandler.h"
+#include "tibsun_globals.h"
 
 
 /**
@@ -190,12 +192,55 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
 
         UIColor = ColorScheme::From_Name("LightGold");
         ToolTipColor = ColorScheme::From_Name("Green");
+        Crew = Rule->Crew;
+        Engineer = Rule->Engineer;
+        Technician = Rule->Technician;
+        SurvivorDivisor = Rule->SurvivorDivisor;
     }
 
     UIColor = ini.Get_ColorSchemeType(ini_name, "UIColor", UIColor);
     ToolTipColor = ini.Get_ColorSchemeType(ini_name, "ToolTipColor", ToolTipColor);
+    Crew = ini.Get_Infantry(ini_name, "Crew", Crew);
+    Engineer = ini.Get_Infantry(ini_name, "Engineer", Engineer);
+    Technician = ini.Get_Infantry(ini_name, "Technician", Technician);
+    SurvivorDivisor = ini.Get_Int(ini_name, "SurvivorDivisor", SurvivorDivisor);
 
     IsInitialized = true;
 
     return true;
+}
+
+const InfantryTypeClass* SideClassExtension::Get_Crew(SideType side)
+{
+    if (side == SIDE_NONE)
+        return Rule->Crew;
+
+    return Extension::Fetch<SideClassExtension>(Sides[side])->Crew;
+}
+
+
+const InfantryTypeClass* SideClassExtension::Get_Engineer(SideType side)
+{
+    if (side == SIDE_NONE)
+        return Rule->Engineer;
+
+    return Extension::Fetch<SideClassExtension>(Sides[side])->Engineer;
+}
+
+
+const InfantryTypeClass* SideClassExtension::Get_Technician(SideType side)
+{
+    if (side == SIDE_NONE)
+        return Rule->Technician;
+
+    return Extension::Fetch<SideClassExtension>(Sides[side])->Technician;
+}
+
+
+int SideClassExtension::Get_Survivor_Divisor(SideType side)
+{
+    if (side == SIDE_NONE)
+        return Rule->SurvivorDivisor;
+
+    return Extension::Fetch<SideClassExtension>(Sides[side])->SurvivorDivisor;
 }

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -45,7 +45,12 @@
 SideClassExtension::SideClassExtension(const SideClass *this_ptr) :
     AbstractTypeClassExtension(this_ptr),
     UIColor(COLORSCHEME_NONE),
-    ToolTipColor(COLORSCHEME_NONE)
+    ToolTipColor(COLORSCHEME_NONE),
+    Crew(nullptr),
+    Engineer(nullptr),
+    Technician(nullptr),
+    Disguise(nullptr),
+    SurvivorDivisor(100)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("SideClassExtension::SideClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -201,6 +206,7 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
         Crew = Rule->Crew;
         Engineer = Rule->Engineer;
         Technician = Rule->Technician;
+        Disguise = Rule->Disguise;
         SurvivorDivisor = Rule->SurvivorDivisor;
     }
 

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -34,6 +34,7 @@
 #include "rules.h"
 #include "debughandler.h"
 #include "tibsun_globals.h"
+#include "vinifera_saveload.h"
 
 
 /**
@@ -111,6 +112,10 @@ HRESULT SideClassExtension::Load(IStream *pStm)
     }
 
     new (this) SideClassExtension(NoInitClass());
+
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Crew, "Crew");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Engineer, "Engineer");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Technician, "Technician");
     
     return hr;
 }

--- a/src/extensions/side/sideext.h
+++ b/src/extensions/side/sideext.h
@@ -69,11 +69,13 @@ SideClassExtension final : public AbstractTypeClassExtension
         static const InfantryTypeClass* Get_Crew(SideType side);
         static const InfantryTypeClass* Get_Engineer(SideType side);
         static const InfantryTypeClass* Get_Technician(SideType side);
+        static const InfantryTypeClass* Get_Disguise(SideType side);
         static int Get_Survivor_Divisor(SideType side);
 
         inline static const InfantryTypeClass* Get_Crew(const HouseClass* house) { return Get_Crew(house->Class->Side); }
         inline static const InfantryTypeClass* Get_Engineer(const HouseClass* house) { return Get_Engineer(house->Class->Side); }
         inline static const InfantryTypeClass* Get_Technician(const HouseClass* house) { return Get_Technician(house->Class->Side); }
+        inline static const InfantryTypeClass* Get_Disguise(const HouseClass* house) { return Get_Disguise(house->Class->Side); }
         inline static int Get_Survivor_Divisor(const HouseClass* house) { return Get_Survivor_Divisor(house->Class->Side); }
 
     public:
@@ -102,6 +104,11 @@ SideClassExtension final : public AbstractTypeClassExtension
          *  InfantryType used as this Side's technician.
          */
         const InfantryTypeClass* Technician;
+
+        /**
+         *  InfantryType used as this Side's disguise.
+         */
+        const InfantryTypeClass* Disguise;
 
         /**
          *  The number of survivors is divided by this much when calculating a building's number of survivors.

--- a/src/extensions/side/sideext.h
+++ b/src/extensions/side/sideext.h
@@ -29,7 +29,12 @@
 
 #include "abstracttypeext.h"
 #include "side.h"
+#include "house.h"
+#include "housetype.h"
+#include "tibsun_globals.h"
 
+
+class InfantryTypeClass;
 
 class DECLSPEC_UUID(UUID_SIDE_EXTENSION)
 SideClassExtension final : public AbstractTypeClassExtension
@@ -61,6 +66,16 @@ SideClassExtension final : public AbstractTypeClassExtension
 
         virtual bool Read_INI(CCINIClass &ini) override;
 
+        static const InfantryTypeClass* Get_Crew(SideType side);
+        static const InfantryTypeClass* Get_Engineer(SideType side);
+        static const InfantryTypeClass* Get_Technician(SideType side);
+        static int Get_Survivor_Divisor(SideType side);
+
+        inline static const InfantryTypeClass* Get_Crew(const HouseClass* house) { return Get_Crew(house->Class->Side); }
+        inline static const InfantryTypeClass* Get_Engineer(const HouseClass* house) { return Get_Engineer(house->Class->Side); }
+        inline static const InfantryTypeClass* Get_Technician(const HouseClass* house) { return Get_Technician(house->Class->Side); }
+        inline static int Get_Survivor_Divisor(const HouseClass* house) { return Get_Survivor_Divisor(house->Class->Side); }
+
     public:
 
         /**
@@ -72,4 +87,24 @@ SideClassExtension final : public AbstractTypeClassExtension
          *  Color scheme to be used for the tooltips of this side.
          */
         ColorSchemeType ToolTipColor;
+
+        /**
+         *  InfantryType used as this Side's crew.
+         */
+        const InfantryTypeClass* Crew;
+
+        /**
+         *  InfantryType used as this Side's engineer.
+         */
+        const InfantryTypeClass* Engineer;
+
+        /**
+         *  InfantryType used as this Side's technician.
+         */
+        const InfantryTypeClass* Technician;
+
+        /**
+         *  The number of survivors is divided by this much when calculating a building's number of survivors.
+         */
+        int SurvivorDivisor;
 };

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1046,7 +1046,7 @@ const InfantryTypeClass* TechnoClassExt::_Crew_Type() const
     /**
      *  If it's armed, it could also have a technician exit it.
      */
-    if (Is_Weapon_Equipped() && Random_Pick(0, 99) < 15) {
+    if (Is_Weapon_Equipped() && Percent_Chance(15)) {
         return SideClassExtension::Get_Technician(House);
     }
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -72,7 +72,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsSortCameoAsBaseDefense(false),
     Description(""),
     IsFilterFromBandBoxSelection(false),
-    CrewCount(0)
+    CrewCount(1)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -283,10 +283,6 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     BSurface *imagesurface = Vinifera_Get_Image_Surface(This()->CameoFilename);
     if (imagesurface) {
         CameoImageSurface = imagesurface;
-    }
-
-    if (!IsInitialized) {
-        CrewCount = This()->IsCrew ? 1 : 0;
     }
 
     IsSortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", IsSortCameoAsBaseDefense);

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -71,7 +71,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     CameoImageSurface(nullptr),
     IsSortCameoAsBaseDefense(false),
     Description(""),
-    IsFilterFromBandBoxSelection(false)
+    IsFilterFromBandBoxSelection(false),
+    CrewCount(0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -284,8 +285,13 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
         CameoImageSurface = imagesurface;
     }
 
+    if (!IsInitialized) {
+        CrewCount = This()->IsCrew ? 1 : 0;
+    }
+
     IsSortCameoAsBaseDefense = ini.Get_Bool(ini_name, "SortCameoAsBaseDefense", IsSortCameoAsBaseDefense);
     IsFilterFromBandBoxSelection = ini.Get_Bool(ini_name, "FilterFromBandBoxSelection", IsFilterFromBandBoxSelection);
+    CrewCount = ini.Get_Int(ini_name, "CrewCount", CrewCount);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -184,4 +184,9 @@ class TechnoTypeClassExtension : public ObjectTypeClassExtension
          *  if any objects in the selection have it set to false (e. g., harvesters and MCVs won't be selected with tanks).
          */
         bool IsFilterFromBandBoxSelection;
+
+        /**
+         *  How many crew members should exit this object when it is destroyed?
+         */
+        int CrewCount;
 };


### PR DESCRIPTION
- This PR adds the option to customize the crew a side uses.

In `RULES.INI`:
```ini
[SOMESIDE]        ; Side
Crew=             ; InfantryType, this side's crew. Defaults to `[General]->Crew`
Engineer=         ; InfantryType, this side's engineer. Defaults to `[General]->Engineer`
Technician=       ; InfantryType, this side's technician. Defaults to `[General]->Technician`
Disguise=         ; InfantryType, the type this side will se other players' spies as. Defaults  to `[General]->Disguise`
SurvivorDivisor=  ; integer, this side's survivor divisor. Defaults to `[General]->SurvivorDivisor`
```

- This PR allows customizing the chance that an engineer will exit a building upon its deconstruction.

In `RULES.INI`:
```ini
[SOMEBUILDING]    ; BuildingType
EngineerChance=0  ; integer (%), what is the chance that an engineer will exit this building as its crew. Defaults to 25 for `Factory=BuildingType`, 0 otherwise.
```

- This PR allows customizing how many crew will exit a unit upon its death. Crew will only exit if `Crewed=yes`, even if `CrewCount` is set to a number grater than 0.

In `RULES.INI`:
```ini
[SOMETECHNO]  ; TechnoType
CrewCount=1   ; integer, how many crew will exit this unit.
```

```{note}
This tag does not apply to buildings.
```

Resolves #445, partially #457.