### PR TITLE
Explosion Damage improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -169,7 +169,7 @@ This page lists all the individual contributions to the project by their author.
   - Add `TargetZoneScan` to TechnoTypes.
   - Fix a bug where a visceroid was spawned when poison gas destroyed a non-crewed vehicle, building, or terrain object.
   - Fix a bug where it was impossible to tell infantry to enter cloaked allied transports.
-  - Implement `Explosive` for animations.
+  - Implement `ExplosionDamage` for animations.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **Starkku**:
@@ -220,7 +220,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement `DecloakToFire`.
   - Implement `CellSpread` and `PercentAtMax`.
   - Implement `ScorchChance`, `CraterChance` and `CellAnimChance`.
-  - Implement `Explosive` for animations.
+  - Implement `ExplosionDamage` for animations.
   - Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier`.
   - Implement `Volumetric`.
   - Animations now use their `Warhead` to deal damage, if one is specified.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -169,6 +169,7 @@ This page lists all the individual contributions to the project by their author.
   - Add `TargetZoneScan` to TechnoTypes.
   - Fix a bug where a visceroid was spawned when poison gas destroyed a non-crewed vehicle, building, or terrain object.
   - Fix a bug where it was impossible to tell infantry to enter cloaked allied transports.
+  - Implement `Explosive` for animations.
 - **secsome**:
   - Add support for up to 32767 waypoints to be used in scenarios.
 - **Starkku**:
@@ -219,3 +220,4 @@ This page lists all the individual contributions to the project by their author.
   - Implement `DecloakToFire`.
   - Implement `CellSpread` and `PercentAtMax`.
   - Implement `ScorchChance`, `CraterChance` and `CellAnimChance`.
+  - Implement `Explosive` for animations.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -222,5 +222,5 @@ This page lists all the individual contributions to the project by their author.
   - Implement `ScorchChance`, `CraterChance` and `CellAnimChance`.
   - Implement `ExplosionDamage` for animations.
   - Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier`.
-  - Implement `Volumetric`.
+  - Implement `Volumetric`, `SnapToCellCenter`.
   - Animations now use their `Warhead` to deal damage, if one is specified.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -221,3 +221,4 @@ This page lists all the individual contributions to the project by their author.
   - Implement `CellSpread` and `PercentAtMax`.
   - Implement `ScorchChance`, `CraterChance` and `CellAnimChance`.
   - Implement `Explosive` for animations.
+  - Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -222,3 +222,4 @@ This page lists all the individual contributions to the project by their author.
   - Implement `ScorchChance`, `CraterChance` and `CellAnimChance`.
   - Implement `Explosive` for animations.
   - Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier`.
+  - Implement `Volumetric`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -218,3 +218,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix the map glitching around when scrolling if the map is not large enough to fill the entire screen.
   - Implement `DecloakToFire`.
   - Implement `CellSpread` and `PercentAtMax`.
+  - Implement `ScorchChance`, `CraterChance` and `FireChance`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -217,3 +217,4 @@ This page lists all the individual contributions to the project by their author.
   - VehicleTypes with Jumpjet locomotion now take damage in flight.
   - Fix the map glitching around when scrolling if the map is not large enough to fill the entire screen.
   - Implement `DecloakToFire`.
+  - Implement `CellSpread` and `PercentAtMax`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -218,4 +218,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix the map glitching around when scrolling if the map is not large enough to fill the entire screen.
   - Implement `DecloakToFire`.
   - Implement `CellSpread` and `PercentAtMax`.
-  - Implement `ScorchChance`, `CraterChance` and `FireChance`.
+  - Implement `ScorchChance`, `CraterChance` and `CellAnimChance`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -223,3 +223,4 @@ This page lists all the individual contributions to the project by their author.
   - Implement `Explosive` for animations.
   - Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier`.
   - Implement `Volumetric`.
+  - Animations now use their `Warhead` to deal damage, if one is specified.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1178,6 +1178,21 @@ TurretFacings=32     ; integer, the turret facing count.
 
 ## Warheads
 
+### Cell Spread
+
+- Vinifera ports the Cell Spread mechanic from Red Alert 2, allowing for more destructive and flexible weapons.
+
+In `RULES.INI`:
+```ini
+[SOMEWARHEAD]      ; WarheadType
+CellSpread=-1      ; float, the maximum range, in cells, at which a weapon using this warhead will damage objects.
+PercentAtMax=100%  ; % or float, the fraction of the damage that is applied at the weapon's max range.
+```
+
+```{note}
+When `CellSpread` is negative, vanilla TS `Spread` logic is applied.
+```
+
 ### MinDamage
 
 - Vinifera allows customizing the minimum damage dealt using a specific warhead.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1223,16 +1223,16 @@ CellAnim=         ; list of AnimTypes, the list of animation to pick from when a
 
 ### Damage Modifier against types of objects
 
-- Vinifera allows specified a broad multiplier to damage against infantry, vehicles, aircraft, buildings and terrain objects.
+- Vinifera allows specified a broad modifier to damage against infantry, vehicles, aircraft, buildings and terrain objects.
 
 In `RULES.INI`:
 ```ini
-[SOMEWARHEAD]            ; WarheadType
-InfantryMultiplier=100%  ; % or float, modifier applied to damage dealt to infantry by this warhead.
-VehicleMultiplier=100%   ; % or float, modifier applied to damage dealt to vehicles by this warhead.
-AircraftMultiplier=100%  ; % or float, modifier applied to damage dealt to aircraft by this warhead.
-BuildingMultiplier=100%  ; % or float, modifier applied to damage dealt to buildings by this warhead.
-TerrainMultiplier=100%   ; % or float, modifier applied to damage dealt to terrain objects by this warhead.
+[SOMEWARHEAD]          ; WarheadType
+InfantryModifier=100%  ; % or float, modifier applied to damage dealt to infantry by this warhead.
+VehicleModifier=100%   ; % or float, modifier applied to damage dealt to vehicles by this warhead.
+AircraftModifier=100%  ; % or float, modifier applied to damage dealt to aircraft by this warhead.
+BuildingModifier=100%  ; % or float, modifier applied to damage dealt to buildings by this warhead.
+TerrainModifier=100%   ; % or float, modifier applied to damage dealt to terrain objects by this warhead.
 ```
 
 ### MinDamage

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -64,12 +64,12 @@ MiddleFrame=   ; integer, the frame number in which the animation system will pe
 `MiddleFrame=0` is reserved and will not cause `MiddleAnims` to be spawned on every loop, but rather once at the start of the animation (like with `StartAnims`). To repeatedly spawn animations at the start of the loop, use `MiddleFrame` values of `1` or higher.
 ```
 
-### Middle Frame Exlosion
+### Middle Frame Explosion
 
 - Vinifera allows the animation to spawn an explosion on its biggest frame (also controlled by `MiddleFrame=`) using its `Warhead=`.
 
 In `ART.INI`:
-```ini
+```iniwea
 [AnimType]         ; AnimType
 ExplosionDamage=0  ; integer, if positive, the animation will spawn an explosion during its biggest frame dealing this much damage.
 ```

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1193,6 +1193,26 @@ PercentAtMax=100%  ; % or float, the fraction of the damage that is applied at t
 When `CellSpread` is negative, vanilla TS `Spread` logic is applied.
 ```
 
+### Smudges and Fires
+
+- Vinifera allows weapons to spawn scorches, craters and fires on cells affected by explosions.
+
+```{note}
+When using `Spread`, only the cell directly hit by the explosion will be considered. When using `CellSpread`, all affected cells are taken into account.
+```
+
+In `RULES.INI`:
+```ini
+[SOMEWARHEAD]    ; WarheadType
+ScorchChance=-1  ; % or float, the chance that an affected cell will contain a new scorch after the explosion.
+CraterChance=-1  ; % or float, the chance that an affected cell will contain a new crater after the explosion.
+FireChance=-1    ; % or float, the chance that an affected cell will contain a new fire animation after the explosion.
+```
+
+```{note}
+Only one of these affects will be applied to the cell at a time.
+```
+
 ### MinDamage
 
 - Vinifera allows customizing the minimum damage dealt using a specific warhead.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1193,9 +1193,9 @@ PercentAtMax=100%  ; % or float, the fraction of the damage that is applied at t
 When `CellSpread` is negative, vanilla TS `Spread` logic is applied.
 ```
 
-### Smudges and Fires
+### Smudges and Animations
 
-- Vinifera allows weapons to spawn scorches, craters and fires on cells affected by explosions.
+- Vinifera allows weapons to spawn scorches, craters and animations on cells affected by explosions.
 
 ```{note}
 When using `Spread`, only the cell directly hit by the explosion will be considered. When using `CellSpread`, all affected cells are taken into account.
@@ -1203,10 +1203,11 @@ When using `Spread`, only the cell directly hit by the explosion will be conside
 
 In `RULES.INI`:
 ```ini
-[SOMEWARHEAD]    ; WarheadType
-ScorchChance=-1  ; % or float, the chance that an affected cell will contain a new scorch after the explosion.
-CraterChance=-1  ; % or float, the chance that an affected cell will contain a new crater after the explosion.
-FireChance=-1    ; % or float, the chance that an affected cell will contain a new fire animation after the explosion.
+[SOMEWARHEAD]     ; WarheadType
+ScorchChance=0    ; % or float, the chance that an affected cell will contain a new scorch after the explosion.
+CraterChance=0    ; % or float, the chance that an affected cell will contain a new crater after the explosion.
+CellAnimChance=0  ; % or float, the chance that an affected cell will contain a new animation after the explosion.
+CellAnim=         ; list of AnimTypes, the list of animation to pick from when a random animation is spawned. Defaults to `[AudioVisual]->OnFire`.
 ```
 
 ```{note}

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -69,7 +69,7 @@ MiddleFrame=   ; integer, the frame number in which the animation system will pe
 - Vinifera allows the animation to spawn an explosion on its biggest frame (also controlled by `MiddleFrame=`) using its `Warhead=`.
 
 In `ART.INI`:
-```iniwea
+```ini
 [AnimType]         ; AnimType
 ExplosionDamage=0  ; integer, if positive, the animation will spawn an explosion during its biggest frame dealing this much damage.
 ```

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1213,8 +1213,18 @@ In `RULES.INI`:
 Volumetric=no  ; boolean, should objects in flight always be considered for damage by this warhead.
 ```
 
+### SnapToCellCenter
+
+- Vinifera allows focing explosions using a certain warhead to take place in the center of the cell where they occur. This can help reduce damage randomness in some cases.
+
+In `RULES.INI`:
+```ini
+[SOMEWARHEAD]        ; WarheadType
+SnapToCellCenter=no  ; boolean, do explosions using this warhead always take place in the cell center
+```
+
 ```{note}
-This tag may incur a small performance cost, as the game has to consider all units, infantry and aircraft on the map.
+This tag does not alter the visuals of the explosion in any way, but only affects the way damage is dealt.
 ```
 
 ### Smudges and Animations

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1210,10 +1210,6 @@ CellAnimChance=0  ; % or float, the chance that an affected cell will contain a 
 CellAnim=         ; list of AnimTypes, the list of animation to pick from when a random animation is spawned. Defaults to `[AudioVisual]->OnFire`.
 ```
 
-```{note}
-Only one of these affects will be applied to the cell at a time.
-```
-
 ### MinDamage
 
 - Vinifera allows customizing the minimum damage dealt using a specific warhead.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -71,7 +71,7 @@ MiddleFrame=   ; integer, the frame number in which the animation system will pe
 In `ART.INI`:
 ```ini
 [AnimType]         ; AnimType
-Explosive=no       ; boolean, should this aniamtino spawn an explosion on its biggest frame?
+Explosive=no       ; boolean, should this animation spawn an explosion on its biggest frame?
 ExplosionDamage=0  ; integer, the damage dealt by this animation's explosion.
 ```
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1229,7 +1229,7 @@ This tag does not alter the visuals of the explosion in any way, but only affect
 
 ### Smudges and Animations
 
-- Vinifera allows weapons to spawn scorches, craters and animations on cells affected by explosions.
+- Vinifera allows weapons to spawn scorches, craters and animations on cells affected by explosions. Similarly to damage, the smudge/animation spawn chance can be reduced with range.
 
 ```{note}
 When using `Spread`, only the cell directly hit by the explosion will be considered. When using `CellSpread`, all affected cells are taken into account.
@@ -1237,11 +1237,14 @@ When using `Spread`, only the cell directly hit by the explosion will be conside
 
 In `RULES.INI`:
 ```ini
-[SOMEWARHEAD]     ; WarheadType
-ScorchChance=0    ; % or float, the chance that an affected cell will contain a new scorch after the explosion.
-CraterChance=0    ; % or float, the chance that an affected cell will contain a new crater after the explosion.
-CellAnimChance=0  ; % or float, the chance that an affected cell will contain a new animation after the explosion.
-CellAnim=         ; list of AnimTypes, the list of animation to pick from when a random animation is spawned. Defaults to `[AudioVisual]->OnFire`.
+[SOMEWARHEAD]           ; WarheadType
+ScorchChance=0          ; % or float, the chance that an affected cell will contain a new scorch after the explosion.
+ScorchPercentAtMax=1    ; % or float, the fraction of the chance that is applied at the weapon's max range.
+CraterChance=0          ; % or float, the chance that an affected cell will contain a new crater after the explosion.
+CraterPercentAtMax=1    ; % or float, the fraction of the chance that is applied at the weapon's max range.
+CellAnimChance=0        ; % or float, the chance that an affected cell will contain a new animation after the explosion.
+CellAnimPercentAtMax=1  ; % or float, the fraction of the chance that is applied at the weapon's max range.
+CellAnim=               ; list of AnimTypes, the list of animation to pick from when a random animation is spawned. Defaults to `[AudioVisual]->OnFire`.
 ```
 
 ### Damage Modifier against types of objects

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -71,8 +71,7 @@ MiddleFrame=   ; integer, the frame number in which the animation system will pe
 In `ART.INI`:
 ```ini
 [AnimType]         ; AnimType
-Explosive=no       ; boolean, should this animation spawn an explosion on its biggest frame?
-ExplosionDamage=0  ; integer, the damage dealt by this animation's explosion.
+ExplosionDamage=0  ; integer, if positive, the animation will spawn an explosion during its biggest frame dealing this much damage.
 ```
 
 ### Various Keys Ported from Red Alert 2

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -64,6 +64,17 @@ MiddleFrame=   ; integer, the frame number in which the animation system will pe
 `MiddleFrame=0` is reserved and will not cause `MiddleAnims` to be spawned on every loop, but rather once at the start of the animation (like with `StartAnims`). To repeatedly spawn animations at the start of the loop, use `MiddleFrame` values of `1` or higher.
 ```
 
+### Middle Frame Exlosion
+
+- Vinifera allows the animation to spawn an explosion on its biggest frame (also controlled by `MiddleFrame=`) using its `Warhead=`.
+
+In `ART.INI`:
+```ini
+[AnimType]         ; AnimType
+Explosive=no       ; boolean, should this aniamtino spawn an explosion on its biggest frame?
+ExplosionDamage=0  ; integer, the damage dealt by this animation's explosion.
+```
+
 ### Various Keys Ported from Red Alert 2
 
 - Vinifera implements various AnimType keys from Red Alert 2.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1221,6 +1221,20 @@ CellAnimChance=0  ; % or float, the chance that an affected cell will contain a 
 CellAnim=         ; list of AnimTypes, the list of animation to pick from when a random animation is spawned. Defaults to `[AudioVisual]->OnFire`.
 ```
 
+### Damage Modifier against types of objects
+
+- Vinifera allows specified a broad multiplier to damage against infantry, vehicles, aircraft, buildings and terrain objects.
+
+In `RULES.INI`:
+```ini
+[SOMEWARHEAD]            ; WarheadType
+InfantryMultiplier=100%  ; % or float, modifier applied to damage dealt to infantry by this warhead.
+VehicleMultiplier=100%   ; % or float, modifier applied to damage dealt to vehicles by this warhead.
+AircraftMultiplier=100%  ; % or float, modifier applied to damage dealt to aircraft by this warhead.
+BuildingMultiplier=100%  ; % or float, modifier applied to damage dealt to buildings by this warhead.
+TerrainMultiplier=100%   ; % or float, modifier applied to damage dealt to terrain objects by this warhead.
+```
+
 ### MinDamage
 
 - Vinifera allows customizing the minimum damage dealt using a specific warhead.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1204,6 +1204,20 @@ PercentAtMax=100%  ; % or float, the fraction of the damage that is applied at t
 When `CellSpread` is negative, vanilla TS `Spread` logic is applied.
 ```
 
+### Volumetric
+
+- By default, explosions located strictly on the ground do not deal damage against targets in air. You can change this on a per-warhead basis.
+
+In `RULES.INI`:
+```ini
+[SOMEWARHEAD]  ; WarheadType
+Volumetric=no  ; boolean, should objects in flight always be considered for damage by this warhead.
+```
+
+```{note}
+This tag may incur a small performance cost, as the game has to consider all units, infantry and aircraft on the map.
+```
+
 ### Smudges and Animations
 
 - Vinifera allows weapons to spawn scorches, craters and animations on cells affected by explosions.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -170,7 +170,7 @@ New:
 - Add `TargetZoneScan` to TechnoTypes (by Rampastring)
 - Implement `DecloakToFire` (by ZivDero)
 - Implement `CellSpread` and `PercentAtMax` (by ZivDero)
-- Implement `ScorchChance`, `CraterChance` and `FireChance` (by ZivDero)
+- Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -171,7 +171,7 @@ New:
 - Implement `DecloakToFire` (by ZivDero)
 - Implement `CellSpread` and `PercentAtMax` (by ZivDero)
 - Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
-- Implement `Explosive` for animations (by ZivDero, Rampastring)
+- Implement `ExplosionDamage` for animations (by ZivDero, Rampastring)
 - Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier` (by ZivDero)
 - Implement `Volumetric` (by ZivDero)
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -173,7 +173,7 @@ New:
 - Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
 - Implement `ExplosionDamage` for animations (by ZivDero, Rampastring)
 - Implement `InfantryModifier`, `VehicleModifier`, `AircraftModifier`, `BuildingModifier`, `TerrainModifier` (by ZivDero)
-- Implement `Volumetric` (by ZivDero)
+- Implement `Volumetric`, `SnapToCellCenter` (by ZivDero)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -173,6 +173,7 @@ New:
 - Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
 - Implement `Explosive` for animations (by ZivDero, Rampastring)
 - Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier` (by ZivDero)
+- Implement `Volumetric` (by ZivDero)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -169,6 +169,7 @@ New:
 - Implement a feature for animations to spawn additional animations (by CCHyper/tomsons26, ZivDero)
 - Add `TargetZoneScan` to TechnoTypes (by Rampastring)
 - Implement `DecloakToFire` (by ZivDero)
+- Implement `CellSpread` and `PercentAtMax` (by ZivDero)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -170,6 +170,7 @@ New:
 - Add `TargetZoneScan` to TechnoTypes (by Rampastring)
 - Implement `DecloakToFire` (by ZivDero)
 - Implement `CellSpread` and `PercentAtMax` (by ZivDero)
+- Implement `ScorchChance`, `CraterChance` and `FireChance` (by ZivDero)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -172,7 +172,7 @@ New:
 - Implement `CellSpread` and `PercentAtMax` (by ZivDero)
 - Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
 - Implement `ExplosionDamage` for animations (by ZivDero, Rampastring)
-- Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier` (by ZivDero)
+- Implement `InfantryModifier`, `VehicleModifier`, `AircraftModifier`, `BuildingModifier`, `TerrainModifier` (by ZivDero)
 - Implement `Volumetric` (by ZivDero)
 
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -240,6 +240,7 @@ Vanilla fixes:
 - `[CombatDamage]->MinDamage` now works as expected and damage is no long always a minimum of `1` (by ZivDero)
 - VehicleTypes with Jumpjet locomotion now take damage in flight (by ZivDero)
 - Fix the map glitching around when scrolling if the map is not large enough to fill the entire screen (by Belonit, ZivDero)
+- Animations now use their `Warhead` to deal damage, if one is specified (by ZivDero)
 
 </details>
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -170,7 +170,7 @@ New:
 - Add `TargetZoneScan` to TechnoTypes (by Rampastring)
 - Implement `DecloakToFire` (by ZivDero)
 - Implement `CellSpread` and `PercentAtMax` (by ZivDero)
-- Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
+- Implement customizable spawnig of animations and smudges by explosions (by ZivDero)
 - Implement `ExplosionDamage` for animations (by ZivDero, Rampastring)
 - Implement `InfantryModifier`, `VehicleModifier`, `AircraftModifier`, `BuildingModifier`, `TerrainModifier` (by ZivDero)
 - Implement `Volumetric`, `SnapToCellCenter` (by ZivDero)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -171,6 +171,7 @@ New:
 - Implement `DecloakToFire` (by ZivDero)
 - Implement `CellSpread` and `PercentAtMax` (by ZivDero)
 - Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
+- Implement `Explosive` for animations (by ZivDero, Rampastring)
 
 
 Vanilla fixes:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -172,6 +172,7 @@ New:
 - Implement `CellSpread` and `PercentAtMax` (by ZivDero)
 - Implement `ScorchChance`, `CraterChance` and `CellAnimChance` (by ZivDero)
 - Implement `Explosive` for animations (by ZivDero, Rampastring)
+- Implement `InfantryMultiplier`, `VehicleMultiplier`, `AircraftMultiplier`, `BuildingMultiplier`, `TerrainMultiplier` (by ZivDero)
 
 
 Vanilla fixes:

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -461,6 +461,17 @@ function_return:
 
 
 /**
+ *  A helper is required because of stack issues.
+ */
+static Coordinate & Center_Coord_Helper(ObjectClass * obj)
+{
+    static Coordinate coord;
+    coord = obj->Center_Coord();
+    return coord;
+}
+
+
+/**
  *  Allows the animation to explode
  *  when it has reached its largest stage.
  *
@@ -479,7 +490,7 @@ DECLARE_PATCH(_AnimClass_Middle_Explosion_Patch)
      */
     animtypeext = Extension::Fetch<AnimTypeClassExtension>(animtype);
     if (animtypeext->IsExplosive && animtype->Warhead) {
-        Explosion_Damage(this_ptr->Center_Coord(), animtypeext->ExplosionDamage, nullptr, animtype->Warhead, true);
+        Explosion_Damage(Center_Coord_Helper(this_ptr), animtypeext->ExplosionDamage, nullptr, animtype->Warhead, true);
     }
 
     /**

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -489,7 +489,7 @@ DECLARE_PATCH(_AnimClass_Middle_Explosion_Patch)
      * If this animation is specified to do area damage, do the area damage effect now.
      */
     animtypeext = Extension::Fetch<AnimTypeClassExtension>(animtype);
-    if (animtypeext->IsExplosive && animtype->Warhead) {
+    if (animtypeext->ExplosionDamage > 0 && animtype->Warhead) {
         Explosion_Damage(Center_Coord_Helper(this_ptr), animtypeext->ExplosionDamage, nullptr, animtype->Warhead, true);
     }
 

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -65,7 +65,6 @@ AnimTypeClassExtension::AnimTypeClassExtension(const AnimTypeClass *this_ptr) :
     EndAnimsMaximum(),
     EndAnimsDelay(),
     MiddleFrame(-1),
-    IsExplosive(false),
     ExplosionDamage(0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("AnimTypeClassExtension::AnimTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -64,7 +64,9 @@ AnimTypeClassExtension::AnimTypeClassExtension(const AnimTypeClass *this_ptr) :
     EndAnimsMinimum(),
     EndAnimsMaximum(),
     EndAnimsDelay(),
-    MiddleFrame(-1)
+    MiddleFrame(-1),
+    IsExplosive(false),
+    ExplosionDamage(0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("AnimTypeClassExtension::AnimTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -416,6 +418,9 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
     if (This()->Image && This()->Image->Get_Frame_Count() > 0) {
         MiddleFrame = ini.Get_Int_Clamp(ini_name, "MiddleFrame", -1, This()->Image->Get_Frame_Count() - 1, MiddleFrame);
     }
+
+    IsExplosive = ini.Get_Bool(ini_name, "Explosive", IsExplosive);
+    ExplosionDamage = ini.Get_Int(ini_name, "ExplosionDamage", ExplosionDamage);
 
     IsInitialized = true;
 

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -275,6 +275,8 @@ void AnimTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(EndAnimsMinimum.Count());
     crc(EndAnimsMaximum.Count());
     crc(EndAnimsDelay.Count());
+    crc(IsExplosive);
+    crc(ExplosionDamage);
 }
 
 

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -275,7 +275,6 @@ void AnimTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(EndAnimsMinimum.Count());
     crc(EndAnimsMaximum.Count());
     crc(EndAnimsDelay.Count());
-    crc(IsExplosive);
     crc(ExplosionDamage);
 }
 
@@ -421,7 +420,6 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
         MiddleFrame = ini.Get_Int_Clamp(ini_name, "MiddleFrame", -1, This()->Image->Get_Frame_Count() - 1, MiddleFrame);
     }
 
-    IsExplosive = ini.Get_Bool(ini_name, "Explosive", IsExplosive);
     ExplosionDamage = ini.Get_Int(ini_name, "ExplosionDamage", ExplosionDamage);
 
     IsInitialized = true;

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -137,12 +137,7 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
         int MiddleFrame;
 
         /**
-         *  Does this animation spawn an explosion at it's biggest frame?
-         */
-        bool IsExplosive;
-
-        /**
-         *  The  amount of damage dealt by this animation's explosion.
+         *  If positive, the animation will spawn an explosion during its biggest frame dealing this much damage.
          */
         int ExplosionDamage;
 };

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -135,4 +135,14 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
          *  The middle (biggest) frame, if set by the user.
          */
         int MiddleFrame;
+
+        /**
+         *  Does this animation spawn an explosion at it's biggest frame?
+         */
+        bool IsExplosive;
+
+        /**
+         *  The  amount of damage dealt by this animation's explosion.
+         */
+        int ExplosionDamage;
 };

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -499,6 +499,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
             for (int x = -cell_radius; x <= cell_radius; x++) {
                 for (int y = -cell_radius; y <= cell_radius; y++) {
                     Cell newcell = cell + Cell(x, y);
+                    if (!Map.In_Radar(newcell)) continue;
                     if (Distance(Cell_Coord(newcell), Cell_Coord(cell)) <= range) {
                         Damage_Overlay(newcell, warhead, strength, do_chain_reaction);
                         Spawn_Flames_And_Smudges(newcell, warhead);

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -121,19 +121,19 @@ int Vinifera_Modify_Damage(int damage, WarheadTypeClass* warhead, ObjectClass * 
         switch (target->RTTI)
         {
         case RTTI_INFANTRY:
-            damage *= warhead_ext->InfantryMultiplier;
+            damage *= warhead_ext->InfantryModifier;
             break;
         case RTTI_UNIT:
-            damage *= warhead_ext->VehicleMultiplier;
+            damage *= warhead_ext->VehicleModifier;
             break;
         case RTTI_AIRCRAFT:
-            damage *= warhead_ext->AircraftMultiplier;
+            damage *= warhead_ext->AircraftModifier;
             break;
         case RTTI_BUILDING:
-            damage *= warhead_ext->BuildingMultiplier;
+            damage *= warhead_ext->BuildingModifier;
             break;
         case RTTI_TERRAIN:
-            damage *= warhead_ext->TerrainMultiplier;
+            damage *= warhead_ext->TerrainModifier;
             break;
         default:
             break;
@@ -207,19 +207,19 @@ int Vinifera_Modify_Damage(int damage, WarheadTypeClass* warhead, ObjectClass * 
         switch (target->RTTI)
         {
         case RTTI_INFANTRY:
-            damage *= warhead_ext->InfantryMultiplier;
+            damage *= warhead_ext->InfantryModifier;
             break;
         case RTTI_UNIT:
-            damage *= warhead_ext->VehicleMultiplier;
+            damage *= warhead_ext->VehicleModifier;
             break;
         case RTTI_AIRCRAFT:
-            damage *= warhead_ext->AircraftMultiplier;
+            damage *= warhead_ext->AircraftModifier;
             break;
         case RTTI_BUILDING:
-            damage *= warhead_ext->BuildingMultiplier;
+            damage *= warhead_ext->BuildingModifier;
             break;
         case RTTI_TERRAIN:
-            damage *= warhead_ext->TerrainMultiplier;
+            damage *= warhead_ext->TerrainModifier;
             break;
         default:
             break;

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -583,8 +583,8 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
         if (warhead->Particle->BehavesLike == 1) { // This is actually Gas behavior, there are 2 slightly different enums
             MasterParticle->Spawn_Held_Particle(coord, coord);
         } else {
-            ParticleSystemClass* ps = new ParticleSystemClass(warhead->Particle, coord);
-            ps->Spawn_Held_Particle(coord, coord);
+            ParticleSystemClass* psys = new ParticleSystemClass(warhead->Particle, coord);
+            psys->Spawn_Held_Particle(coord, coord);
         }
     }
 

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -478,7 +478,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
                 const Cell* list = object->Occupy_List();
                 distance = INT_MAX;
                 while (*list != REFRESH_EOL) {
-                    int trydist = Distance_Level_Snap(explosion_coord, object->Get_Coord() + Cell_Coord(*list++));
+                    int trydist = Distance_Level_Snap(explosion_coord, Cell_Coord(object->Get_Cell() + *list++));
                     distance = std::min(trydist, distance);
                 }
             } else {

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -391,8 +391,9 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
     }
 
     const auto warhead_ext = Extension::Fetch<WarheadTypeClassExtension>(warhead);
+    bool use_cell_spread = warhead_ext->CellSpread >= 0;
 
-    if (warhead_ext->CellSpread < 0) {
+    if (!use_cell_spread) {
         /**
          *  Collecting targets within a range of 1 cell is the same as sweeping through this cell,
          *  as well as the surrounding cells.
@@ -426,7 +427,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
                 if (distance < LEVEL_LEPTON_H * 2) {
                     distance = 0;
                 }
-            } else if (object->RTTI == RTTI_BUILDING && warhead_ext->CellSpread >= 0) {
+            } else if (object->RTTI == RTTI_BUILDING && use_cell_spread) {
                 /**
                  *  For buildings, let's consider their closest cell to the explosion.
                  */
@@ -485,7 +486,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
     cellptr = &Map[cell];
 
     if (close_to_ground) {
-        if (warhead_ext->CellSpread < 0) {
+        if (!use_cell_spread) {
             Damage_Overlay(cell, warhead, strength, do_chain_reaction);
             Spawn_Flames_And_Smudges(cell, warhead);
         }

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -562,7 +562,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
         for (int f = 0; f < 4; f++) {
             Coordinate adjacent = Adjacent_Coord_With_Height(coord, _part_facings[f]);
             if (Map[adjacent].Overlay != OVERLAY_NONE && OverlayTypes[Map[adjacent].Overlay]->IsExplosive) {
-                new AnimClass(AnimTypeClass::As_Pointer(AnimTypeClass::From_Name("FIRE3")), coord, Random_Pick(1, 3) + 3);
+                new AnimClass(AnimTypes[AnimTypeClass::From_Name("FIRE3")], coord, Random_Pick(1, 3) + 3);
             }
         }
     }

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -415,7 +415,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
      *  Fill the list with units that are in flight, because
      *  they are not present in cell data.
      */
-    if (Map.Get_Cell_Height(Cell_Coord(cell)) < coord.Z) {
+    if (warhead_ext->IsVolumetric || Map.Get_Cell_Height(Cell_Coord(cell)) < coord.Z) {
 
         for (int index = 0; index < Aircrafts.Count(); index++) {
             AircraftClass* aircraft = Aircrafts[index];

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -308,8 +308,12 @@ void Spawn_Flames_And_Smudges(const Cell & cell, const WarheadTypeClass * warhea
     else if (Probability_Of(warhead_ext->CraterChance)) {
         SmudgeTypeClass::Create_Crater(cell_coord, 100, 100, false);
     }
-    if (Probability_Of(warhead_ext->FireChance)) {
-        new AnimClass(Rule->OnFire[Random_Pick(0, Rule->OnFire.Count() - 1)], cell_coord);
+    if (Probability_Of(warhead_ext->CellAnimChance)) {
+        const TypeList<AnimTypeClass*>* anims = &warhead_ext->CellAnim;
+        if (anims->Count() == 0) {
+            anims = &Rule->OnFire;
+        }
+        new AnimClass((*anims)[Random_Pick(0, anims->Count() - 1)], cell_coord);
     }
 }
 

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -364,7 +364,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
                     distance /= 2;
                 }
             }
-            if (object->Strength > 0 && object->IsDown && !object->IsInLimbo && distance < range) {
+            if (object->Strength > 0 && object->IsDown && !object->IsInLimbo && distance <= range) {
                 int damage = strength;
                 if (warhead != Rule->IonStormWarhead || !object->Is_Foot() || static_cast<FootClass*>(object)->Team == nullptr || !static_cast<FootClass*>(object)->Team->Class->IsIonImmune) {
                     object->Take_Damage(damage, distance, warhead, source);

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -485,7 +485,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
         }
     }
 
-    const bool close_to_ground = std::abs(coord.Z - Map.Get_Cell_Height(coord)) < LEVEL_LEPTON_H * 2;
+    const bool close_to_ground = std::abs(coord.Z - Map.Get_Cell_Height(coord)) < LEVEL_LEPTON_H;
 
     cellptr = &Map[cell];
 

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -438,7 +438,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
                 const Cell* list = object->Occupy_List();
                 distance = INT_MAX;
                 while (*list != REFRESH_EOL) {
-                    int trydist = Distance_Level_Snap(coord, Cell_Coord(*list++));
+                    int trydist = Distance_Level_Snap(coord, object->Get_Coord() + Cell_Coord(*list++));
                     distance = std::min(trydist, distance);
                 }
             } else {

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -308,7 +308,7 @@ void Spawn_Flames_And_Smudges(const Cell & cell, const WarheadTypeClass * warhea
     else if (Probability_Of(warhead_ext->CraterChance)) {
         SmudgeTypeClass::Create_Crater(cell_coord, 100, 100, false);
     }
-    else if (Probability_Of(warhead_ext->FireChance)) {
+    if (Probability_Of(warhead_ext->FireChance)) {
         new AnimClass(Rule->OnFire[Random_Pick(0, Rule->OnFire.Count() - 1)], cell_coord);
     }
 }

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -182,6 +182,11 @@ static bool Is_On_High_Bridge(const Coordinate& coord)
 }
 
 
+/**
+ *  Collects the targets to deal damage to in the legacy way.
+ *
+ *  @author: ZivDero
+ */
 void Legacy_Get_Explosion_Targets(const Coordinate& coord, TechnoClass* source, DynamicVectorClass<ObjectClass*>& objects)
 {
     Cell cell;      // Cell number under explosion.
@@ -239,6 +244,11 @@ void Legacy_Get_Explosion_Targets(const Coordinate& coord, TechnoClass* source, 
 }
 
 
+/**
+ *  Collects the targets to deal damage to in a certain range.
+ *
+ *  @author: ZivDero
+ */
 void New_Get_Explosion_Targets(const Coordinate& coord, TechnoClass* source, int range, DynamicVectorClass<ObjectClass*>& objects)
 {
     Cell cell;      // Cell number under explosion.
@@ -302,15 +312,7 @@ void New_Get_Explosion_Targets(const Coordinate& coord, TechnoClass* source, int
 /**
  *  Inflict an explosion damage affect.
  *
- *  @author: 08/16/1991 JLB : Created.                                       
- *           11/30/1991 JLB : Uses coordinate system.                        
- *           12/27/1991 JLB : Radius of explosion damage effect.             
- *           04/13/1994 JLB : Streamlined.                                   
- *           04/16/1994 JLB : Warhead damage type modifier.                  
- *           04/17/1994 JLB : Cleaned up.                                    
- *           06/20/1994 JLB : Uses object pointers to distribute damage.     
- *           06/20/1994 JLB : Source is a pointer.                           
- *           06/18/1996 JLB : Strength could be negative for healing effects.
+ *  @author: 08/16/1991 JLB : Created.
  *           12/14/2024 ZivDero : Adjustments for Tiberian Sun
  */
 void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClass* source, const WarheadTypeClass* warhead, bool do_chain_reaction)

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -215,8 +215,7 @@ void Legacy_Get_Explosion_Targets(const Coordinate& coord, TechnoClass* source, 
 
         /**
          *  Add all objects in this cell to the list of objects to possibly apply
-         *  damage to. Do not include overlapping objects; selection state can affect
-         *  the overlappers, and this causes multiplayer games to go out of sync.
+         *  damage to.
          */
         object = cellptr->Cell_Occupier(isbridge);
         while (object) {
@@ -279,8 +278,7 @@ void New_Get_Explosion_Targets(const Coordinate& coord, TechnoClass* source, int
 
             /**
              *  Add all objects in this cell to the list of objects to possibly apply
-             *  damage to. Do not include overlapping objects; selection state can affect
-             *  the overlappers, and this causes multiplayer games to go out of sync.
+             *  damage to.
              */
             object = cellptr->Cell_Occupier(isbridge);
             while (object) {

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -306,7 +306,7 @@ void Spawn_Flames_And_Smudges(const Cell & cell, const WarheadTypeClass * warhea
         SmudgeTypeClass::Create_Scorch(cell_coord, 100, 100, false);
     }
     else if (Probability_Of(warhead_ext->CraterChance)) {
-        SmudgeTypeClass::Create_Scorch(cell_coord, 100, 100, false);
+        SmudgeTypeClass::Create_Crater(cell_coord, 100, 100, false);
     }
     else if (Probability_Of(warhead_ext->FireChance)) {
         new AnimClass(Rule->OnFire[Random_Pick(0, Rule->OnFire.Count() - 1)], cell_coord);

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -28,7 +28,6 @@
 #include "tibsun_inline.h"
 #include "buildingext_hooks.h"
 #include "combatext_hooks.h"
-
 #include "aircraft.h"
 #include "anim.h"
 #include "animtype.h"
@@ -47,7 +46,6 @@
 #include "building.h"
 #include "coord.h"
 #include "debughandler.h"
-
 #include "hooker.h"
 #include "hooker_macros.h"
 #include "infantry.h"
@@ -427,6 +425,16 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
                 distance = std::abs(coord.Z - object->Get_Z_Coord());
                 if (distance < LEVEL_LEPTON_H * 2) {
                     distance = 0;
+                }
+            } else if (object->RTTI == RTTI_BUILDING && warhead_ext->CellSpread >= 0) {
+                /**
+                 *  For buildings, let's consider their closest cell to the explosion.
+                 */
+                const Cell* list = object->Occupy_List();
+                distance = INT_MAX;
+                while (*list != REFRESH_EOL) {
+                    int trydist = Distance_Level_Snap(coord, Cell_Coord(*list++));
+                    distance = std::min(trydist, distance);
                 }
             } else {
                 distance = Distance_Level_Snap(coord, object->Target_Coord());

--- a/src/extensions/extension.cpp
+++ b/src/extensions/extension.cpp
@@ -152,6 +152,7 @@
 
 #include <iostream>
 
+#include "aircrafttracker.h"
 #include "armortype.h"
 #include "kamikazetracker.h"
 #include "rockettype.h"
@@ -2132,6 +2133,7 @@ unsigned Extension::Get_Save_Version_Number()
     version += sizeof(RocketTypeClass);
     version += sizeof(SpawnManagerClass);
     version += sizeof(KamikazeTrackerClass);
+    version += sizeof(AircraftTrackerClass);
 
     return version;
 }

--- a/src/extensions/extension_hooks.cpp
+++ b/src/extensions/extension_hooks.cpp
@@ -101,6 +101,7 @@
 //#include "alphashapeext_hooks.h"
 //#include "veinholemonsterext_hooks.h"
 
+#include "aircrafttracker_hooks.h"
 #include "rulesext_hooks.h"
 #include "scenarioext_hooks.h"
 #include "sessionext_hooks.h"
@@ -302,4 +303,5 @@ void Extension_Hooks()
      */
     TheaterTypeClassExtension_Hooks();
     SpawnManager_Hooks();
+    AircraftTracker_Hooks();
 }

--- a/src/extensions/foot/footext.cpp
+++ b/src/extensions/foot/footext.cpp
@@ -125,3 +125,25 @@ void FootClassExtension::Compute_CRC(WWCRCEngine &crc) const
 
     TechnoClassExtension::Compute_CRC(crc);
 }
+
+
+/**
+ *  Sets the last known flight cell of this object.
+ *
+ *  @author: ZivDero
+ */
+void FootClassExtension::Set_Last_Flight_Cell(Cell cell)
+{
+    LastFlightCell = cell;
+}
+
+
+/**
+ *  Gets the last known flight cell of this object.
+ *
+ *  @author: ZivDero
+ */
+Cell FootClassExtension::Get_Last_Flight_Cell()
+{
+    return LastFlightCell;
+}

--- a/src/extensions/scenario/scenarioext_hooks.cpp
+++ b/src/extensions/scenario/scenarioext_hooks.cpp
@@ -38,6 +38,7 @@
 #include "ccini.h"
 #include "endgame.h"
 #include "addon.h"
+#include "aircrafttracker.h"
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
@@ -97,6 +98,7 @@ DECLARE_PATCH(_Clear_Scenario_Patch)
     ScenExtension->Clear_All_Waypoints();
 
     KamikazeTracker->Clear();
+    AircraftTracker->Clear();
 
     JMP(0x005DC872);
 }

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -60,7 +60,8 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     PercentAtMax(1.0f),
     ScorchChance(0.0f),
     CraterChance(0.0f),
-    CellAnimChance(0.0f)
+    CellAnimChance(0.0f),
+    CellAnim()
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -74,7 +75,8 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
  *  @author: CCHyper
  */
 WarheadTypeClassExtension::WarheadTypeClassExtension(const NoInitClass &noinit) :
-    AbstractTypeClassExtension(noinit)
+    AbstractTypeClassExtension(noinit),
+    CellAnim(noinit)
 {
     //EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension(NoInitClass) - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -55,7 +55,9 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     ShakePixelYLo(0),
     ShakePixelXHi(0),
     ShakePixelXLo(0),
-    MinDamage(-1)
+    MinDamage(-1),
+    CellSpread(-1.0f),
+    PercentAtMax(1.0f)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -185,6 +187,8 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(ShakePixelYLo);
     crc(ShakePixelXHi);
     crc(ShakePixelXLo);
+    crc(CellSpread);
+    crc(PercentAtMax);
 }
 
 
@@ -289,6 +293,9 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     This()->IsOrganic = ini.Get_Bool(ini_name, "Organic", This()->IsOrganic);
 
     MinDamage = ini.Get_Int(ini_name, "MinDamage", MinDamage);
+
+    CellSpread = ini.Get_Float(ini_name, "CellSpread", CellSpread);
+    PercentAtMax = ini.Get_Float(ini_name, "PercentAtMax", PercentAtMax);
 
     IsInitialized = true;
 

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -57,7 +57,10 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     ShakePixelXLo(0),
     MinDamage(-1),
     CellSpread(-1.0f),
-    PercentAtMax(1.0f)
+    PercentAtMax(1.0f),
+    ScorchChance(0.0f),
+    CraterChance(0.0f),
+    FireChance(0.0f)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -296,6 +299,13 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
 
     CellSpread = ini.Get_Float(ini_name, "CellSpread", CellSpread);
     PercentAtMax = ini.Get_Float(ini_name, "PercentAtMax", PercentAtMax);
+
+    ScorchChance = ini.Get_Float(ini_name, "ScorchChance", ScorchChance);
+    ScorchChance = std::clamp(ScorchChance, 0.0f, 1.0f);
+    CraterChance = ini.Get_Float(ini_name, "CraterChance", CraterChance);
+    CraterChance = std::clamp(CraterChance, 0.0f, 1.0f);
+    FireChance = ini.Get_Float(ini_name, "FireChance", FireChance);
+    FireChance = std::clamp(FireChance, 0.0f, 1.0f);
 
     IsInitialized = true;
 

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -59,8 +59,11 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     CellSpread(-1.0f),
     PercentAtMax(1.0f),
     ScorchChance(0.0f),
+    ScorchPercentAtMax(1.0f),
     CraterChance(0.0f),
+    CraterPercentAtMax(1.0f),
     CellAnimChance(0.0f),
+    CellAnimPercentAtMax(1.0f),
     CellAnim(),
     InfantryModifier(1.0f),
     VehicleModifier(1.0f),
@@ -210,8 +213,11 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(CellSpread);
     crc(PercentAtMax);
     crc(ScorchChance);
+    crc(ScorchPercentAtMax);
     crc(CraterChance);
+    crc(CraterPercentAtMax);
     crc(CellAnimChance);
+    crc(CellAnimPercentAtMax);
     crc(CellAnim.Count());
     crc(InfantryModifier);
     crc(VehicleModifier);
@@ -330,10 +336,18 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
 
     ScorchChance = ini.Get_Float(ini_name, "ScorchChance", ScorchChance);
     ScorchChance = std::clamp(ScorchChance, 0.0f, 1.0f);
+    ScorchPercentAtMax = ini.Get_Float(ini_name, "ScorchPercentAtMax", ScorchPercentAtMax);
+    ScorchPercentAtMax = std::clamp(ScorchPercentAtMax, 0.0f, 1.0f);
+
     CraterChance = ini.Get_Float(ini_name, "CraterChance", CraterChance);
     CraterChance = std::clamp(CraterChance, 0.0f, 1.0f);
+    CraterPercentAtMax = ini.Get_Float(ini_name, "CraterPercentAtMax", CraterPercentAtMax);
+    CraterPercentAtMax = std::clamp(CraterPercentAtMax, 0.0f, 1.0f);
+
     CellAnimChance = ini.Get_Float(ini_name, "CellAnimChance", CellAnimChance);
     CellAnimChance = std::clamp(CellAnimChance, 0.0f, 1.0f);
+    CellAnimPercentAtMax = ini.Get_Float(ini_name, "CellAnimPercentAtMax", CellAnimPercentAtMax);
+    CellAnimPercentAtMax = std::clamp(CellAnimPercentAtMax, 0.0f, 1.0f);
     CellAnim = ini.Get_Anims(ini_name, "CellAnim", CellAnim);
 
     InfantryModifier = ini.Get_Float(ini_name, "InfantryModifier", InfantryModifier);

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -61,7 +61,12 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     ScorchChance(0.0f),
     CraterChance(0.0f),
     CellAnimChance(0.0f),
-    CellAnim()
+    CellAnim(),
+    InfantryMultiplier(1.0f),
+    VehicleMultiplier(1.0f),
+    AircraftMultiplier(1.0f),
+    BuildingMultiplier(1.0f),
+    TerrainMultiplier(1.0f)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -202,6 +207,15 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(ShakePixelXLo);
     crc(CellSpread);
     crc(PercentAtMax);
+    crc(ScorchChance);
+    crc(CraterChance);
+    crc(CellAnimChance);
+    crc(CellAnim.Count());
+    crc(InfantryMultiplier);
+    crc(VehicleMultiplier);
+    crc(AircraftMultiplier);
+    crc(BuildingMultiplier);
+    crc(TerrainMultiplier);
 }
 
 
@@ -317,6 +331,12 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     CellAnimChance = ini.Get_Float(ini_name, "CellAnimChance", CellAnimChance);
     CellAnimChance = std::clamp(CellAnimChance, 0.0f, 1.0f);
     CellAnim = ini.Get_Anims(ini_name, "CellAnim", CellAnim);
+
+    InfantryMultiplier = ini.Get_Float(ini_name, "InfantryMultiplier", InfantryMultiplier);
+    VehicleMultiplier = ini.Get_Float(ini_name, "VehicleMultiplier", VehicleMultiplier);
+    AircraftMultiplier = ini.Get_Float(ini_name, "AircraftMultiplier", AircraftMultiplier);
+    BuildingMultiplier = ini.Get_Float(ini_name, "BuildingMultiplier", BuildingMultiplier);
+    TerrainMultiplier = ini.Get_Float(ini_name, "TerrainMultiplier", TerrainMultiplier);
 
     IsInitialized = true;
 

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -67,7 +67,8 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     AircraftModifier(1.0f),
     BuildingModifier(1.0f),
     TerrainModifier(1.0f),
-    IsVolumetric(false)
+    IsVolumetric(false),
+    IsSnapToCellCenter(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -217,6 +218,8 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(AircraftModifier);
     crc(BuildingModifier);
     crc(TerrainModifier);
+    crc(IsVolumetric);
+    crc(IsSnapToCellCenter);
 }
 
 
@@ -340,6 +343,7 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     TerrainModifier = ini.Get_Float(ini_name, "TerrainModifier", TerrainModifier);
 
     IsVolumetric = ini.Get_Bool(ini_name, "Volumetric", IsVolumetric);
+    IsSnapToCellCenter = ini.Get_Bool(ini_name, "SnapToCellCenter", IsSnapToCellCenter);
 
     IsInitialized = true;
 

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -60,7 +60,7 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     PercentAtMax(1.0f),
     ScorchChance(0.0f),
     CraterChance(0.0f),
-    FireChance(0.0f)
+    CellAnimChance(0.0f)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -121,12 +121,18 @@ HRESULT WarheadTypeClassExtension::Load(IStream *pStm)
 {
     //EXT_DEBUG_TRACE("WarheadTypeClassExtension::Load - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
+    CellAnim.Clear();
+
     HRESULT hr = AbstractTypeClassExtension::Load(pStm);
     if (FAILED(hr)) {
         return hr;
     }
 
     new (this) WarheadTypeClassExtension(NoInitClass());
+
+    CellAnim.Load(pStm);
+
+    VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP_LIST(CellAnim, "CellAnim");
     
     return hr;
 }
@@ -145,6 +151,8 @@ HRESULT WarheadTypeClassExtension::Save(IStream *pStm, BOOL fClearDirty)
     if (FAILED(hr)) {
         return hr;
     }
+
+    CellAnim.Save(pStm);
 
     return hr;
 }
@@ -304,8 +312,9 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     ScorchChance = std::clamp(ScorchChance, 0.0f, 1.0f);
     CraterChance = ini.Get_Float(ini_name, "CraterChance", CraterChance);
     CraterChance = std::clamp(CraterChance, 0.0f, 1.0f);
-    FireChance = ini.Get_Float(ini_name, "FireChance", FireChance);
-    FireChance = std::clamp(FireChance, 0.0f, 1.0f);
+    CellAnimChance = ini.Get_Float(ini_name, "CellAnimChance", CellAnimChance);
+    CellAnimChance = std::clamp(CellAnimChance, 0.0f, 1.0f);
+    CellAnim = ini.Get_Anims(ini_name, "CellAnim", CellAnim);
 
     IsInitialized = true;
 

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -62,11 +62,11 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     CraterChance(0.0f),
     CellAnimChance(0.0f),
     CellAnim(),
-    InfantryMultiplier(1.0f),
-    VehicleMultiplier(1.0f),
-    AircraftMultiplier(1.0f),
-    BuildingMultiplier(1.0f),
-    TerrainMultiplier(1.0f)
+    InfantryModifier(1.0f),
+    VehicleModifier(1.0f),
+    AircraftModifier(1.0f),
+    BuildingModifier(1.0f),
+    TerrainModifier(1.0f)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -211,11 +211,11 @@ void WarheadTypeClassExtension::Compute_CRC(WWCRCEngine &crc) const
     crc(CraterChance);
     crc(CellAnimChance);
     crc(CellAnim.Count());
-    crc(InfantryMultiplier);
-    crc(VehicleMultiplier);
-    crc(AircraftMultiplier);
-    crc(BuildingMultiplier);
-    crc(TerrainMultiplier);
+    crc(InfantryModifier);
+    crc(VehicleModifier);
+    crc(AircraftModifier);
+    crc(BuildingModifier);
+    crc(TerrainModifier);
 }
 
 
@@ -332,11 +332,11 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     CellAnimChance = std::clamp(CellAnimChance, 0.0f, 1.0f);
     CellAnim = ini.Get_Anims(ini_name, "CellAnim", CellAnim);
 
-    InfantryMultiplier = ini.Get_Float(ini_name, "InfantryMultiplier", InfantryMultiplier);
-    VehicleMultiplier = ini.Get_Float(ini_name, "VehicleMultiplier", VehicleMultiplier);
-    AircraftMultiplier = ini.Get_Float(ini_name, "AircraftMultiplier", AircraftMultiplier);
-    BuildingMultiplier = ini.Get_Float(ini_name, "BuildingMultiplier", BuildingMultiplier);
-    TerrainMultiplier = ini.Get_Float(ini_name, "TerrainMultiplier", TerrainMultiplier);
+    InfantryModifier = ini.Get_Float(ini_name, "InfantryModifier", InfantryModifier);
+    VehicleModifier = ini.Get_Float(ini_name, "VehicleModifier", VehicleModifier);
+    AircraftModifier = ini.Get_Float(ini_name, "AircraftModifier", AircraftModifier);
+    BuildingModifier = ini.Get_Float(ini_name, "BuildingModifier", BuildingModifier);
+    TerrainModifier = ini.Get_Float(ini_name, "TerrainModifier", TerrainModifier);
 
     IsInitialized = true;
 

--- a/src/extensions/warheadtype/warheadtypeext.cpp
+++ b/src/extensions/warheadtype/warheadtypeext.cpp
@@ -66,7 +66,8 @@ WarheadTypeClassExtension::WarheadTypeClassExtension(const WarheadTypeClass *thi
     VehicleModifier(1.0f),
     AircraftModifier(1.0f),
     BuildingModifier(1.0f),
-    TerrainModifier(1.0f)
+    TerrainModifier(1.0f),
+    IsVolumetric(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("WarheadTypeClassExtension::WarheadTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -337,6 +338,8 @@ bool WarheadTypeClassExtension::Read_INI(CCINIClass &ini)
     AircraftModifier = ini.Get_Float(ini_name, "AircraftModifier", AircraftModifier);
     BuildingModifier = ini.Get_Float(ini_name, "BuildingModifier", BuildingModifier);
     TerrainModifier = ini.Get_Float(ini_name, "TerrainModifier", TerrainModifier);
+
+    IsVolumetric = ini.Get_Bool(ini_name, "Volumetric", IsVolumetric);
 
     IsInitialized = true;
 

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -111,7 +111,12 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
         float CraterChance;
 
         /**
-         *  The chance that a cell affected by this warhead will spawn a random fire.
+         *  The chance that a cell affected by this warhead will spawn a random anim from the list.
          */
-        float FireChance;
+        float CellAnimChance;
+
+        /**
+         *  The list of anims to pick from when CellAnimChance is triggered.
+         */
+        TypeList<AnimTypeClass*> CellAnim;
 };

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -104,16 +104,19 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
          *  The chance that a cell affected by this warhead will spawn a random scorch.
          */
         float ScorchChance;
+        float ScorchPercentAtMax;
 
         /**
          *  The chance that a cell affected by this warhead will spawn a random crater.
          */
         float CraterChance;
+        float CraterPercentAtMax;
 
         /**
          *  The chance that a cell affected by this warhead will spawn a random anim from the list.
          */
         float CellAnimChance;
+        float CellAnimPercentAtMax;
 
         /**
          *  The list of anims to pick from when CellAnimChance is triggered.

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -123,9 +123,9 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
         /**
          *  Damage multipliers against various object types.
          */
-        float InfantryMultiplier;
-        float VehicleMultiplier;
-        float AircraftMultiplier;
-        float BuildingMultiplier;
-        float TerrainMultiplier;
+        float InfantryModifier;
+        float VehicleModifier;
+        float AircraftModifier;
+        float BuildingModifier;
+        float TerrainModifier;
 };

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -99,4 +99,19 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
          *  The fraction of the damage that is applied at this weapon's max range.
          */
         float PercentAtMax;
+
+        /**
+         *  The chance that a cell affected by this warhead will spawn a random scorch.
+         */
+        float ScorchChance;
+
+        /**
+         *  The chance that a cell affected by this warhead will spawn a random crater.
+         */
+        float CraterChance;
+
+        /**
+         *  The chance that a cell affected by this warhead will spawn a random fire.
+         */
+        float FireChance;
 };

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -128,4 +128,9 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
         float AircraftModifier;
         float BuildingModifier;
         float TerrainModifier;
+
+        /**
+         *  Should this warhead always damage things in air, regardless of the explosion height?
+         */
+        bool IsVolumetric;
 };

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -89,4 +89,14 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
          *  The minimum damage something using this warhead can deal. Negative means to use Rule->MinDamage.
          */
         int MinDamage;
+
+        /**
+         *  The maximum range, in cells, at which a weapon using this warhead will damage objects.
+         */
+        float CellSpread;
+
+        /**
+         *  The fraction of the damage that is applied at this weapon's max range.
+         */
+        float PercentAtMax;
 };

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -119,4 +119,13 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
          *  The list of anims to pick from when CellAnimChance is triggered.
          */
         TypeList<AnimTypeClass*> CellAnim;
+
+        /**
+         *  Damage multipliers against various object types.
+         */
+        float InfantryMultiplier;
+        float VehicleMultiplier;
+        float AircraftMultiplier;
+        float BuildingMultiplier;
+        float TerrainMultiplier;
 };

--- a/src/extensions/warheadtype/warheadtypeext.h
+++ b/src/extensions/warheadtype/warheadtypeext.h
@@ -133,4 +133,9 @@ WarheadTypeClassExtension final : public AbstractTypeClassExtension
          *  Should this warhead always damage things in air, regardless of the explosion height?
          */
         bool IsVolumetric;
+
+        /**
+         *  Should explosions using this warhead always take place at the center of the cell?
+         */
+        bool IsSnapToCellCenter;
 };

--- a/src/new/aircrafttracker/aircrafttracker.cpp
+++ b/src/new/aircrafttracker/aircrafttracker.cpp
@@ -161,8 +161,8 @@ void AircraftTrackerClass::Untrack(FootClass* target)
  */
 HRESULT STDMETHODCALLTYPE AircraftTrackerClass::Load(IStream* stream)
 {
-    for (auto& Region : Regions) {
-        HRESULT result = Load_Primitive_Vector(stream, Region, "Regions");
+    for (auto& region : Regions) {
+        HRESULT result = Load_Primitive_Vector(stream, region, "Regions");
         if (FAILED(result)) {
             return result;
         }
@@ -215,8 +215,8 @@ void AircraftTrackerClass::Clear(void)
  */
 HRESULT STDMETHODCALLTYPE AircraftTrackerClass::Save(IStream* stream)
 {
-    for (auto& Region : Regions) {
-        HRESULT result = Save_Primitive_Vector(stream, Region, "Regions");
+    for (auto& region : Regions) {
+        HRESULT result = Save_Primitive_Vector(stream, region, "Regions");
         if (FAILED(result)) {
             return result;
         }

--- a/src/new/aircrafttracker/aircrafttracker.cpp
+++ b/src/new/aircrafttracker/aircrafttracker.cpp
@@ -64,21 +64,19 @@ int AircraftTrackerClass::Adjacent_Region(int region, int xoff, int yoff)
     int regx = region % 20;
     int regy = region / 20;
 
-    if (xoff + regx >= 0 && xoff + regx > (20 - 1)) {
+    if (xoff + regx > (20 - 1)) {
         regx = (20 - 1);
-    }
-    else {
+    } else {
         regx = xoff + regx < 0 ? 0 : xoff + regx;
     }
 
-    if (yoff + regy >= 0 && yoff + regy > (20 - 1)) {
+    if (yoff + regy > (20 - 1)) {
         regy = (20 - 1);
-    }
-    else {
+    } else {
         regy = yoff + regy < 0 ? 0 : yoff + regy;
     }
 
-    return(regx + regy * 20);
+    return regx + regy * 20;
 }
 
 

--- a/src/new/aircrafttracker/aircrafttracker.cpp
+++ b/src/new/aircrafttracker/aircrafttracker.cpp
@@ -1,0 +1,244 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          AIRCRAFTTRACKER.CPP
+ *
+ *  @authors       ZivDero
+ *
+ *  @brief         AircraftTrackerClass reimplementation from YR.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include "aircrafttracker.h"
+
+#include <algorithm>
+
+#include "foot.h"
+#include "swizzle.h"
+#include "cell.h"
+#include "extension.h"
+#include "footext.h"
+#include "mouse.h"
+#include "vinifera_saveload.h"
+
+
+/**
+ *  Copies the tracking region to the working set.
+ *
+ *  @author: ZivDero
+ */
+void AircraftTrackerClass::Copy_Region(int region)
+{
+    int count = Regions[region].Count();
+    for (int i = 0; i < count; i++) {
+        FootClass* foot = Regions[region][i];
+        WorkingSet.Add(foot);
+    }
+}
+
+
+/**
+ *  Fetches a region relative to the given one.
+ *
+ *  @author: ZivDero
+ */
+int AircraftTrackerClass::Adjacent_Region(int region, int xoff, int yoff)
+{
+    int regx = region % 20;
+    int regy = region / 20;
+
+    if (xoff + regx >= 0 && xoff + regx > (20 - 1)) {
+        regx = (20 - 1);
+    }
+    else {
+        regx = xoff + regx < 0 ? 0 : xoff + regx;
+    }
+
+    if (yoff + regy >= 0 && yoff + regy > (20 - 1)) {
+        regy = (20 - 1);
+    }
+    else {
+        regy = yoff + regy < 0 ? 0 : yoff + regy;
+    }
+
+    return(regx + regy * 20);
+}
+
+
+/**
+ *  Gets the region that contains this cell.
+ *
+ *  @author: ZivDero
+ */
+int AircraftTrackerClass::Get_Region(Cell cell)
+{
+    int x = std::max(0, static_cast<int>(cell.X));
+    int y = std::max(0, static_cast<int>(cell.Y));
+
+    int regx = std::min(19, x / (Map.MapCellWidth / 20));
+    int regy = std::min(19, y / (Map.MapCellHeight / 20));
+
+    return regx + regy * 20;
+}
+
+
+/**
+ *  Fetches the targets around this cell in a given range.
+ *
+ *  @author: ZivDero
+ */
+void AircraftTrackerClass::Fetch_Targets(CellClass* cellptr, int range)
+{
+    range = std::max(range, 1);
+    int region_range = (range + 19) / 20;
+
+    bool copied_regions[400] = {};
+
+    Cell cell = Coord_Cell(cellptr->Center_Coord());
+    int center_region = Get_Region(cell);
+
+    for (int x = -region_range; x <= region_range; x++) {
+        for (int y = -region_range; y <= region_range; y++) {
+            int adjacent_region = Adjacent_Region(center_region, x, y);
+            if (!copied_regions[adjacent_region]) {
+                Copy_Region(adjacent_region);
+                copied_regions[adjacent_region] = true;
+            }
+        }
+    }
+}
+
+
+/**
+ *  Adds the object to the tracker.
+ *
+ *  @author: ZivDero
+ */
+void AircraftTrackerClass::Track(FootClass* target)
+{
+    Cell cell = target->Get_Cell();
+    const auto target_ext = Extension::Fetch<FootClassExtension>(target);
+    target_ext->Set_Last_Flight_Cell(cell);
+    Regions[Get_Region(cell)].Add(target);
+}
+
+
+/**
+ *  Removes the object from the tracker.
+ *
+ *  @author: ZivDero
+ */
+void AircraftTrackerClass::Untrack(FootClass* target)
+{
+    const auto target_ext = Extension::Fetch<FootClassExtension>(target);
+    Cell cell = target_ext->Get_Last_Flight_Cell();
+    target_ext->Set_Last_Flight_Cell(CELL_NONE);
+    Regions[Get_Region(cell)].Delete(target);
+}
+
+
+/**
+ *  Loads the tracker from the stream.
+ *
+ *  @author: ZivDero
+ */
+HRESULT STDMETHODCALLTYPE AircraftTrackerClass::Load(IStream* stream)
+{
+    for (auto& Region : Regions) {
+        HRESULT result = Load_Primitive_Vector(stream, Region, "Regions");
+        if (FAILED(result)) {
+            return result;
+        }
+        VINIFERA_SWIZZLE_REQUEST_POINTER_REMAP_LIST(Regions[i], "Regions");
+    }
+
+    return S_OK;
+}
+
+
+/**
+ *  Gets the next target from the working set.
+ *
+ *  @author: ZivDero
+ */
+FootClass* AircraftTrackerClass::Get_Target(void)
+{
+    if (WorkingSet.Count() == 0) {
+        return nullptr;
+    }
+
+    FootClass* target = WorkingSet[0];
+    WorkingSet.Delete(target);
+    return target;
+}
+
+
+/**
+ *  Clears the tracker.
+ *
+ *  @author: ZivDero
+ */
+void AircraftTrackerClass::Clear(void)
+{
+    for (int i = 0; i < 400; i++) {
+        int old = Regions[i].Length();
+        Regions[i].Clear();
+        Regions[i].Resize(old, nullptr);
+    }
+    int old = WorkingSet.Length();
+    WorkingSet.Clear();
+    WorkingSet.Resize(old, nullptr);
+}
+
+
+/**
+ *  Saves the tracker to the stream.
+ *
+ *  @author: ZivDero
+ */
+HRESULT STDMETHODCALLTYPE AircraftTrackerClass::Save(IStream* stream)
+{
+    for (auto& Region : Regions) {
+        HRESULT result = Save_Primitive_Vector(stream, Region, "Regions");
+        if (FAILED(result)) {
+            return result;
+        }
+    }
+
+    return S_OK;
+}
+
+
+/**
+ *  Updates an object's position in the tracker.
+ *
+ *  @author: ZivDero
+ */
+void AircraftTrackerClass::Update_Position(FootClass* target, Cell oldcell, Cell newcell)
+{
+    const auto target_ext = Extension::Fetch<FootClassExtension>(target);
+    target_ext->Set_Last_Flight_Cell(newcell);
+    const int oldregion = Get_Region(oldcell);
+    const int newregion = Get_Region(newcell);
+    if (oldregion != newregion) {
+        Regions[oldregion].Delete(target);
+        Regions[newregion].Add(target);
+    }
+}

--- a/src/new/aircrafttracker/aircrafttracker.h
+++ b/src/new/aircrafttracker/aircrafttracker.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          FOOTEXT.H
+ *  @file          AIRCRAFTTRACKER.H
  *
- *  @author        CCHyper
+ *  @authors       ZivDero
  *
- *  @brief         Extended FootClass class.
+ *  @brief         AircraftTrackerClass reimplementation from YR.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,36 +27,41 @@
  ******************************************************************************/
 #pragma once
 
-#include "technoext.h"
-#include "foot.h"
+#include "vector.h"
+#include <unknwn.h>
+#include "tibsun_defines.h"
+
+class AbstractClass;
+class FootClass;
+class CellClass;
 
 
-class FootClassExtension : public TechnoClassExtension
-{
-    public:
-        /**
-         *  IPersistStream
-         */
-        IFACEMETHOD(Load)(IStream *pStm);
-        IFACEMETHOD(Save)(IStream *pStm, BOOL fClearDirty);
+class AircraftTrackerClass {
+public:
+    AircraftTrackerClass() { }
+    ~AircraftTrackerClass() { };
 
-    public:
-        FootClassExtension(const FootClass *this_ptr);
-        FootClassExtension(const NoInitClass &noinit);
-        virtual ~FootClassExtension();
+    FootClass* Get_Target();
+    void Fetch_Targets(CellClass* cellptr, int range);
 
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
+    void Track(FootClass* target);
+    void Untrack(FootClass* target);
+    void Update_Position(FootClass* target, Cell oldcell, Cell newcell);
 
-        virtual FootClass *This() const override { return reinterpret_cast<FootClass *>(TechnoClassExtension::This()); }
-        virtual const FootClass *This_Const() const override { return reinterpret_cast<const FootClass *>(TechnoClassExtension::This_Const()); }
+    void Clear();
 
-        virtual void Set_Last_Flight_Cell(Cell cell);
-        virtual Cell Get_Last_Flight_Cell();
+    HRESULT STDMETHODCALLTYPE Load(IStream* pStm);
+    HRESULT STDMETHODCALLTYPE Save(IStream* pStm);
 
-    public:
-        /**
-         *  The last known flight cell of this object, used by the AircraftTracker.
-         */
-        Cell LastFlightCell;
+    AircraftTrackerClass(const AircraftTrackerClass&) = delete;
+    AircraftTrackerClass& operator= (const AircraftTrackerClass&) = delete;
+
+private:
+    int Get_Region(Cell cell);
+    void Copy_Region(int region);
+    int Adjacent_Region(int region, int dy, int dx);
+
+public:
+    DynamicVectorClass<FootClass*> Regions[400];
+    DynamicVectorClass<FootClass*> WorkingSet;
 };

--- a/src/new/aircrafttracker/aircrafttracker_hooks.cpp
+++ b/src/new/aircrafttracker/aircrafttracker_hooks.cpp
@@ -1,0 +1,270 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          AIRCRAFTTRACKER_HOOKS.CPP
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Contains the hooks for AircraftTrackerClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include "aircrafttracker_hooks.h"
+
+#include "aircrafttracker.h"
+#include "extension.h"
+#include "flylocomotion.h"
+#include "footext.h"
+#include "hooker.h"
+#include "hooker_macros.h"
+#include "jumpjetlocomotion.h"
+#include "spawnmanager.h"
+#include "techno.h"
+#include "technotype.h"
+#include "kamikazetracker.h"
+#include "levitatelocomotion.h"
+#include "tibsun_globals.h"
+#include "veinholemonster.h"
+#include "vinifera_globals.h"
+#include "voc.h"
+
+
+void JJ_Track_Helper(JumpjetLocomotionClass* loco)
+{
+    FootClassExtension* extension;
+    Cell last_cell;
+
+    extension = Extension::Fetch<FootClassExtension>(loco->LinkedTo);
+    last_cell = extension->Get_Last_Flight_Cell();
+
+    if (last_cell == CELL_NONE) {
+        AircraftTracker->Track(loco->LinkedTo);
+    }
+}
+
+
+DECLARE_PATCH(_JumpjetLocomotionClass_State0_AircraftTrackerPatch)
+{
+    GET_REGISTER_STATIC(JumpjetLocomotionClass*, loco, edi);
+    static FootClassExtension* extension;
+    static Cell last_cell;
+
+    JJ_Track_Helper(loco);
+
+    // Stolen instruction
+    loco->CurrentState = JumpjetLocomotionClass::ASCENDING;
+
+    JMP(0x004F977E);
+}
+
+
+void JJ_Update_Position_Helper(JumpjetLocomotionClass* loco)
+{
+    FootClassExtension* linked_ext;
+    Cell oldcell, newcell;
+
+    linked_ext = Extension::Fetch<FootClassExtension>(loco->LinkedTo);
+
+    oldcell = linked_ext->Get_Last_Flight_Cell();
+    newcell = loco->LinkedTo->Get_Cell();
+
+    if (newcell != oldcell) {
+        AircraftTracker->Update_Position(loco->LinkedTo, oldcell, newcell);
+    }
+}
+
+
+DECLARE_PATCH(_JumpjetLocomotionClass_State1_AircraftTrackerPatch)
+{
+    GET_REGISTER_STATIC(JumpjetLocomotionClass*, loco, esi);
+    
+    JJ_Update_Position_Helper(loco);
+
+    // Stolen instructions (function epilogue)
+    _asm pop edi
+    _asm pop esi
+    _asm add esp, 0x14
+
+    JMP(0x004F9EBF);
+}
+
+
+DECLARE_PATCH(_JumpjetLocomotionClass_State3_AircraftTrackerPatch)
+{
+    GET_REGISTER_STATIC(JumpjetLocomotionClass*, loco, ecx);
+
+    _asm pushad
+
+    JJ_Update_Position_Helper(loco);
+
+    _asm popad
+
+    // Stolen instructions
+    _asm mov esi, ecx
+    _asm lea edx, [esp+0x10]
+
+    JMP(0x004FA071);
+}
+
+
+DECLARE_PATCH(_JumpjetLocomotionClass_State4_AircraftTrackerPatch)
+{
+    GET_REGISTER_STATIC(JumpjetLocomotionClass*, loco, esi);
+
+    AircraftTracker->Untrack(loco->LinkedTo);
+
+    // Stolen instruction
+    loco->CurrentState = JumpjetLocomotionClass::GROUNDED;
+
+    JMP(0x004FA42E);
+}
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ *
+ *  @note: This must not contain a constructor or destructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+static class FlyLocomotionClassExt final : public FlyLocomotionClass
+{
+public:
+    void _Take_Off();
+};
+
+
+void FlyLocomotionClassExt::_Take_Off()
+{
+    if (LinkedTo->EMPFramesRemaining <= 0) {
+        IsLanding = false;
+        IsTakingOff = true;
+        FlightLevel = LinkedTo->Techno_Type_Class()->Flight_Level();
+
+        const auto extension = Extension::Fetch<FootClassExtension>(LinkedTo);
+        if (extension->Get_Last_Flight_Cell() == CELL_NONE) {
+            AircraftTracker->Track(LinkedTo);
+        }
+
+        if (LinkedTo->Get_Height() == 0) {
+            LinkedTo->PrimaryFacing.Set(LinkedTo->SecondaryFacing.Desired());
+        }
+
+        Sound_Effect(LinkedTo->Techno_Type_Class()->AuxSound1, LinkedTo->Get_Coord());
+    }
+}
+
+
+DECLARE_PATCH(_FlyLocomotionClass_Movement_AI_AircraftTracker_Patch1)
+{
+    GET_REGISTER_STATIC(FlyLocomotionClass*, loco, edi);
+    static FootClassExtension* linked_ext;
+    static Cell oldcell, newcell;
+
+    linked_ext = Extension::Fetch<FootClassExtension>(loco->LinkedTo);
+
+    oldcell = linked_ext->Get_Last_Flight_Cell();
+    newcell = loco->LinkedTo->Get_Cell();
+
+    if (newcell != oldcell && loco->Is_Moving_Now()) {
+        AircraftTracker->Update_Position(loco->LinkedTo, oldcell, newcell);
+    }
+
+    // Stolen instructions
+    _asm mov ecx, [edi+4]
+    _asm lea ebp, [edi+4]
+
+    JMP(0x00499F57);
+}
+
+
+DECLARE_PATCH(_FlyLocomotionClass_Movement_AI_AircraftTracker_Patch2)
+{
+    GET_REGISTER_STATIC(FootClass*, linked_to, ecx);
+
+    AircraftTracker->Untrack(linked_to);
+
+    // Stolen instruction
+    linked_to->Set_Height(0);
+
+    JMP(0x0049A087);
+}
+
+
+DECLARE_PATCH(_FlyLocomotionClass_Process_Landing_AircraftTracker_Patch)
+{
+    GET_REGISTER_STATIC(FlyLocomotionClass*, loco, esi);
+
+    AircraftTracker->Untrack(loco->LinkedTo);
+
+    // Stolen instructions
+    loco->CurrentSpeed = 0;
+    loco->TargetSpeed = 0;
+
+    _asm mov bp, 0
+    JMP(0x0049B938);
+}
+
+
+void Levitate_Update_Position_Helper(LevitateLocomotionClass* loco)
+{
+    FootClassExtension* linked_ext;
+    Cell oldcell, newcell;
+
+    linked_ext = Extension::Fetch<FootClassExtension>(loco->LinkedTo);
+
+    oldcell = linked_ext->Get_Last_Flight_Cell();
+    newcell = loco->LinkedTo->Get_Cell();
+
+    if (newcell != oldcell) {
+        AircraftTracker->Update_Position(loco->LinkedTo, oldcell, newcell);
+    }
+}
+
+
+DECLARE_PATCH(_LevitateLocomotionClass_State_AI_AircraftTracker_Patch)
+{
+    GET_REGISTER_STATIC(ILocomotion*, loco, ebp);
+    static int result;
+
+    Levitate_Update_Position_Helper(static_cast<LevitateLocomotionClass*>(loco));
+
+    result = loco->Is_Moving();
+
+    _asm mov eax, result
+    JMP_REG(edi, 0x00500C01);
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void AircraftTracker_Hooks()
+{
+    Patch_Jump(0x004F9777, &_JumpjetLocomotionClass_State0_AircraftTrackerPatch);
+    Patch_Jump(0x004F9EBA, &_JumpjetLocomotionClass_State1_AircraftTrackerPatch);
+    Patch_Jump(0x004FA06B, &_JumpjetLocomotionClass_State3_AircraftTrackerPatch);
+    Patch_Jump(0x004FA427, &_JumpjetLocomotionClass_State4_AircraftTrackerPatch);
+    Patch_Jump(0x0049CB00, &FlyLocomotionClassExt::_Take_Off);
+    Patch_Jump(0x00499F51, &_FlyLocomotionClass_Movement_AI_AircraftTracker_Patch1);
+    Patch_Jump(0x0049A07D, &_FlyLocomotionClass_Movement_AI_AircraftTracker_Patch2);
+    Patch_Jump(0x0049B92C, &_FlyLocomotionClass_Process_Landing_AircraftTracker_Patch);
+    Patch_Jump(0x00500BFA, &_LevitateLocomotionClass_State_AI_AircraftTracker_Patch);
+}

--- a/src/new/aircrafttracker/aircrafttracker_hooks.h
+++ b/src/new/aircrafttracker/aircrafttracker_hooks.h
@@ -4,11 +4,11 @@
  *
  *  @project       Vinifera
  *
- *  @file          FOOTEXT.H
+ *  @file          AIRCRAFTTRACKER_HOOKS.H
  *
- *  @author        CCHyper
+ *  @author        ZivDero
  *
- *  @brief         Extended FootClass class.
+ *  @brief         Contains the hooks for AircraftTrackerClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License
@@ -27,36 +27,4 @@
  ******************************************************************************/
 #pragma once
 
-#include "technoext.h"
-#include "foot.h"
-
-
-class FootClassExtension : public TechnoClassExtension
-{
-    public:
-        /**
-         *  IPersistStream
-         */
-        IFACEMETHOD(Load)(IStream *pStm);
-        IFACEMETHOD(Save)(IStream *pStm, BOOL fClearDirty);
-
-    public:
-        FootClassExtension(const FootClass *this_ptr);
-        FootClassExtension(const NoInitClass &noinit);
-        virtual ~FootClassExtension();
-
-        virtual void Detach(TARGET target, bool all = true) override;
-        virtual void Compute_CRC(WWCRCEngine &crc) const override;
-
-        virtual FootClass *This() const override { return reinterpret_cast<FootClass *>(TechnoClassExtension::This()); }
-        virtual const FootClass *This_Const() const override { return reinterpret_cast<const FootClass *>(TechnoClassExtension::This_Const()); }
-
-        virtual void Set_Last_Flight_Cell(Cell cell);
-        virtual Cell Get_Last_Flight_Cell();
-
-    public:
-        /**
-         *  The last known flight cell of this object, used by the AircraftTracker.
-         */
-        Cell LastFlightCell;
-};
+void AircraftTracker_Hooks();

--- a/src/new/locomotion/testlocomotion.cpp
+++ b/src/new/locomotion/testlocomotion.cpp
@@ -238,7 +238,7 @@ IFACEMETHODIMP_(Coordinate) TestLocomotionClass::Head_To_Coord()
     /**
      *  Return the current coordinate.
      */
-    return Linked_To()->Get_Coord();
+    return LinkedTo->Get_Coord();
 }
 
 
@@ -252,7 +252,7 @@ IFACEMETHODIMP_(MoveType) TestLocomotionClass::Can_Enter_Cell(Cell cell)
     /**
      *  Query the linked object to determine if the cell can be entered.
      */
-    return Linked_To()->Can_Enter_Cell(&Map[cell]);
+    return LinkedTo->Can_Enter_Cell(&Map[cell]);
 }
 
 
@@ -366,9 +366,9 @@ IFACEMETHODIMP_(bool) TestLocomotionClass::Process()
         /**
          *  Pickup the object the game world before we set the new coord.
          */
-        Linked_To()->Mark(MARK_UP);
+        LinkedTo->Mark(MARK_UP);
         if (Can_Enter_Cell(Coord_Cell(coord)) == MOVE_OK) {
-            Linked_To()->Set_Coord(coord);
+            LinkedTo->Set_Coord(coord);
 
             /**
              *  Increase the angle, wrapping if full circle is complete.
@@ -379,7 +379,7 @@ IFACEMETHODIMP_(bool) TestLocomotionClass::Process()
                 Angle = 0;
             }
         }
-        Linked_To()->Mark(MARK_DOWN);
+        LinkedTo->Mark(MARK_DOWN);
     }
 
     return Is_Moving();
@@ -429,7 +429,7 @@ IFACEMETHODIMP_(void) TestLocomotionClass::Stop_Moving()
  */
 IFACEMETHODIMP_(void) TestLocomotionClass::Do_Turn(DirStruct coord)
 {
-    Linked_To()->PrimaryFacing.Set(coord);
+    LinkedTo->PrimaryFacing.Set(coord);
 }
 
 
@@ -443,7 +443,7 @@ IFACEMETHODIMP_(void) TestLocomotionClass::Unlimbo()
     /**
      *  Set the objects ramp for redraw.
      */
-    Force_New_Slope(Linked_To()->Get_Cell_Ptr()->Ramp);
+    Force_New_Slope(LinkedTo->Get_Cell_Ptr()->Ramp);
 }
 
 
@@ -572,7 +572,7 @@ IFACEMETHODIMP_(void) TestLocomotionClass::Force_New_Slope(int ramp)
  */
 IFACEMETHODIMP_(bool) TestLocomotionClass::Is_Moving_Now()
 {
-    if (Linked_To()->PrimaryFacing.Is_Rotating()) {
+    if (LinkedTo->PrimaryFacing.Is_Rotating()) {
         return true;
     }
 
@@ -591,7 +591,7 @@ IFACEMETHODIMP_(bool) TestLocomotionClass::Is_Moving_Now()
  */
 IFACEMETHODIMP_(int) TestLocomotionClass::Apparent_Speed()
 {
-    return Linked_To()->Current_Speed();
+    return LinkedTo->Current_Speed();
 }
 
 
@@ -658,9 +658,9 @@ IFACEMETHODIMP_(void) TestLocomotionClass::Mark_All_Occupation_Bits(int mark)
 {
     Coordinate headto = Head_To_Coord();
     if (mark != 0) {
-        Linked_To()->Set_Occupy_Bit(headto);
+        LinkedTo->Set_Occupy_Bit(headto);
     } else {
-        Linked_To()->Clear_Occupy_Bit(headto);
+        LinkedTo->Clear_Occupy_Bit(headto);
     }
 }
 

--- a/src/new/spawnmanager/spawnmanager_hooks.cpp
+++ b/src/new/spawnmanager/spawnmanager_hooks.cpp
@@ -6,7 +6,7 @@
  *
  *  @file          SPAWNMANAGER_HOOKS.CPP
  *
- *  @author        CCHyper
+ *  @author        ZivDero
  *
  *  @brief         Contains the hooks for SpawnManagerClass
  *                 and KamikazeTrackerClass.

--- a/src/new/spawnmanager/spawnmanager_hooks.h
+++ b/src/new/spawnmanager/spawnmanager_hooks.h
@@ -6,9 +6,10 @@
  *
  *  @file          SPAWNMANAGER_HOOKS.H
  *
- *  @author        CCHyper
+ *  @author        ZivDero
  *
- *  @brief         Contains the hooks for SpawnManagerClass.
+ *  @brief         Contains the hooks for SpawnManagerClass
+ *                 and KamikazeTrackerClass.
  *
  *  @license       Vinifera is free software: you can redistribute it and/or
  *                 modify it under the terms of the GNU General Public License

--- a/src/vinifera/vinifera_functions.cpp
+++ b/src/vinifera/vinifera_functions.cpp
@@ -58,6 +58,7 @@
 #include "asserthandler.h"
 #include <string>
 
+#include "aircrafttracker.h"
 #include "rocketlocomotion.h"
 #include "setup_hooks.h"
 
@@ -637,6 +638,7 @@ bool Vinifera_Startup()
 #endif
 
     KamikazeTracker = new KamikazeTrackerClass;
+    AircraftTracker = new AircraftTrackerClass;
 
     return true;
 }
@@ -683,6 +685,9 @@ bool Vinifera_Shutdown()
 
     delete KamikazeTracker;
     KamikazeTracker = nullptr;
+
+    delete AircraftTracker;
+    AircraftTracker = nullptr;
 
     DEV_DEBUG_INFO("Shutdown - New Count: %d, Delete Count: %d\n", Vinifera_New_Count, Vinifera_Delete_Count);
 

--- a/src/vinifera/vinifera_globals.cpp
+++ b/src/vinifera/vinifera_globals.cpp
@@ -29,6 +29,8 @@
 
 #include "vinifera_globals.h"
 
+#include "aircrafttracker.h"
+
 
 bool Vinifera_DeveloperMode = false;
 
@@ -84,6 +86,7 @@ DynamicVectorClass<MouseTypeClass *> MouseTypes;
 DynamicVectorClass<ActionTypeClass *> ActionTypes;
 
 KamikazeTrackerClass* KamikazeTracker = nullptr;
+AircraftTrackerClass* AircraftTracker = nullptr;
 
 MFCC *GenericMix = nullptr;
 MFCC *IsoGenericMix = nullptr;

--- a/src/vinifera/vinifera_globals.h
+++ b/src/vinifera/vinifera_globals.h
@@ -33,6 +33,7 @@
 
 
 class KamikazeTrackerClass;
+class AircraftTrackerClass;
 class SpawnManagerClass;
 class EBoltClass;
 class TheaterTypeClass;
@@ -102,6 +103,7 @@ extern MFCC *GenericMix;
 extern MFCC *IsoGenericMix;
 
 extern KamikazeTrackerClass *KamikazeTracker;
+extern AircraftTrackerClass *AircraftTracker;
 
 
 /**

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -127,6 +127,7 @@
 #include <atlbase.h>
 #include <atlcom.h>
 
+#include "aircrafttracker.h"
 #include "animtypeext.h"
 #include "hooker.h"
 #include "language.h"
@@ -379,6 +380,7 @@ bool Vinifera_Put_All(IStream *pStm, bool save_net)
      *  Save new global class instances.
      */
     KamikazeTracker->Save(pStm, false);
+    AircraftTracker->Save(pStm);
 
     /**
      *  Save skirmish values.
@@ -623,6 +625,9 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
      */
     KamikazeTracker->Clear();
     KamikazeTracker->Load(pStm);
+
+    AircraftTracker->Clear();
+    AircraftTracker->Load(pStm);
 
     /**
      *  Load skirmish values.


### PR DESCRIPTION
- This PR ports the Cell Spread mechanic from Red Alert 2, allowing for more destructive and flexible weapons.

In `RULES.INI`:
```ini
[SOMEWARHEAD]      ; WarheadType
CellSpread=-1      ; float, the maximum range, in cells, at which a weapon using this warhead will damage objects.
PercentAtMax=100%  ; % or float, the fraction of the damage that is applied at the weapon's max range.
```

### Smudges and Fires

- This PR also allows weapons to spawn scorches, craters and animations on cells affected by explosions.

```{note}
When using `Spread`, only the cell directly hit by the explosion will be considered. When using `CellSpread`, all affected cells are taken into account.
```

In `RULES.INI`:
```ini
[SOMEWARHEAD]     ; WarheadType
ScorchChance=0    ; % or float, the chance that an affected cell will contain a new scorch after the explosion.
CraterChance=0    ; % or float, the chance that an affected cell will contain a new crater after the explosion.
CellAnimChance=0  ; % or float, the chance that an affected cell will contain a new animation after the explosion.
CellAnim=         ; list of AnimTypes, the list of animation to pick from when a random animation is spawned. Defaults to `[AudioVisual]->OnFire`.
```

- This PR also allows the animation to spawn an explosion on its biggest frame (also controlled by `MiddleFrame=`) using its `Warhead=`.

In `ART.INI`:
```ini
[AnimType]         ; AnimType
ExplosionDamage=0  ; integer, the damage dealt by this animation's explosion.
```

- This PR also allows specified a broad modifier to damage against infantry, vehicles, aircraft, buildings and terrain objects.

In `RULES.INI`:
```ini
[SOMEWARHEAD]          ; WarheadType
InfantryModifier=100%  ; % or float, modifier applied to damage dealt to infantry by this warhead.
VehicleModifier=100%   ; % or float, modifier applied to damage dealt to vehicles by this warhead.
AircraftModifier=100%  ; % or float, modifier applied to damage dealt to aircraft by this warhead.
BuildingModifier=100%  ; % or float, modifier applied to damage dealt to buildings by this warhead.
TerrainModifier=100%   ; % or float, modifier applied to damage dealt to terrain objects by this warhead.
```

Resolves #1150, resolves #92, resolves #979