### PR TITLE
Allow customizing power plants per side

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,4 +187,5 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed.
   - Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying.
   - Allow customizing the hunter-seeker unit type per side.
+  - Allow customizing power plants per side.
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -181,7 +181,7 @@ AdvancedPowerPlant=  ; BuildingType, the regular power plant this side uses.
 PowerTurbine=        ; BuildingType, the power turbine this side uses.
 ```
 
-- The AI will first attempt to fill its existing regular power plants with turbines, then, if possible, construct additional advanced power plants, otherwise build new regular power plants.
+- The AI will prioritize upgrading its existing regular power plants with turbines. If possible, it will then construct advanced power plants; otherwise, it will build additional regular power plants.
 - If the side's name contains `GDI`, the defaults are as follows:
 ```ini
 RegularPowerPlant=[General]->GDIPowerPlant
@@ -191,18 +191,18 @@ PowerTurbine=[General]->GDIPowerTurbine
 - Otherwise, the defaults are as follows:
 ```ini
 RegularPowerPlant=[General]->NodRegularPower
-AdvancedPowerPlant=NodAdvancedPower
+AdvancedPowerPlant=[General]->NodAdvancedPower
 PowerTurbine=<none>
 ```
 
 ```{note}
-If you wish to reset a key compared to its default, you can specify `<none>` as its value.
+If you want to remove a key's default value, you can set its value to `<none>`.
 ```
 
 ### Hunter-Seeker
 
 - Vinifera adds the option to customize what unit serves as the Hunter-Seeker per side.
-- The default Hunter-Seeker is `[General]->GDIHunterSeeker` if the side's name contains `GDI`, otherwise `[General]->NodHunterSeeker`.
+- The default Hunter-Seeker is `[General]->GDIHunterSeeker` if the side's name contains `GDI`; otherwise, it defaults to `[General]->NodHunterSeeker`.
 
 In `RULES.INI`:
 ```ini

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -169,9 +169,40 @@ ToolTipColor=Green  ; ColorScheme, the color to be used when drawing tooltips.
 
 ![image](https://github.com/user-attachments/assets/f4219655-2d28-49d2-9537-25f2fe4ae102)
 
+### Power Plants
+
+- Vinifera allows customizing what power plants the AI will build per side.
+
+In `RULES.INI`:
+```ini
+[SOMESIDE]           ; Side
+RegularPowerPlant=   ; BuildingType, the advanced power plant this side uses.
+AdvancedPowerPlant=  ; BuildingType, the regular power plant this side uses.
+PowerTurbine=        ; BuildingType, the power turbine this side uses.
+```
+
+- The AI will first attempt to fill its existing regular power plants with turbines, then, if possible, construct additional advanced power plants, otherwise build new regular power plants.
+- If the side's name contains `GDI`, the defaults are as follows:
+```ini
+RegularPowerPlant=[General]->GDIPowerPlant
+AdvancedPowerPlant=<none>
+PowerTurbine=[General]->GDIPowerTurbine
+```
+- Otherwise, the defaults are as follows:
+```ini
+RegularPowerPlant=[General]->NodRegularPower
+AdvancedPowerPlant=NodAdvancedPower
+PowerTurbine=<none>
+```
+
+```{note}
+If you wish to reset a key compared to its default, you can specify `<none>` as its value.
+```
+
 ### Hunter-Seeker
 
-- Vinifera adds the option to customize what unit serves as the Hunter-Seeker per side. The default Hunter-Seeker is `[General]->GDIHunterSeeker` if the side's name contains `GDI`, otherwise `[General]->NodHunterSeeker`.
+- Vinifera adds the option to customize what unit serves as the Hunter-Seeker per side.
+- The default Hunter-Seeker is `[General]->GDIHunterSeeker` if the side's name contains `GDI`, otherwise `[General]->NodHunterSeeker`.
 
 In `RULES.INI`:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -211,6 +211,7 @@ Vanilla fixes:
 - Fix a bug where crew wouldn't exit from construction yards when they were sold or destroyed (by ZivDero)
 - Fix a bug where you could sometimes get extra crew to exit a building that was being sold and was destroying/undeploying (by ZivDero)
 - Allow customizing the hunter-seeker unit type per side (by ZivDero)
+- Allow customizing power plants per side (by ZivDero)
 
 </details>
 

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -412,7 +412,7 @@ int HouseClassExt::_AI_Building()
     /**
      *  Build our chosen power structure before building whatever else we're trying to build.
      */
-    Base.Nodes.Insert(Base.Nodes.ID(node) - 1, BaseNodeClass(choice->Type, Cell()));
+    Base.Nodes.Insert(Base.Nodes.ID(node), BaseNodeClass(choice->Type, Cell()));
 
     return 1;
 }

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -261,6 +261,12 @@ ProdFailType HouseClassExt::_Abandon_Production(RTTIType type, int id)
  */
 int HouseClassExt::_AI_Building()
 {
+    enum {
+        BASE_WALL = -3,
+        BASE_UNKNOWN = -2,
+        BASE_DEFENSE = -1
+    };
+
     /**
      *  Unfortunately, ts-patches spawner has a hack here.
      *  Until we reimplement the spawner in Vinifera, this will have to do.
@@ -291,19 +297,20 @@ int HouseClassExt::_AI_Building()
 
     if (!node) return TICKS_PER_SECOND;
 
-    if (node->Type == -3) {
-        /**
-         *  Build some walls.
-         */
+    /**
+     *  Build some walls.
+     */
+    if (node->Type == BASE_WALL) {
         Base.Nodes.Delete(Base.Nodes.ID(node));
         AI_Build_Wall();
         return 1;
     }
 
-    if (node->Type == -1 || BuildingTypes[node->Type] == Rule->WallTower && node->Where.X != 0 && node->Where.Y != 0) {
-        /**
-         *  Build some defenses.
-         */
+    /**
+     *  Build some defenses.
+     */
+    if (node->Type == BASE_DEFENSE || BuildingTypes[node->Type] == Rule->WallTower && node->Where.X != 0 && node->Where.Y != 0) {
+
         const int nodeid = Base.Nodes.ID(node);
         if (!AI_Build_Defense(nodeid, Base.field_38.Count() > 0 ? &Base.field_38 : nullptr)) {
 
@@ -325,11 +332,11 @@ int HouseClassExt::_AI_Building()
         node = Base.Next_Buildable();
     }
 
-    if (!node || node->Type == -2) return TICKS_PER_SECOND;
+    if (!node || node->Type == BASE_UNKNOWN) return TICKS_PER_SECOND;
 
     /**
      *  In campaigns, or if we have enough power, or if we're trying to building a construction yard,
-     *  just proceed to build the next base node.
+     *  just proceed with building the base node.
      */
     BuildingTypeClass* b = BuildingTypes[node->Type];
     if (Session.Type == GAME_NORMAL || spawner_hack_mpnodes || b->Drain + Drain <= Power - PowerSurplus || Rule->BuildConst.Is_Present(b) || b->Drain <= 0) {

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -300,7 +300,7 @@ int HouseClassExt::_AI_Building()
         return 1;
     }
 
-    if (node->Type == -1 || BuildingTypes[node->Type] == Rule->WallTower && node->Where != Cell()) {
+    if (node->Type == -1 || BuildingTypes[node->Type] == Rule->WallTower && node->Where.X != 0 && node->Where.Y != 0) {
         /**
          *  Build some defenses.
          */

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -44,6 +44,9 @@
 #include "asserthandler.h"
 #include "extension_globals.h"
 #include "sidebarext.h"
+#include "rules.h"
+#include "session.h"
+#include "ccini.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
@@ -62,6 +65,7 @@ static class HouseClassExt final : public HouseClass
 public:
     ProdFailType _Begin_Production(RTTIType type, int id, bool resume);
     ProdFailType _Abandon_Production(RTTIType type, int id);
+    int _AI_Building();
 };
 
 
@@ -245,6 +249,165 @@ ProdFailType HouseClassExt::_Abandon_Production(RTTIType type, int id)
     delete fptr;
 
     return PROD_OK;
+}
+
+
+/**
+ *  Determines what building to build.
+ *
+ *  @author: 09/29/1995 JLB - Created.
+ *           ZivDero - Adjustments for Tiberian Sun
+ */
+int HouseClassExt::_AI_Building()
+{
+    /**
+     *  Unfortunately, ts-patches spawner has a hack here.
+     *  Until we reimplement the spawner in Vinifer, this will have to do.
+     */
+    static bool spawner_hack_init = false;
+    static bool spawner_hack_mpnodes = false;
+
+    if (!spawner_hack_init)
+    {
+        RawFileClass file("SPAWN.INI");
+        CCINIClass spawn_ini;
+
+        if (file.Is_Available()) {
+
+            spawn_ini.Load(file, false);
+            spawner_hack_mpnodes = spawn_ini.Get_Bool("Settings", "UseMPAIBaseNodes", spawner_hack_mpnodes);
+        }
+
+        spawner_hack_init = true;
+    }
+
+
+    if (BuildStructure != BUILDING_NONE) return TICKS_PER_SECOND;
+
+    if (ConstructionYards.Count() == 0) return TICKS_PER_SECOND;
+
+    BaseNodeClass* node = Base.Next_Buildable();
+
+    if (!node) return TICKS_PER_SECOND;
+
+    if (node->Type == -3) {
+        /**
+         *  Build some walls.
+         */
+        Base.Nodes.Delete(Base.Nodes.ID(node));
+        AI_Build_Wall();
+        return 1;
+    }
+
+    if (node->Type == -1 || BuildingTypes[node->Type] == Rule->WallTower && node->Where != Cell()) {
+        /**
+         *  Build some defenses.
+         */
+        const int nodeid = Base.Nodes.ID(node);
+        if (!AI_Build_Defense(nodeid, Base.field_38.Count() > 0 ? &Base.field_38 : nullptr)) {
+
+            /**
+             *  If it's a wall tower, delete it twice?
+             *  Perhaps it's assumed that the wall tower is followed by its upgrade?
+             */
+            if (node->Type == Rule->WallTower->Get_Heap_ID()) {
+                Base.Nodes.Delete(nodeid);
+            }
+
+            /**
+             *  Remove the node from the list.
+             */
+            Base.Nodes.Delete(nodeid);
+            return 1;
+        }
+
+        node = Base.Next_Buildable();
+    }
+
+    if (!node || node->Type == -2) return TICKS_PER_SECOND;
+
+    /**
+     *  In campaigns, or if we have enough power, or if we're trying to building a construction yard,
+     *  just proceed to build the next base node.
+     */
+    BuildingTypeClass* b = BuildingTypes[node->Type];
+    if (Session.Type == GAME_NORMAL || spawner_hack_mpnodes || b->Drain + Drain <= Power - PowerSurplus || Rule->BuildConst.Is_Present(b) || b->Drain <= 0) {
+
+        /**
+         *  Check if this is a building upgrade if we can actually place the upgrade where it's scheduled to be placed.
+         */
+        if (b->PowersUpToLevel == -1 && !node->Where) {
+            if (b->PowersUpBuilding[0]) {
+
+                BuildingClass* existing_b = Map[node->Where].Cell_Building();
+                BuildingTypeClass* desired_b = BuildingTypes[BuildingTypeClass::From_Name(b->PowersUpBuilding)];
+
+                if (!existing_b || existing_b->Class != desired_b
+                    || existing_b->Class->PowersUpToLevel == -1 && existing_b->UpgradeLevel >= existing_b->Class->Upgrades
+                    || existing_b->Class->PowersUpToLevel == 0 && existing_b->UpgradeLevel > 0) {
+
+                    node->Where = Cell();
+                }
+            }
+        }
+
+        BuildStructure = node->Type;
+        return TICKS_PER_SECOND;
+    }
+
+    /**
+     *  In skirmish, try to build a power plant if there is insufficient power.
+     */
+    const BuildingTypeClass* choice = nullptr;
+    if (!std::strcmp(Class->IniName, "GDI")) {
+
+        bool can_build_turbine = false;
+        for (int i = 0; i < Buildings.Count(); i++)
+        {
+            BuildingClass* b2 = Buildings[i];
+            if (b2->Owning_House() == this) {
+                if (b2->Class == Rule->GDIPowerPlant && b2->UpgradeLevel < b2->Class->Upgrades) {
+                    can_build_turbine = true;
+                    break;
+                }
+            }
+        }
+
+        if (can_build_turbine && Probability_Of2(Rule->AIUseTurbineUpgradeProbability)) {
+            choice = Rule->GDIPowerTurbine;
+        }
+        else {
+            choice = Rule->GDIPowerPlant;
+        }
+    }
+    else
+    {
+        DynamicVectorClass<BuildingTypeClass*> owned_buildings;
+
+        for (int i = 0; i < Buildings.Count(); i++)
+        {
+            BuildingClass* b2 = Buildings[i];
+            if (b2->Owning_House() == this) {
+                owned_buildings.Add(b2->Class);
+            }
+        }
+
+        if (Has_Prerequisites(Rule->NodAdvancedPower, owned_buildings, owned_buildings.Count()))
+        {
+            choice = Rule->NodAdvancedPower;
+        }
+        else
+        {
+            choice = Rule->NodRegularPower;
+        }
+    }
+
+    /**
+     *  Build our chosen power structure before building whatever else we're trying to build.
+     */
+    Base.Nodes.Insert(Base.Nodes.ID(node) - 1, BaseNodeClass(choice->Type, Cell()));
+
+    return 1;
 }
 
 
@@ -547,4 +710,6 @@ void HouseClassExtension_Hooks()
     Patch_Jump(0x004BC187, &_HouseClass_Can_Build_BuildLimit_Handle_Vehicle_Transform);
 
     Patch_Jump(0x004CB6C1, &_HouseClass_Enable_SWs_Check_For_Building_Power);
+
+    Patch_Jump(0x004C10E0, &HouseClassExt::_AI_Building);
 }

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -126,6 +126,9 @@ HRESULT SideClassExtension::Load(IStream *pStm)
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Engineer, "Engineer");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Technician, "Technician");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Disguise, "Disguise");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(RegularPowerPlant, "RegularPowerPlant");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(AdvancedPowerPlant, "AdvancedPowerPlant");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(PowerTurbine, "PowerTurbine");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(HunterSeeker, "HunterSeeker");
     
     return hr;

--- a/src/extensions/side/sideext.cpp
+++ b/src/extensions/side/sideext.cpp
@@ -51,6 +51,9 @@ SideClassExtension::SideClassExtension(const SideClass *this_ptr) :
     Technician(nullptr),
     Disguise(nullptr),
     SurvivorDivisor(100),
+    RegularPowerPlant(nullptr),
+    AdvancedPowerPlant(nullptr),
+    PowerTurbine(nullptr),
     HunterSeeker(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("SideClassExtension::SideClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
@@ -213,8 +216,15 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
         SurvivorDivisor = Rule->SurvivorDivisor;
 
         if (std::strstr(ini_name, "GDI")) {
+            RegularPowerPlant = Rule->GDIPowerPlant;
+            AdvancedPowerPlant = nullptr;
+            PowerTurbine = Rule->GDIPowerTurbine;
             HunterSeeker = Rule->GDIHunterSeeker;
+
         } else {
+            RegularPowerPlant = Rule->NodRegularPower;
+            AdvancedPowerPlant = Rule->NodAdvancedPower;
+            PowerTurbine = nullptr;
             HunterSeeker = Rule->NodHunterSeeker;
         }
     }
@@ -227,6 +237,10 @@ bool SideClassExtension::Read_INI(CCINIClass &ini)
     Technician = ini.Get_Infantry(ini_name, "Technician", Technician);
     Disguise = ini.Get_Infantry(ini_name, "Disguise", Disguise);
     SurvivorDivisor = ini.Get_Int(ini_name, "SurvivorDivisor", SurvivorDivisor);
+
+    RegularPowerPlant = ini.Get_Building(ini_name, "RegularPowerPlant", RegularPowerPlant);
+    AdvancedPowerPlant = ini.Get_Building(ini_name, "AdvancedPowerPlant", AdvancedPowerPlant);
+    PowerTurbine = ini.Get_Building(ini_name, "PowerTurbine", PowerTurbine);
 
     HunterSeeker = ini.Get_Unit(ini_name, "HunterSeeker", HunterSeeker);
 

--- a/src/extensions/side/sideext.h
+++ b/src/extensions/side/sideext.h
@@ -115,8 +115,19 @@ SideClassExtension final : public AbstractTypeClassExtension
          */
         int SurvivorDivisor;
 
+        /**
+         *  BuildingType used as this Side's regular power plant.
+         */
         const BuildingTypeClass* RegularPowerPlant;
+
+        /**
+         *  BuildingType used as this Side's advanced power plant.
+         */
         const BuildingTypeClass* AdvancedPowerPlant;
+
+        /**
+         *  BuildingType used as this Side's power turbine.
+         */
         const BuildingTypeClass* PowerTurbine;
 
         /**

--- a/src/extensions/side/sideext.h
+++ b/src/extensions/side/sideext.h
@@ -115,6 +115,10 @@ SideClassExtension final : public AbstractTypeClassExtension
          */
         int SurvivorDivisor;
 
+        const BuildingTypeClass* RegularPowerPlant;
+        const BuildingTypeClass* AdvancedPowerPlant;
+        const BuildingTypeClass* PowerTurbine;
+
         /**
          *  UnitType used as this Side's Hunter-Seeker.
          */


### PR DESCRIPTION
This PR allows customizing what power plants the AI will build per side.

In `RULES.INI`:
```ini
[SOMESIDE]           ; Side
RegularPowerPlant=   ; BuildingType, the advanced power plant this side uses.
AdvancedPowerPlant=  ; BuildingType, the regular power plant this side uses.
PowerTurbine=        ; BuildingType, the power turbine this side uses.
```

- The AI will prioritize upgrading its existing regular power plants with turbines. If possible, it will then construct advanced power plants; otherwise, it will build additional regular power plants.
- If the side's name contains `GDI`, the defaults are as follows:
```ini
RegularPowerPlant=[General]->GDIPowerPlant
AdvancedPowerPlant=<none>
PowerTurbine=[General]->GDIPowerTurbine
```
- Otherwise, the defaults are as follows:
```ini
RegularPowerPlant=[General]->NodRegularPower
AdvancedPowerPlant=[General]->NodAdvancedPower
PowerTurbine=<none>
```

```{note}
If you want to remove a key's default value, you can set its value to `<none>`.
```