### PR TITLE
Allow customizing the Hunter-Seeker per side.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -186,4 +186,5 @@ This page lists all the individual contributions to the project by their author.
   - Add per-side crew customization.
   - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed.
   - Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying.
+  - Allow customizing the hunter-seeker unit type per side.
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -142,7 +142,7 @@ SpawnDelay=3  ; unsigned integer, the number of frames between each of the spawn
 
 ## Sides
 
-## Crew
+### Crew
 
 - Vinifera adds the option to customize the crew a side uses.
 
@@ -156,18 +156,28 @@ Disguise=         ; InfantryType, the type this side will see other players' spi
 SurvivorDivisor=  ; integer, this side's survivor divisor. Defaults to `[General]->SurvivorDivisor`
 ```
 
-## Colors
+### Colors
 
 - Vinifera adds the option to customize what colors are used in the user interface per-side.
 
 In `RULES.INI`:
 ```ini
-[SOMESIDE]          ; SideT
+[SOMESIDE]          ; Side
 UIColor=LightGold   ; ColorScheme, the color to be used when drawing UI elements.
 ToolTipColor=Green  ; ColorScheme, the color to be used when drawing tooltips.
 ```
 
 ![image](https://github.com/user-attachments/assets/f4219655-2d28-49d2-9537-25f2fe4ae102)
+
+### Hunter-Seeker
+
+- Vinifera adds the option to customize what unit serves as the Hunter-Seeker per side. The default Hunter-Seeker is `[General]->GDIHunterSeeker` if the side's name contains `GDI`, otherwise `[General]->NodHunterSeeker`.
+
+In `RULES.INI`:
+```ini
+[SOMESIDE]     ; Side
+HunterSeeker=  ; UnitType, the unit that is this side's Hunter-Seeker.
+```
 
 ## Technos
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -210,6 +210,7 @@ Vanilla fixes:
 - Fix a bug where the camera kept following a followed object when a trigger or script told it to center on a waypoint or team (by Rampastring)
 - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed (by ZivDero)
 - Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying (by ZivDero)
+- Allow customizing the hunter-seeker unit type per side (by ZivDero)
 
 </details>
 

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -50,7 +50,8 @@ SideClassExtension::SideClassExtension(const SideClass *this_ptr) :
     Engineer(nullptr),
     Technician(nullptr),
     Disguise(nullptr),
-    SurvivorDivisor(100)
+    SurvivorDivisor(100),
+    HunterSeeker(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("SideClassExtension::SideClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -122,6 +123,7 @@ HRESULT SideClassExtension::Load(IStream *pStm)
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Engineer, "Engineer");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Technician, "Technician");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Disguise, "Disguise");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(HunterSeeker, "HunterSeeker");
     
     return hr;
 }
@@ -203,20 +205,30 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
 
         UIColor = ColorScheme::From_Name("LightGold");
         ToolTipColor = ColorScheme::From_Name("Green");
+
         Crew = Rule->Crew;
         Engineer = Rule->Engineer;
         Technician = Rule->Technician;
         Disguise = Rule->Disguise;
         SurvivorDivisor = Rule->SurvivorDivisor;
+
+        if (std::strstr(ini_name, "GDI")) {
+            HunterSeeker = Rule->GDIHunterSeeker;
+        } else {
+            HunterSeeker = Rule->NodHunterSeeker;
+        }
     }
 
     UIColor = ini.Get_ColorSchemeType(ini_name, "UIColor", UIColor);
     ToolTipColor = ini.Get_ColorSchemeType(ini_name, "ToolTipColor", ToolTipColor);
+
     Crew = ini.Get_Infantry(ini_name, "Crew", Crew);
     Engineer = ini.Get_Infantry(ini_name, "Engineer", Engineer);
     Technician = ini.Get_Infantry(ini_name, "Technician", Technician);
     Disguise = ini.Get_Infantry(ini_name, "Disguise", Disguise);
     SurvivorDivisor = ini.Get_Int(ini_name, "SurvivorDivisor", SurvivorDivisor);
+
+    HunterSeeker = ini.Get_Unit(ini_name, "HunterSeeker", HunterSeeker);
 
     IsInitialized = true;
 

--- a/src/extensions/side/sideext.h
+++ b/src/extensions/side/sideext.h
@@ -114,4 +114,9 @@ SideClassExtension final : public AbstractTypeClassExtension
          *  The number of survivors is divided by this much when calculating a building's number of survivors.
          */
         int SurvivorDivisor;
+
+        /**
+         *  UnitType used as this Side's Hunter-Seeker.
+         */
+        const UnitTypeClass* HunterSeeker;
 };

--- a/src/extensions/super/superext_hooks.cpp
+++ b/src/extensions/super/superext_hooks.cpp
@@ -31,9 +31,62 @@
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "extension.h"
+#include "unit.h"
+#include "house.h"
+#include "housetype.h"
+#include "sideext.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  Helper function that creates a hunter-seeker for the house's side.
+ *
+ *  @author: ZivDero
+ */
+static UnitClass* Make_HunterSeeker(HouseClass* house)
+{
+    const auto side_ext = Extension::Fetch<SideClassExtension>(Sides[house->Class->Side]);
+
+    if (side_ext->HunterSeeker) {
+        return new UnitClass(const_cast<UnitTypeClass*>(side_ext->HunterSeeker), house);
+    }
+
+    return nullptr;
+}
+
+
+/**
+ *  Patch to use the hunter-seeker for the house's side.
+ *
+ *  @author: ZivDero
+ */
+DECLARE_PATCH(_SuperClass_Place_HunterSeeker_Type_Patch)
+{
+    GET_REGISTER_STATIC(SuperClass*, this_ptr, esi);
+    static UnitClass* hunter_seeker;
+
+    /**
+     *  Fetch the hunter-seeker for this house's side.
+     */
+    hunter_seeker = Make_HunterSeeker(this_ptr->House);
+    _asm mov esi, hunter_seeker
+
+    /**
+     *  If we've successfully created a hunter-seeker, proceed to launching it.
+     */
+    if (hunter_seeker) {
+        JMP(0x0060C642);
+    }
+    /**
+     *  Otherwise, abort (return).
+     */
+    else {
+        JMP(0x0060C68F);
+    }
+}
 
 
 /**
@@ -45,4 +98,6 @@ void SuperClassExtension_Hooks()
      *  Initialises the extended class.
      */
     SuperClassExtension_Init();
+
+    Patch_Jump(0x0060C5DE, &_SuperClass_Place_HunterSeeker_Type_Patch);
 }


### PR DESCRIPTION
This PR adds the option to customize what unit serves as the Hunter-Seeker per side. The default Hunter-Seeker is `[General]->GDIHunterSeeker` if the side's name contains `GDI`, otherwise `[General]->NodHunterSeeker`.

In `RULES.INI`:
```ini
[SOMESIDE]     ; Side
HunterSeeker=  ; UnitType, the unit that is this side's Hunter-Seeker.
```