### PR TITLE
Implement WaterAlt

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -195,4 +195,5 @@ This page lists all the individual contributions to the project by their author.
   - Allow customizing power plants per side.
   - Reimplement aircraft carriers and missile launchers from Red Alert 2.
   - Implement `DontScore`.
+  - Implement `WaterAlt`.
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -411,6 +411,20 @@ CrewCount=1   ; integer, how many crew will exit this unit.
 This tag does not apply to buildings.
 ```
 
+### Alternative Water Image 
+
+- `WaterAlt` can now be used to control whether a voxel unit uses a different model when in water, similar to the APC in vanilla.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]  ; TechnoType
+WaterAlt=no   ; boolean, does this Techno use a different voxel model when in water. Defaults to yes for `[APC]`, no for other Technos.
+```
+
+```{note}
+Unlike the APC in vanilla, the alternative model is loaded into a separate area of memory from the turret model. This means that Technos that have `WaterAlt=yes` set **can** have turrets.
+```
+
 ### AILegalTarget
 
 - `AILegalTarget` can be used with TechnoTypes to forbid the AI from performing a targeting evaluation on this object. It is subject to LegalTarget=yes.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -256,7 +256,7 @@ MaxRandomSpawnOffset=0   ; integer, if greater than 0, the spawn offset will be 
 In `RULES.INI`:
 ```ini
 [SOMETECHNO]        ; TechnoType
-NoSpawnAlt=no       ; boolean, should this Techno use an alternate voxel model when it's out of spawns?
+NoSpawnAlt=no       ; boolean, should this Techno use an alternative voxel model when it's out of spawns?
                     ; When true, the model named SOMETECHNOWO will be used when it's out of spawns.
 ```
 
@@ -418,7 +418,8 @@ This tag does not apply to buildings.
 In `RULES.INI`:
 ```ini
 [SOMETECHNO]  ; TechnoType
-WaterAlt=no   ; boolean, does this Techno use a different voxel model when in water. Defaults to yes for `[APC]`, no for other Technos.
+WaterAlt=no   ; boolean, should this Techno use a different voxel model when in water. Defaults to yes for `[APC]`, no for other Technos.
+              ; When true, the model named SOMETECHNOW will be used when it's in water.
 ```
 
 ```{note}

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -157,6 +157,7 @@ New:
 - Implement the Torpedo logic from Red Alert 1 for BulletTypes (by Rampastring)
 - Add `BuildTimeCost` (by Rampastring)
 - Allow scenarios to have custom score screen bar colors (by Rampastring)
+- Implement `WaterAlt` (by ZivDero)
 
 
 Vanilla fixes:

--- a/src/extensions/objecttype/objecttypeext.cpp
+++ b/src/extensions/objecttype/objecttypeext.cpp
@@ -81,11 +81,17 @@ ObjectTypeClassExtension::~ObjectTypeClassExtension()
  */
 HRESULT ObjectTypeClassExtension::Load(IStream *pStm)
 {
-    AltVoxelIndex.Clear();
-    delete AltVoxel.VoxelLibrary;
-    delete AltVoxel.MotionLibrary;
-    AltVoxel.VoxelLibrary = nullptr;
-    AltVoxel.MotionLibrary = nullptr;
+    NoSpawnVoxelIndex.Clear();
+    delete NoSpawnVoxel.VoxelLibrary;
+    delete NoSpawnVoxel.MotionLibrary;
+    NoSpawnVoxel.VoxelLibrary = nullptr;
+    NoSpawnVoxel.MotionLibrary = nullptr;
+
+    WaterVoxelIndex.Clear();
+    delete WaterVoxel.VoxelLibrary;
+    delete WaterVoxel.MotionLibrary;
+    WaterVoxel.VoxelLibrary = nullptr;
+    WaterVoxel.MotionLibrary = nullptr;
 
     //EXT_DEBUG_TRACE("ObjectTypeClassExtension::Load - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -94,9 +100,13 @@ HRESULT ObjectTypeClassExtension::Load(IStream *pStm)
         return E_FAIL;
     }
 
-    AltVoxelIndex.Clear();
-    AltVoxel.VoxelLibrary = nullptr;
-    AltVoxel.MotionLibrary = nullptr;
+    NoSpawnVoxelIndex.Clear();
+    NoSpawnVoxel.VoxelLibrary = nullptr;
+    NoSpawnVoxel.MotionLibrary = nullptr;
+
+    WaterVoxelIndex.Clear();
+    WaterVoxel.VoxelLibrary = nullptr;
+    WaterVoxel.MotionLibrary = nullptr;
 
     Fetch_Voxel_Image(GraphicName);
     
@@ -159,17 +169,22 @@ bool ObjectTypeClassExtension::Read_INI(CCINIClass &ini)
 {
     //EXT_DEBUG_TRACE("ObjectTypeClassExtension::Read_INI - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
+    const char* ini_name = Name();
+
+    if (!IsInitialized) {
+        WaterAlt = strcmpi(This()->IniName, "APC") == 0;
+    }
+
     if (!AbstractTypeClassExtension::Read_INI(ini)) {
         return false;
     }
-
-    const char *ini_name = Name();
 
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
 
     NoSpawnAlt = ini.Get_Bool(ini_name, "NoSpawnAlt", NoSpawnAlt);
+    WaterAlt = ini.Get_Bool(ini_name, "WaterAlt", WaterAlt);
 
     if (This()->IsVoxel)
     {
@@ -193,17 +208,26 @@ void ObjectTypeClassExtension::Fetch_Voxel_Image(const char* graphic_name)
     if (NoSpawnAlt)
     {
         std::snprintf(buffer, sizeof(buffer), "%sWO", graphic_name);
-        success &= Load_Voxel(AltVoxel, buffer);
+        success &= Load_Voxel(NoSpawnVoxel, buffer);
+    }
+
+    if (WaterAlt)
+    {
+        std::snprintf(buffer, sizeof(buffer), "%sW", graphic_name);
+        success &= Load_Voxel(WaterVoxel, buffer);
     }
 
     if (success)
     {
-        AltVoxelIndex.Clear();
+        NoSpawnVoxelIndex.Clear();
+        WaterVoxelIndex.Clear();
     }
     else
     {
-        delete AltVoxel.VoxelLibrary;
-        delete AltVoxel.MotionLibrary;
+        delete NoSpawnVoxel.VoxelLibrary;
+        delete NoSpawnVoxel.MotionLibrary;
+        delete WaterVoxel.VoxelLibrary;
+        delete WaterVoxel.MotionLibrary;
     }
 }
 

--- a/src/extensions/objecttype/objecttypeext.h
+++ b/src/extensions/objecttype/objecttypeext.h
@@ -78,6 +78,17 @@ class ObjectTypeClassExtension : public AbstractTypeClassExtension
         /**
          *  The voxel model to use when the object has no spawn, and its cache.
          */
-        VoxelObject AltVoxel;
-        VoxelIndexClass AltVoxelIndex;
+        VoxelObject NoSpawnVoxel;
+        VoxelIndexClass NoSpawnVoxelIndex;
+
+        /**
+         *  Should the object use a different voxel model when it is in water?
+         */
+        bool WaterAlt;
+
+        /**
+         *  The voxel model to use when the object is in water, and its cache.
+         */
+        VoxelObject WaterVoxel;
+        VoxelIndexClass WaterVoxelIndex;
 };

--- a/src/extensions/objecttype/objecttypeext_hooks.cpp
+++ b/src/extensions/objecttype/objecttypeext_hooks.cpp
@@ -180,13 +180,6 @@ void ObjectTypeClassExt::_Fetch_Voxel_Image()
         success &= Load_Voxel(AuxVoxel2, buffer);
     }
 
-    // Should be moved to a separate location
-    if (!strcmpi(IniName, "APC"))
-    {
-        std::snprintf(buffer, sizeof(buffer), "%sW", Graphic_Name());
-        success &= Load_Voxel(AuxVoxel, buffer);
-    }
-
     if (success)
     {
         unsigned char max_dimension = Voxel.VoxelLibrary->Get_Layer_Info(0, 0)->XSize;

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -208,19 +208,18 @@ void UnitClassExt::_Draw_Voxel(unsigned int frame, int key, Rect& rect, Point2D&
     VoxelObject* voxel = nullptr;
     VoxelIndexClass* cache = nullptr;
 
-    if (!std::strcmp(Class->IniName, "APC")
+    if (typeext->WaterAlt
         && Map[Get_Coord()].Land_Type() == LAND_WATER
         && !IsOnBridge
         && Get_Height() < CELL_HEIGHT(1))
     {
-        voxel = &Class->AuxVoxel;
-        cache = nullptr;
-        key = -1;
+        voxel = &typeext->WaterVoxel;
+        cache = &typeext->WaterVoxelIndex;
     }
     else if (typeext->NoSpawnAlt && ext->SpawnManager && !ext->SpawnManager->Docked_Count())
     {
-        voxel = &typeext->AltVoxel;
-        cache = &typeext->AltVoxelIndex;
+        voxel = &typeext->NoSpawnVoxel;
+        cache = &typeext->NoSpawnVoxelIndex;
     }
     else
     {


### PR DESCRIPTION
Closes #64 

This pull request implements a new key for TechnoTypes to control their image when they enter any land with water properties.

- `WaterAlt` can now be used to control whether a voxel unit uses a different model when in water, similar to the APC in vanilla.

In `RULES.INI`:
```ini
[SOMETECHNO]  ; TechnoType
WaterAlt=no   ; boolean, should this Techno use a different voxel model when in water. Defaults to yes for `[APC]`, no for other Technos.
              ; When true, the model named SOMETECHNOW will be used when it's in water.
```

```{note}
Unlike the APC in vanilla, the alternative model is loaded into a separate area of memory from the turret model. This means that Technos that have `WaterAlt=yes` set **can** have turrets.
```
