### PR TITLE
Can edit the SuperWeapon Icon display status text

### DIFF
--- a/src/extensions/sidebar/sidebarext_hooks.cpp
+++ b/src/extensions/sidebar/sidebarext_hooks.cpp
@@ -47,6 +47,7 @@
 #include "sidebarext.h"
 #include "spritecollection.h"
 #include "super.h"
+#include "superext.h"
 #include "supertype.h"
 #include "supertypeext.h"
 #include "techno.h"
@@ -1666,7 +1667,7 @@ void StripClassExt::_Draw_It(bool complete)
                     production = true;
                     completed = !PlayerPtr->SuperWeapon[spc]->Needs_Redraw();
                     isready = PlayerPtr->SuperWeapon[spc]->Is_Ready();
-                    state = PlayerPtr->SuperWeapon[spc]->Ready_String();
+                    state = Extension::Fetch<SuperClassExtension>(PlayerPtr->SuperWeapon[spc])->Ready_String();
                     stage = PlayerPtr->SuperWeapon[spc]->Anim_Stage();
                     darken = false;
 

--- a/src/extensions/super/superext.cpp
+++ b/src/extensions/super/superext.cpp
@@ -26,12 +26,15 @@
  *
  ******************************************************************************/
 #include "superext.h"
+#include "supertypeext.h"
 #include "super.h"
 #include "wwcrc.h"
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
-
+#include "wstring.h"
+#include "language.h"
+#include "fetchres.h"
 
 /**
  *  Class constructor.
@@ -163,4 +166,49 @@ void SuperClassExtension::Detach(TARGET target, bool all)
 void SuperClassExtension::Compute_CRC(WWCRCEngine &crc) const
 {
     //EXT_DEBUG_TRACE("SuperClassExtension::Compute_CRC - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+}
+
+/**
+ * Added Ready_String of custom string function.
+ * 
+ *  @author: GenKyoko
+ */
+const char* SuperClassExtension::Ready_String() const
+{
+    SuperClass* pThis = This();
+    SuperWeaponTypeClassExtension* pTypeExt = Extension::Fetch<SuperWeaponTypeClassExtension>(pThis->Class);
+
+    if (pThis->IsSuspended)
+    {
+        return pTypeExt->Misc_SuspendString;
+    }
+
+    if (!pThis->Class->IsUseChargeDrain)
+    {
+        SpecialWeaponType type = pThis->Class->ActsLike;
+        bool IsReady = pThis->IsReady;
+
+        if (type == SPECIAL_HUNTER_SEEKER) {
+            if (!IsReady)
+                return nullptr;
+            return pTypeExt->Misc_ReadyString;
+        }
+        if (!IsReady)
+            return nullptr;
+        return pTypeExt->Misc_ReadyString;
+    }
+
+    if (!pThis->field_34) {
+        return pTypeExt->Misc_ChargingString;
+    }
+
+    if (!(pThis->field_34 - 1)) {
+        return pTypeExt->Misc_ReadyString;
+    }
+
+    if ((pThis->field_34 - 1) != 1) {
+        return nullptr;
+    }
+
+    return pTypeExt->Misc_ActiveString;
 }

--- a/src/extensions/super/superext.h
+++ b/src/extensions/super/superext.h
@@ -66,6 +66,8 @@ SuperClassExtension final : public AbstractClassExtension
         virtual const SuperClass *This_Const() const override { return reinterpret_cast<const SuperClass *>(AbstractClassExtension::This_Const()); }
         virtual RTTIType What_Am_I() const override { return RTTI_SUPERWEAPON; }
 
+        const char* Ready_String() const;
+
     public:
         /**
          *  The time at which the flash mode should return to normal.

--- a/src/extensions/super/superext_hooks.cpp
+++ b/src/extensions/super/superext_hooks.cpp
@@ -88,6 +88,26 @@ DECLARE_PATCH(_SuperClass_Place_HunterSeeker_Type_Patch)
     }
 }
 
+DECLARE_PATCH(_SuperClass_Ready_String_Patch)
+{
+    GET_REGISTER_STATIC(SuperClass*, this_ptr, ecx);
+
+    static const char* ready_str;
+    static SuperClassExtension* extension;
+    extension = Extension::Fetch<SuperClassExtension>(this_ptr);
+
+    ready_str = extension->Ready_String();
+
+    /**
+     * A new string obtained using a function.
+     */
+    _asm {
+        mov eax, ready_str
+        mov [esp+40], eax
+    }
+
+    JMP(0x005F526F)
+}
 
 /**
  *  Main function for patching the hooks.
@@ -100,4 +120,6 @@ void SuperClassExtension_Hooks()
     SuperClassExtension_Init();
 
     Patch_Jump(0x0060C5DE, &_SuperClass_Place_HunterSeeker_Type_Patch);
+    Patch_Jump(0x005F5266, &_SuperClass_Ready_String_Patch);
+
 }

--- a/src/extensions/supertype/supertypeext.cpp
+++ b/src/extensions/supertype/supertypeext.cpp
@@ -33,7 +33,8 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
-
+#include "fetchres.h"
+#include "language.h"
 
 /**
  *  Class constructor.
@@ -45,7 +46,11 @@ SuperWeaponTypeClassExtension::SuperWeaponTypeClassExtension(const SuperWeaponTy
     SidebarImage(),
     IsShowTimer(false),
     CameoImageSurface(nullptr),
-    ActionOutOfRange(ACTION_EMPULSE_RANGE)
+    ActionOutOfRange(ACTION_EMPULSE_RANGE),
+    Misc_ReadyString(),
+    Misc_SuspendString(),
+    Misc_ActiveString(),
+    Misc_ChargingString()
 {
     //if (this_ptr) EXT_DEBUG_TRACE("SuperWeaponTypeClassExtension::SuperWeaponTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -212,6 +217,13 @@ bool SuperWeaponTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     ActionOutOfRange = ini.Get_ActionType(ini_name, "ActionOutOfRange", ActionOutOfRange);
+
+    // String
+    bool IsHS = This()->Type == SPECIAL_HUNTER_SEEKER;
+    ini.Get_String(ini_name, "ReadyString", Fetch_String(IsHS?TXT_RELEASE_THE_HOUNDS:TXT_READY), Misc_ReadyString, 0x10);
+    ini.Get_String(ini_name, "ActivedString", Fetch_String(TXT_FIRESTORM_ON), Misc_ActiveString, 0x10);
+    ini.Get_String(ini_name, "ChargingString", Fetch_String(TXT_CHARGING), Misc_ChargingString, 0x10);
+    ini.Get_String(ini_name, "SuspendString", Fetch_String(TXT_HOLD), Misc_SuspendString, 0x10);
 
     IsInitialized = true;
     

--- a/src/extensions/supertype/supertypeext.h
+++ b/src/extensions/supertype/supertypeext.h
@@ -29,10 +29,9 @@
 
 #include "abstracttypeext.h"
 #include "supertype.h"
-
+#include "wstring.h"
 
 class BSurface;
-
 
 class DECLSPEC_UUID(UUID_SUPERWEAPONTYPE_EXTENSION)
 SuperWeaponTypeClassExtension final : public AbstractTypeClassExtension
@@ -86,4 +85,24 @@ SuperWeaponTypeClassExtension final : public AbstractTypeClassExtension
          *  Action type used for the cursor when the SW is out of range to fire.
          */
         ActionType ActionOutOfRange;
+
+        /**
+         * The string that appears when it's ready.
+         */
+        char Misc_ReadyString[0x11];
+
+        /**
+         *  A string that is displayed when preparing a special weapon with a charge function.
+         */
+        char Misc_ChargingString[0x11];
+
+        /**
+         * A string when activating a special weapon using IsUseChargeDrain.
+         */
+        char Misc_ActiveString[0x11];
+
+        /**
+         * The string that appears when a special weapon is ready to be interrupted.
+         */
+        char Misc_SuspendString[0x11];
 };

--- a/src/extensions/supertype/supertypeext.h
+++ b/src/extensions/supertype/supertypeext.h
@@ -29,7 +29,6 @@
 
 #include "abstracttypeext.h"
 #include "supertype.h"
-#include "wstring.h"
 
 class BSurface;
 


### PR DESCRIPTION
Customizable superweapon ready strings.
[**SomeSWType**]
**ReadyString**=<**String Data**>, default is TXT_READY or TXT_RELEASE_THE_HOUNDS(Type is Hunter Seeker).
**ActivedString**=<**String Data**>, default is TXT_FIRESTORM_ON.
**ChargingString**=<**String Data**>, default is TXT_CHARGING.
**SuspendString**=<**String Data**>, default is TXT_HOLD.