### PR TITLE
Modify docs to indicate SpawnDelay is an ART.INI key

### DIFF
--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -147,7 +147,7 @@ When an infantry with `Mechanic=yes` and `OmniHealer=yes` is selected and the mo
 
 - Vinifera adds the `SpawnDelay` key from Red Alert 2.
 
-In `RULES.INI`:
+In `ART.INI`:
 ```ini
 [SOMEBULLET]  ; BulletType
 SpawnDelay=3  ; unsigned integer, the number of frames between each of the spawned trailer animations.


### PR DESCRIPTION
This key was originally added as a Rules.ini key as indicated in the docs, but @CCHyper later also made it work in Art.ini by my request. When I just tested it to see which would have priority however, it turned out that it doesn't work in Rules.ini anymore at all and now that I search for it in the YR INI files, it's apparently only used in ART.INI there as well (which would explain why it would've been removed from RULES.INI in Vinifera).

Since I didn't find any other examples of ART.INI sections for projectiles I ended up calling it `[SOMEANIM]` in the example code, but I'm not fully certain that this is correct.