### PR TITLE
Implement Torpedo logic from Red Alert 1

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -157,8 +157,9 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where house firepower bonus, veterancy and crate upgrade damage modifiers were not applied to railgun `AmbientDamage=`.
   - Implement `FilterFromBandBoxSelection`.
   - Add the possibility to customize the UI and Tooltip colors per-side.
-  - Harvesters' refinery-seeking algorithm now considers both free and occupied refineries when figuring out which refinery to unload at (by Rampastring)
-  - Harvesters now consider distance to refinery when moving from one Tiberium patch to another (by Rampastring)
+  - Harvesters' refinery-seeking algorithm now considers both free and occupied refineries when figuring out which refinery to unload at.
+  - Harvesters now consider distance to refinery when moving from one Tiberium patch to another.
+  - Implement the Torpedo logic from Red Alert 1 for BulletTypes.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **ZivDero**:

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -153,6 +153,16 @@ In `ART.INI`:
 SpawnDelay=3  ; unsigned integer, the number of frames between each of the spawned trailer animations.
 ```
 
+### Torpedoes
+
+- Vinifera ports the Torpedo logic from Red Alert 1. Torpedoes can only be fired at targets on water. Additionally, torpedoes explode when they collide with land or an enemy unit.
+
+In `RULES.INI`:
+```ini
+[SOMEBULLET]
+Torpedo=yes   ; boolean, is this projectile considered a torpedo?
+```
+
 ## Sides
 
 ### Crew

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -154,6 +154,7 @@ New:
 - Implement `DontScore` (by ZivDero)
 - Harvesters' refinery-seeking algorithm now considers both free and occupied refineries when figuring out which refinery to unload at (by Rampastring)
 - Harvesters now consider distance to refinery when moving from one Tiberium patch to another (by Rampastring)
+- Implement the Torpedo logic from Red Alert 1 for BulletTypes (by Rampastring)
 
 
 Vanilla fixes:

--- a/src/extensions/bullettype/bullettypeext.cpp
+++ b/src/extensions/bullettype/bullettypeext.cpp
@@ -41,7 +41,8 @@
  */
 BulletTypeClassExtension::BulletTypeClassExtension(const BulletTypeClass *this_ptr) :
     ObjectTypeClassExtension(this_ptr),
-    SpawnDelay(3)           // Default hardcoded value.
+    SpawnDelay(3),           // Default hardcoded value.
+    IsTorpedo(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("BulletTypeClassExtension::BulletTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -188,6 +189,8 @@ bool BulletTypeClassExtension::Read_INI(CCINIClass &ini)
         return false;
     }
     
+    IsTorpedo = ini.Get_Bool(ini_name, "Torpedo", IsTorpedo);
+
     //if (!ArtINI.Is_Present(graphic_name)) {
     //    return false;
     //}

--- a/src/extensions/bullettype/bullettypeext.h
+++ b/src/extensions/bullettype/bullettypeext.h
@@ -66,4 +66,9 @@ BulletTypeClassExtension final : public ObjectTypeClassExtension
          *  The number of frames between trailer anim spawns.
          */
         unsigned SpawnDelay;
+
+        /**
+         *  If set, this projectile can only be used against targets on water.
+         */
+        bool IsTorpedo;
 };


### PR DESCRIPTION
Partially implements #444

The only thing left out is the line of sight check seen here: https://github.com/electronicarts/CnC_Remastered_Collection/blob/master/REDALERT/VESSEL.CPP#L1081

I also tried porting over it, but it doesn't work in Tiberian Sun; the unit just stays still when `Can_Fire` returns `FIRE_RANGE` while the unit is actually in range according to weapon stats. In Red Alert, that supposedly made submarines move closer to the target.