### PR TITLE
Custom Wakes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -142,6 +142,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement MeteorShowerCommandClass and MeteorImpactCommandClass.
   - Add the "Underground" layer to the tactical display Next and Prev search.
   - Fix a bug where the game could freeze in the score screen in `Clip_Line` when running on Windows 11 24H2.
+  - Add customizable wake animations.
 - **hacklex**:
   - Add Veterancy and Health Filter hotkeys.
 - **Kerbiter (Metadorius)**:

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -303,3 +303,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where Tiberium spawned by animations wouldn't grow or spread.
   - Fix a bug where carryalls assign their ROT to the unit they're carrying.
   - Port to Syringe.
+  - Add customizable wake animations.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1016,10 +1016,6 @@ HideWakeWhenCloaked=no  ; boolean, should this unit not spawn wakes when it's cl
 Wake customizations currently only take effect on units using `DriveLocomotion`.
 ```
 
-```{note}
-`IdleWakeAnim` should have `LoopCount=-1` as it
-```
-
 ### ImmuneToEMP
 
 - Vinifera allows specific TechnoTypes to be immune to EMP effects.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1005,10 +1005,19 @@ ShakeXlo=0    ; unsigned integer, the minimum pixel X value.
 
 In `ART.INI`:
 ```ini
-[SOMETECHNO]     ; TechnoType
-WakeAnim=        ; AnimType, the wake graphic to show as the object moves across water.
-WakeAnimRate=10  ; integer, the rate at which this object creates the wake animation while moving.
-IdleWakeAnim=    ; AnimType, the wake graphic to show when the object is staying still on water.
+[SOMETECHNO]            ; TechnoType
+WakeAnim=               ; AnimType, the wake graphic to show as the object moves across water.
+WakeAnimRate=10         ; integer, the rate at which this object creates the wake animation while moving.
+IdleWakeAnim=           ; AnimType, the wake graphic to show when the object is staying still on water.
+HideWakeWhenCloaked=no  ; boolean, should this unit not spawn wakes when it's cloaked?
+```
+
+```{note}
+Wake customizations currently only take effect on units using `DriveLocomotion`.
+```
+
+```{note}
+`IdleWakeAnim` should have `LoopCount=-1` as it
 ```
 
 ### ImmuneToEMP

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -999,6 +999,18 @@ ShakeXlo=0    ; unsigned integer, the minimum pixel X value.
 
 - Vinifera allows `WalkRate` to be optionally loaded from `ART.INI` image entries, overriding any value defined in `RULES.INI`.
 
+### Wake Animation Customization
+
+- Vinifera allows customizing the wake (moving on water) animation per-techno.
+
+In `ART.INI`:
+```ini
+[SOMETECHNO]     ; TechnoType
+WakeAnim=        ; AnimType, the wake graphic to show as the object moves across water.
+WakeAnimRate=10  ; integer, the rate at which this object creates the wake animation while moving.
+IdleWakeAnim=    ; AnimType
+```
+
 ### ImmuneToEMP
 
 - Vinifera allows specific TechnoTypes to be immune to EMP effects.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1008,7 +1008,7 @@ In `ART.INI`:
 [SOMETECHNO]     ; TechnoType
 WakeAnim=        ; AnimType, the wake graphic to show as the object moves across water.
 WakeAnimRate=10  ; integer, the rate at which this object creates the wake animation while moving.
-IdleWakeAnim=    ; AnimType
+IdleWakeAnim=    ; AnimType, the wake graphic to show when the object is staying still on water.
 ```
 
 ### ImmuneToEMP

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -73,6 +73,8 @@ New:
 - Implement multiplayer beacons (by ZivDero)
 - Chat improvements (by ZivDero)
 - Port to Syringe (by ZivDero)
+- Add customizable wake animations (by CCHyper)
+
 
 Vinifera fixes:
 - Fix unit placement in non-TS Client builds of Vinifera (by ZivDero)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -73,7 +73,7 @@ New:
 - Implement multiplayer beacons (by ZivDero)
 - Chat improvements (by ZivDero)
 - Port to Syringe (by ZivDero)
-- Add customizable wake animations (by CCHyper)
+- Add customizable wake animations (by CCHyper, ZivDero)
 
 
 Vinifera fixes:

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
@@ -127,9 +127,9 @@ static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *t
  */
 DECLARE_PATCH(_DriveLocomotionClass_Process_WakeAnim_Patch)
 {
-    GET_REGISTER_STATIC(DriveLocomotionClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(ILocomotion *, this_ptr, esi);
 
-    DriveLocomotionClass_Process_Create_WakeAnim(this_ptr);
+    DriveLocomotionClass_Process_Create_WakeAnim(static_cast<DriveLocomotionClass*>(this_ptr));
 
     JMP(0x0047E05D);
 }

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
@@ -1,0 +1,107 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DRIVELOCOMOTOREXT_HOOKS.CPP
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended DriveLocomotorClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "drivelocomotionext_hooks.h"
+#include "drivelocomotion.h"
+#include "foot.h"
+#include "technotype.h"
+#include "technotypeext.h"
+#include "cell.h"
+#include "rules.h"
+#include "anim.h"
+#include "extension.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "hooker_macros.h"
+
+
+/**
+ *  Re-implements the section of code that spawns the wake animation as a
+ *  unit moves across water.
+ * 
+ *  @author: CCHyper
+ */
+static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *this_ptr)
+{
+    /**
+     *  Only spawn the wake animation every 10 frames.
+     */
+    if (!(Frame % 10)) {
+
+        FootClass *linked_foot = this_ptr->Linked_To();
+
+        if (!linked_foot->IsOnBridge && linked_foot->Get_Cell_Ptr()->Land_Type() == LAND_WATER) {
+
+            /**
+             *  #issue-944
+             * 
+             *  Fetch the wake animation from the object attached to this
+             *  locomotor, and fall-back to the Rules wake animation if
+             *  one is not defined.
+             */
+            TechnoTypeClassExtension *technotype_ext = Extension::Fetch<TechnoTypeClassExtension>(linked_foot->Techno_Type_Class());
+            const AnimTypeClass *wake_anim = technotype_ext->WakeAnim != nullptr ? technotype_ext->WakeAnim : Rule->Wake;
+
+            /**
+             *  Create the wake animation at the current objects coordinate.
+             */
+            if (wake_anim) {
+                AnimClass *animptr = new AnimClass(wake_anim, linked_foot->Get_Coord());
+                ASSERT(animptr != nullptr);
+            }
+        }
+    }
+}
+
+
+/**
+ *  #issue-944
+ *
+ *  Implement support for custom wake animations as a unit moves across water..
+ *
+ *  @author: CCHyper
+ */
+DECLARE_PATCH(_DriveLocomotionClass_Process_WakeAnim_Patch)
+{
+    GET_REGISTER_STATIC(DriveLocomotionClass *, this_ptr, esi);
+
+    DriveLocomotionClass_Process_Create_WakeAnim(this_ptr);
+
+    JMP(0x0047E05D);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void DriveLocomotionClassExtension_Hooks()
+{
+    Patch_Jump(0x0047DFE8, &_DriveLocomotionClass_Process_WakeAnim_Patch);
+}

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
@@ -50,12 +50,15 @@
  */
 static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *this_ptr)
 {
-    /**
-     *  Only spawn the wake animation every 10 frames.
-     */
-    if (!(Frame % 10)) {
+    FootClass *linked_foot = this_ptr->Linked_To();
+    TechnoTypeClassExtension *technotype_ext = Extension::Fetch<TechnoTypeClassExtension>(linked_foot->Techno_Type_Class());
 
-        FootClass *linked_foot = this_ptr->Linked_To();
+    /**
+     *  #issue-944
+     * 
+     *  Only spawn the wake animation every 'X' frames, as set by the objects properties.
+     */
+    if (!(Frame % technotype_ext->WakeAnimRate)) {
 
         if (!linked_foot->IsOnBridge && linked_foot->Get_Cell_Ptr()->Land_Type() == LAND_WATER) {
 
@@ -66,7 +69,6 @@ static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *t
              *  locomotor, and fall-back to the Rules wake animation if
              *  one is not defined.
              */
-            TechnoTypeClassExtension *technotype_ext = Extension::Fetch<TechnoTypeClassExtension>(linked_foot->Techno_Type_Class());
             const AnimTypeClass *wake_anim = technotype_ext->WakeAnim != nullptr ? technotype_ext->WakeAnim : Rule->Wake;
 
             /**

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
@@ -28,6 +28,7 @@
 #include "drivelocomotionext_hooks.h"
 #include "drivelocomotion.h"
 #include "foot.h"
+#include "footext.h"
 #include "technotype.h"
 #include "technotypeext.h"
 #include "cell.h"
@@ -51,20 +52,52 @@
 static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *this_ptr)
 {
     FootClass *linked_foot = this_ptr->Linked_To();
+    FootClassExtension *linked_footext = Extension::Fetch<FootClassExtension>(linked_foot);
     TechnoTypeClassExtension *technotype_ext = Extension::Fetch<TechnoTypeClassExtension>(linked_foot->Techno_Type_Class());
 
     /**
-     *  #issue-944
-     * 
-     *  Only spawn the wake animation every 'X' frames, as set by the objects properties.
+     *  x
      */
-    if (!(Frame % technotype_ext->WakeAnimRate)) {
+    if (linked_foot->IsOnBridge || linked_foot->Get_Cell_Ptr()->Land_Type() != LAND_WATER) {
+        return;
+    }
 
-        if (!linked_foot->IsOnBridge && linked_foot->Get_Cell_Ptr()->Land_Type() == LAND_WATER) {
+    /**
+     *  x
+     */
+    if (linked_footext->IdleWakeAnim) {
+
+        if (!this_ptr->Is_Moving()) {
+            linked_footext->IdleWakeAnim->Make_Invisible();
+        } else {
+            linked_footext->IdleWakeAnim->Make_Visible();
+        }
+
+    } else {
+        
+        /**
+         *  x
+         */
+        linked_footext->IdleWakeAnim = new AnimClass(technotype_ext->IdleWakeAnim, linked_foot->Get_Coord());
+        ASSERT(linked_footext->IdleWakeAnim != nullptr);
+
+    }
+
+    /**
+     *  x
+     */
+    if (this_ptr->Is_Moving()) {
+
+        /**
+         *  #issue-944
+         * 
+         *  Only spawn the wake animation every 'X' frames, as set by the objects properties.
+         */
+        if (!(Frame % technotype_ext->WakeAnimRate)) {
 
             /**
              *  #issue-944
-             * 
+             *
              *  Fetch the wake animation from the object attached to this
              *  locomotor, and fall-back to the Rules wake animation if
              *  one is not defined.
@@ -78,7 +111,9 @@ static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *t
                 AnimClass *animptr = new AnimClass(wake_anim, linked_foot->Get_Coord());
                 ASSERT(animptr != nullptr);
             }
+
         }
+
     }
 }
 
@@ -105,5 +140,5 @@ DECLARE_PATCH(_DriveLocomotionClass_Process_WakeAnim_Patch)
  */
 void DriveLocomotionClassExtension_Hooks()
 {
-    Patch_Jump(0x0047DFE8, &_DriveLocomotionClass_Process_WakeAnim_Patch);
+    Patch_Jump(0x0047DFDB, &_DriveLocomotionClass_Process_WakeAnim_Patch);
 }

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
@@ -62,6 +62,16 @@ static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *t
         return;
     }
 
+    /**
+     *  If this unit shouldn't show wakes when cloaked, hide the idle wake and return.
+     */
+    if (technotype_ext->IsHideWakeWhenCloaked && linked_foot->Visual_Character() == VISUAL_HIDDEN) {
+        if (linked_footext->IdleWakeAnim) {
+            linked_footext->IdleWakeAnim->Make_Invisible();
+        }
+        return;
+    }
+
     if (technotype_ext->IdleWakeAnim) {
 
         /**

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
@@ -40,7 +40,7 @@
 #include "debughandler.h"
 
 #include "hooker.h"
-#include "hooker_macros.h"
+#include "syringe.h"
 
 
 /**
@@ -51,40 +51,46 @@
  */
 static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *this_ptr)
 {
-    FootClass *linked_foot = this_ptr->Linked_To();
-    FootClassExtension *linked_footext = Extension::Fetch<FootClassExtension>(linked_foot);
-    TechnoTypeClassExtension *technotype_ext = Extension::Fetch<TechnoTypeClassExtension>(linked_foot->Techno_Type_Class());
+    FootClass *linked_foot = this_ptr->LinkedTo;
+    FootClassExtension *linked_footext = Extension::Fetch(linked_foot);
+    TechnoTypeClassExtension *technotype_ext = Extension::Fetch(linked_foot->TClass);
 
     /**
-     *  x
+     *  Wakes are only created if the unit is on water and not on a bridge.
      */
     if (linked_foot->IsOnBridge || linked_foot->Get_Cell_Ptr()->Land_Type() != LAND_WATER) {
         return;
     }
 
-    /**
-     *  x
-     */
-    if (linked_footext->IdleWakeAnim) {
+    if (technotype_ext->IdleWakeAnim) {
 
-        if (!this_ptr->Is_Moving()) {
-            linked_footext->IdleWakeAnim->Make_Invisible();
-        } else {
-            linked_footext->IdleWakeAnim->Make_Visible();
-        }
-
-    } else {
-        
         /**
-         *  x
+         *  If the idle wake animation already exists, toggle its visibility
          */
-        linked_footext->IdleWakeAnim = new AnimClass(technotype_ext->IdleWakeAnim, linked_foot->Get_Coord());
-        ASSERT(linked_footext->IdleWakeAnim != nullptr);
+        if (linked_footext->IdleWakeAnim) {
 
+            if (this_ptr->Is_Moving()) {
+                linked_footext->IdleWakeAnim->Make_Invisible();
+            } else {
+                linked_footext->IdleWakeAnim->Make_Visible();
+            }
+
+        } else {
+
+            /**
+             *  Otherwise, create the wake animation at the current object's coordinate and attach it to follow the object.
+             */
+            linked_footext->IdleWakeAnim = new AnimClass(technotype_ext->IdleWakeAnim, linked_foot->PositionCoord);
+            linked_footext->IdleWakeAnim->Attach_To(linked_foot);
+
+            if (this_ptr->Is_Moving()) {
+                linked_footext->IdleWakeAnim->Make_Invisible();
+            }
+        }
     }
 
     /**
-     *  x
+     *  If the unit is moving, spawn the wake animation.
      */
     if (this_ptr->Is_Moving()) {
 
@@ -105,15 +111,12 @@ static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *t
             const AnimTypeClass *wake_anim = technotype_ext->WakeAnim != nullptr ? technotype_ext->WakeAnim : Rule->Wake;
 
             /**
-             *  Create the wake animation at the current objects coordinate.
+             *  Create the wake animation at the current object's coordinate.
              */
             if (wake_anim) {
-                AnimClass *animptr = new AnimClass(wake_anim, linked_foot->Get_Coord());
-                ASSERT(animptr != nullptr);
+                new AnimClass(wake_anim, linked_foot->PositionCoord);
             }
-
         }
-
     }
 }
 
@@ -125,13 +128,13 @@ static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *t
  *
  *  @author: CCHyper
  */
-DECLARE_PATCH(_DriveLocomotionClass_Process_WakeAnim_Patch)
+DEFINE_HOOK(0x0047DFDB, _DriveLocomotionClass_Process_WakeAnim_Patch, 0)
 {
-    GET_REGISTER_STATIC(ILocomotion *, this_ptr, esi);
+    GET(ILocomotion *, this_ptr, ESI);
 
     DriveLocomotionClass_Process_Create_WakeAnim(static_cast<DriveLocomotionClass*>(this_ptr));
 
-    JMP(0x0047E05D);
+    return 0x0047E05D;
 }
 
 
@@ -140,5 +143,5 @@ DECLARE_PATCH(_DriveLocomotionClass_Process_WakeAnim_Patch)
  */
 void DriveLocomotionClassExtension_Hooks()
 {
-    Patch_Jump(0x0047DFDB, &_DriveLocomotionClass_Process_WakeAnim_Patch);
+
 }

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.cpp
@@ -65,7 +65,7 @@ static void DriveLocomotionClass_Process_Create_WakeAnim(DriveLocomotionClass *t
     /**
      *  If this unit shouldn't show wakes when cloaked, hide the idle wake and return.
      */
-    if (technotype_ext->IsHideWakeWhenCloaked && linked_foot->Visual_Character() == VISUAL_HIDDEN) {
+    if (technotype_ext->IsHideWakeWhenCloaked && linked_foot->Cloak == CLOAKED) {
         if (linked_footext->IdleWakeAnim) {
             linked_footext->IdleWakeAnim->Make_Invisible();
         }

--- a/src/extensions/drivelocomotor/drivelocomotionext_hooks.h
+++ b/src/extensions/drivelocomotor/drivelocomotionext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          DRIVELOCOMOTOREXT_HOOKS.H
+ *
+ *  @author        CCHyper
+ *
+ *  @brief         Contains the hooks for the extended DriveLocomotorClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void DriveLocomotionClassExtension_Hooks();

--- a/src/extensions/extension_hooks.cpp
+++ b/src/extensions/extension_hooks.cpp
@@ -104,6 +104,7 @@
 
 #include "aircrafttracker_hooks.h"
 #include "beacon_hooks.h"
+#include "drivelocomotionext_hooks.h"
 #include "rulesext_hooks.h"
 #include "scenarioext_hooks.h"
 #include "sessionext_hooks.h"
@@ -253,6 +254,11 @@ void Extension_Hooks()
     //AlphaShapeClassExtension_Hooks();                     // Not yet implemented
     //VeinholeMonsterClassExtension_Hooks();                // Not yet implemented
     StorageClassExtension_Hooks();
+
+    /**
+     *  Locomotors.
+     */
+    DriveLocomotionClassExtension_Hooks();
 
     /**
      *  All global class extensions here.

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -72,7 +72,8 @@ TechnoClassExtension::TechnoClassExtension(const TechnoClass *this_ptr) :
     LastTargetFrame(Frame),
     IsToResetBurst(false),
     BurstResetTimer(),
-    LastVeterancy(RANK_NONE)
+    LastVeterancy(RANK_NONE),
+    IdleWakeAnim(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoClassExtension::TechnoClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -124,6 +125,9 @@ TechnoClassExtension::~TechnoClassExtension()
         delete SpawnManager;
         SpawnManager = nullptr;
     }
+    
+    delete IdleWakeAnim;
+    IdleWakeAnim = nullptr;
 }
 
 
@@ -147,6 +151,8 @@ HRESULT TechnoClassExtension::Load(IStream *pStm)
 
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(SpawnManager, "SpawnManager");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(SpawnOwner, "SpawnOwner");
+
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(IdleWakeAnim, "IdleWakeAnim");
     
     return hr;
 }

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -54,7 +54,7 @@
 #include "team.h"
 #include "teamtype.h"
 #include "unit.h"
-#include "weapontype.h"
+#include "anim.h"
 
 
 /**
@@ -125,9 +125,11 @@ TechnoClassExtension::~TechnoClassExtension()
         delete SpawnManager;
         SpawnManager = nullptr;
     }
-    
-    delete IdleWakeAnim;
-    IdleWakeAnim = nullptr;
+
+    if (IdleWakeAnim) {
+        delete IdleWakeAnim;
+        IdleWakeAnim = nullptr;
+    }
 }
 
 
@@ -195,6 +197,10 @@ void TechnoClassExtension::Detach(AbstractClass * target, bool all)
 
     if (target == SpawnOwner) {
         SpawnOwner = nullptr;
+    }
+
+    if (target == IdleWakeAnim) {
+        IdleWakeAnim = nullptr;
     }
 }
 

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -35,6 +35,7 @@ class SpawnManagerClass;
 class EBoltClass;
 class TechnoTypeClass;
 class TechnoTypeClassExtension;
+class AnimClass;
 
 
 class TechnoClassExtension : public RadioClassExtension
@@ -122,4 +123,9 @@ class TechnoClassExtension : public RadioClassExtension
          *  Used to determine when a unit has ranked up.
          */
         VeterancyRankType LastVeterancy;
+
+        /**
+         *  The idle wake animation attached to this object.
+         */
+        AnimClass *IdleWakeAnim;
 };

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -127,5 +127,5 @@ class TechnoClassExtension : public RadioClassExtension
         /**
          *  The idle wake animation attached to this object.
          */
-        AnimClass *IdleWakeAnim;
+        AnimClass* IdleWakeAnim;
 };

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -104,7 +104,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsNaval(false),
     BuiltAt(),
     BuildTimeMultiplier(1.0f),
-    IsOpportunityFire(false)
+    IsOpportunityFire(false),
+    WakeAnim(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -169,6 +170,7 @@ HRESULT TechnoTypeClassExtension::Load(IStream *pStm)
 
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(UnloadingClass, "UnloadingClass");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Spawns, "Spawns");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(WakeAnim, "WakeAnim");
 
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP_LIST(BuiltAt, "BuiltAt");
 
@@ -375,6 +377,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     VoiceHarvest = ini.Get_VocTypes(ini_name, "VoiceHarvest", VoiceHarvest);
     SpecialPipIndex = ini.Get_Int(ini_name, "SpecialPipIndex", SpecialPipIndex);
     PipWrap = ini.Get_Int(ini_name, "PipWrap", PipWrap);
+    WakeAnim = ini.Get_Anim(ini_name, "WakeAnim", WakeAnim);
 
     if (ini.Is_Present(ini_name, "Description"))
         ini.Get_String(ini_name, "Description", Description, std::size(Description));

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -28,6 +28,7 @@
 #include "technotypeext.h"
 
 #include "aircrafttype.h"
+#include "animtype.h"
 #include "technotype.h"
 #include "ccini.h"
 #include "filepng.h"
@@ -382,12 +383,13 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     SpecialPipIndex = ini.Get_Int(ini_name, "SpecialPipIndex", SpecialPipIndex);
     PipWrap = ini.Get_Int(ini_name, "PipWrap", PipWrap);
 
-    WakeAnim = ArtINI.Get_Anim(graphic_name, "WakeAnim", WakeAnim);
+    WakeAnim = TGet_Class(ArtINI, graphic_name, "WakeAnim", WakeAnim);
     WakeAnimRate = ArtINI.Get_Int(graphic_name, "WakeAnimRate", WakeAnimRate);
-    IdleWakeAnim = ArtINI.Get_Anim(graphic_name, "IdleWakeAnim", IdleWakeAnim);
+    IdleWakeAnim = TGet_Class(ArtINI, graphic_name, "IdleWakeAnim", IdleWakeAnim);
 
-    if (ini.Is_Present(ini_name, "Description"))
+    if (ini.Is_Present(ini_name, "Description")) {
         ini.Get_String(ini_name, "Description", Description, std::size(Description));
+    }
 
     IdleRate = ini.Get_Int(ini_name, "IdleRate", IdleRate);
     IdleRate = ArtINI.Get_Int(graphic_name, "IdleRate", IdleRate);

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -108,7 +108,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsOpportunityFire(false),
     WakeAnim(nullptr),
     WakeAnimRate(10),                   // Default DriveLocomotion value.
-    IdleWakeAnim(nullptr)
+    IdleWakeAnim(nullptr),
+    IsHideWakeWhenCloaked(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -299,6 +300,7 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(BuiltAt.Count());
     crc(IsOpportunityFire);
     crc(WakeAnimRate);
+    crc(IsHideWakeWhenCloaked);
 }
 
 
@@ -383,10 +385,6 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     SpecialPipIndex = ini.Get_Int(ini_name, "SpecialPipIndex", SpecialPipIndex);
     PipWrap = ini.Get_Int(ini_name, "PipWrap", PipWrap);
 
-    WakeAnim = TGet_Class(ArtINI, graphic_name, "WakeAnim", WakeAnim);
-    WakeAnimRate = ArtINI.Get_Int(graphic_name, "WakeAnimRate", WakeAnimRate);
-    IdleWakeAnim = TGet_Class(ArtINI, graphic_name, "IdleWakeAnim", IdleWakeAnim);
-
     if (ini.Is_Present(ini_name, "Description")) {
         ini.Get_String(ini_name, "Description", Description, std::size(Description));
     }
@@ -441,6 +439,11 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
 
     BuiltAt = TGet_TypeList(ini, ini_name, "BuiltAt", BuiltAt);
     IsOpportunityFire = ini.Get_Bool(ini_name, "OpportunityFire", IsOpportunityFire);
+
+    WakeAnim = TGet_Class(ArtINI, graphic_name, "WakeAnim", WakeAnim);
+    WakeAnimRate = ArtINI.Get_Int(graphic_name, "WakeAnimRate", WakeAnimRate);
+    IdleWakeAnim = TGet_Class(ArtINI, graphic_name, "IdleWakeAnim", IdleWakeAnim);
+    IsHideWakeWhenCloaked = ArtINI.Get_Bool(graphic_name, "HideWakeWhenCloaked", IsHideWakeWhenCloaked);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -105,7 +105,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     BuiltAt(),
     BuildTimeMultiplier(1.0f),
     IsOpportunityFire(false),
-    WakeAnim(nullptr)
+    WakeAnim(nullptr),
+    WakeAnimRate(10)                    // Default DriveLocomotion value.
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -294,6 +295,7 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(IsNaval);
     crc(BuiltAt.Count());
     crc(IsOpportunityFire);
+    crc(WakeAnimRate);
 }
 
 
@@ -377,7 +379,9 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     VoiceHarvest = ini.Get_VocTypes(ini_name, "VoiceHarvest", VoiceHarvest);
     SpecialPipIndex = ini.Get_Int(ini_name, "SpecialPipIndex", SpecialPipIndex);
     PipWrap = ini.Get_Int(ini_name, "PipWrap", PipWrap);
-    WakeAnim = ini.Get_Anim(ini_name, "WakeAnim", WakeAnim);
+
+    WakeAnim = ArtINI.Get_Anim(graphic_name, "WakeAnim", WakeAnim);
+    WakeAnimRate = ArtINI.Get_Int(graphic_name, "WakeAnimRate", WakeAnimRate);
 
     if (ini.Is_Present(ini_name, "Description"))
         ini.Get_String(ini_name, "Description", Description, std::size(Description));

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -106,7 +106,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     BuildTimeMultiplier(1.0f),
     IsOpportunityFire(false),
     WakeAnim(nullptr),
-    WakeAnimRate(10)                    // Default DriveLocomotion value.
+    WakeAnimRate(10),                   // Default DriveLocomotion value.
+    IdleWakeAnim(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -172,6 +173,7 @@ HRESULT TechnoTypeClassExtension::Load(IStream *pStm)
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(UnloadingClass, "UnloadingClass");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(Spawns, "Spawns");
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(WakeAnim, "WakeAnim");
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP(IdleWakeAnim, "IdleWakeAnim");
 
     VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP_LIST(BuiltAt, "BuiltAt");
 
@@ -382,6 +384,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
 
     WakeAnim = ArtINI.Get_Anim(graphic_name, "WakeAnim", WakeAnim);
     WakeAnimRate = ArtINI.Get_Int(graphic_name, "WakeAnimRate", WakeAnimRate);
+    IdleWakeAnim = ArtINI.Get_Anim(graphic_name, "IdleWakeAnim", IdleWakeAnim);
 
     if (ini.Is_Present(ini_name, "Description"))
         ini.Get_String(ini_name, "Description", Description, std::size(Description));

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -369,7 +369,7 @@ public:
     /**
      *  The wake graphic to show as the object moves across water.
      */
-    const AnimTypeClass *WakeAnim;
+    const AnimTypeClass* WakeAnim;
 
     /**
      *  The rate at which this object creates the wake animation while moving.
@@ -377,7 +377,7 @@ public:
     int WakeAnimRate;
 
     /**
-     *  The wake graphic to show as the object moves across water.
+     *  The wake graphic to show when the object is staying still on water.
      */
-    const AnimTypeClass *IdleWakeAnim;
+    const AnimTypeClass* IdleWakeAnim;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -380,4 +380,9 @@ public:
      *  The wake graphic to show when the object is staying still on water.
      */
     const AnimTypeClass* IdleWakeAnim;
+
+    /**
+     *  Should this unit not spawn wakes when it's cloaked? Usually useful for submarines.
+     */
+    bool IsHideWakeWhenCloaked;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -374,7 +374,7 @@ public:
     /**
      *  The rate at which this object creates the wake animation while moving.
      */
-    unsigned WakeAnimRate;
+    int WakeAnimRate;
 
     /**
      *  The wake graphic to show as the object moves across water.

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -370,4 +370,9 @@ public:
      *  The wake graphic to show as the object moves across water.
      */
     const AnimTypeClass *WakeAnim;
+
+    /**
+     *  The rate at which this object creates the wake animation while moving.
+     */
+    unsigned WakeAnimRate;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -375,4 +375,9 @@ public:
      *  The rate at which this object creates the wake animation while moving.
      */
     unsigned WakeAnimRate;
+
+    /**
+     *  The wake graphic to show as the object moves across water.
+     */
+    const AnimTypeClass *IdleWakeAnim;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -365,4 +365,9 @@ public:
      *  Can this object pick up targets within its range automatically (opportunity fire)?
      */
     bool IsOpportunityFire;
+
+    /**
+     *  The wake graphic to show as the object moves across water.
+     */
+    const AnimTypeClass *WakeAnim;
 };


### PR DESCRIPTION
### Wake Animation Customization

- This PR allows customizing the wake (moving on water) animation per-techno.

In `ART.INI`:
```ini
[SOMETECHNO]            ; TechnoType
WakeAnim=               ; AnimType, the wake graphic to show as the object moves across water.
WakeAnimRate=10         ; integer, the rate at which this object creates the wake animation while moving.
IdleWakeAnim=           ; AnimType, the wake graphic to show when the object is staying still on water.
HideWakeWhenCloaked=no  ; boolean, should this unit not spawn wakes when it's cloaked?
```

```{note}
Wake customizations currently only take effect on units using `DriveLocomotion`.
```