### PR TITLE
Use Special anims for Nukes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -226,3 +226,4 @@ This page lists all the individual contributions to the project by their author.
   - Animations now use their `Warhead` to deal damage, if one is specified.
   - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building.
   - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now have the building display Special animations.
+  - Allow customizing "Missile Launched" voice per super weapon.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -225,3 +225,4 @@ This page lists all the individual contributions to the project by their author.
   - Implement `Volumetric`, `SnapToCellCenter`.
   - Animations now use their `Warhead` to deal damage, if one is specified.
   - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building.
+  - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now have the building display Special animations.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -67,5 +67,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix the map glitching around when scrolling if the map is not large enough to fill the entire screen.
 - Fix a bug where a visceroid was spawned when poison gas destroyed a non-crewed vehicle, building, or terrain object.
 - Fix a bug where it was impossible to tell infantry to enter cloaked allied transports.
-- Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building
-- Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now make the silo play `AnimAux1` and `AnimAux2` for exactly one loop at any rate.
+- Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -302,6 +302,8 @@ HunterSeeker=  ; UnitType, the unit that is this side's Hunter-Seeker.
 
 ## Super Weapons
 
+### Out of Range Cursor
+
 - Vinifera allows customizing the mouse cursor used for ranged super weapons (currently, the EMPulse Cannon).
 
 In `RULES.INI`:
@@ -309,6 +311,17 @@ In `RULES.INI`:
 [SOMESUPERWEAPON]              ; SuperWeaponType
 ActionOutOfRange=EMPulseRange  ; ActionType, the action used by this super weapon when it's out of range.
 ```
+
+### Missile Launched Voice
+
+- Vinifera allows customizing the voiceline played when a Super Weapon with `Type=MultiMissile` or `Type=ChemMissile` is launched.
+
+In `RULES.INI`:
+```ini
+[SOMESUPERWEAPON]              ; SuperWeaponType
+MissileLaunchedVoice=00-I150   ; VoxType, the voice to play when this missile is launched.
+```
+
 
 ## Mouse Cursors and Actions
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -136,6 +136,25 @@ EngineerChance=0  ; integer (%), what is the chance that an engineer will exit t
 It is not recommended to set `EngineerChance=100`, as this may put the game into an infinite loop when it insists an infantry other than an engineer exits the building.
 ```
 
+### Special Animations for `MultiMissile` and `ChemMissile` Super Weapons
+
+- Super weapons with `Type=MultiMissile` and `Type=ChemMissile` now make the silo display animations when fired.
+
+- `SpecialAnim` is played before the missile is launched, and is typically the silo opening animation.
+- `SpecialAnimTwo` is played in between `SpecialAnim` and `SpecialAnimTwo`, after the missile has been launched, and is typically a looping animation of the silo being open.
+- `SpecialAnimThree` is played after `SpecialAnimTwo` and is typically the silo closing animation.
+
+In `ART.INI`:
+```ini
+[SOMEBUILDING]            ; BuildingType
+SpecialAnim=              ; AnimType, the animation to play when the silo is opening.
+SpecialAnimDamaged=       ; AnimType, the animation to play when the silo is opening, and the silo is damaged.
+SpecialAnimTwo=           ; AnimType, the animation to play when the silo is open.
+SpecialAnimTwoDamaged=    ; AnimType, the animation to play when the silo is open, and the silo is damaged.
+SpecialAnimThree=         ; AnimType, the animation to play when the silo is closing.
+SpecialAnimThreeDamaged=  ; AnimType, the animation to play when the silo is closing, and the silo is damaged.
+```
+
 ## Harvesters
 
 - In the original game, harvesters always prefer free refineries over occupied ones, even if the free refinery was much farther away than the occupied refinery. Vinifera fixes this so that harvesters now prefer queueing to occupied refineries if they are much closer than free refineries. The distance for this preference is customizable.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -244,7 +244,7 @@ Vanilla fixes:
 - Fix a bug where a visceroid was spawned when poison gas destroyed a non-crewed vehicle, building, or terrain object (by Rampastring)
 - Fix a bug where it was impossible to tell infantry to enter cloaked allied transports (by Rampastring)
 - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building (by ZivDero)
-- Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now make the silo play `AnimAux1` and `AnimAux2` for exactly one loop at any rate (by ZivDero)
+- Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now have the building display Special animations (by ZivDero)
 
 </details>
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -245,6 +245,7 @@ Vanilla fixes:
 - Fix a bug where it was impossible to tell infantry to enter cloaked allied transports (by Rampastring)
 - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building (by ZivDero)
 - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now have the building display Special animations (by ZivDero)
+- Allow customizing "Missile Launched" voice per super weapon (by ZivDero)
 
 </details>
 

--- a/src/extensions/anim/animext.h
+++ b/src/extensions/anim/animext.h
@@ -29,6 +29,7 @@
 
 #include "objectext.h"
 #include "anim.h"
+#include "animtype.h"
 #include "ttimer.h"
 #include "ftimer.h"
 #include "typelist.h"
@@ -69,6 +70,60 @@ AnimClassExtension final : public ObjectClassExtension
         bool Start();
         bool Middle();
         bool End();
+
+        /**
+         *  This function replicates part of AnimClass::AI and returns whether the next time
+         *  AnimClass::AI is executed, the animation will be deleted.
+         *
+         *  @note This function doesn't take into account the possibility of the animation destroying
+         *  the object it's attached to and thus deleting itself that way.
+         *
+         *  @author: ZivDero
+         */
+        static bool Is_About_To_End(AnimClass* this_ptr)
+        {
+            /**
+             *  Check if the anim is about to change its frame.
+             */
+            if (!this_ptr->IsDisabled && this_ptr->About_To_Change())
+            {
+                const AnimTypeClass * const animtype = this_ptr->Class;
+
+                int stage = this_ptr->Fetch_Stage();
+                int loops = this_ptr->Loops;
+
+                /**
+                 *  Simulate the anim changing its frame.
+                 */
+                stage += this_ptr->Fetch_Step();
+
+                /**
+                 *  If the anim is ping-ponging, it's not ensing right now.
+                 */
+                if (animtype->IsPingPong) {
+                    if ((loops <= 1 && (stage >= animtype->Stages || stage == 0)) || (loops > 1 && (stage >= animtype->LoopEnd - animtype->Start || stage == animtype->Start))) {
+                        return false;
+                    }
+                }
+
+                /**
+                 *  Check to see if the last frame has been displayed. If so, then the
+                 *  animation either ends or loops.
+                 */
+                if ((loops <= 1 && stage >= animtype->Stages) || (loops > 1 && stage >= animtype->LoopEnd - animtype->Start) || (animtype->IsReverse && stage <= animtype->Start)) {
+                    if (loops && loops != UCHAR_MAX) loops--;
+
+                    /**
+                     *  if the anim doesn't loop anymore, and has nothing to chain to, return that it's about to end.
+                     */
+                    if (loops == 0 && animtype->ChainTo == nullptr) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
 
     private:
         bool Spawn_Animations(const Coordinate &coord, const TypeList<AnimTypeClass *> &animlist, const TypeList<int> &countlist, const TypeList<int> &minlist, const TypeList<int> &maxlist, const TypeList<int>& delaylist);

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -1108,7 +1108,7 @@ int _BuildingClass_Mission_Missile_LAUNCH_DOWN(BuildingClass* this_ptr)
      */
     this_ptr->Free_Animation(BANIM_SPECIAL_ONE);
     this_ptr->Free_Animation(BANIM_SPECIAL_TWO);
-    this_ptr->Play_Animation(BANIM_SPECIAL_TWO, false, 0);
+    this_ptr->Play_Animation(BANIM_SPECIAL_THREE, false, 0);
     this_ptr->Status = DONE_LAUNCH;
     return 1;
 }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -1106,7 +1106,7 @@ int _BuildingClass_Mission_Missile_LAUNCH_DOWN(BuildingClass* this_ptr)
     /**
      *  Check if the silo open animation has finished.
      */
-    if (this_ptr->Anims[BANIM_SPECIAL_ONE] == nullptr) {
+    if (this_ptr->Anims[BANIM_SPECIAL_TWO] == nullptr) {
 
         /**
          *  If so, play the closing animation.

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -42,6 +42,8 @@
 #include "aircraft.h"
 #include "aircrafttype.h"
 #include "aircrafttypeext.h"
+#include "anim.h"
+#include "animext.h"
 #include "house.h"
 #include "housetype.h"
 #include "map.h"
@@ -1089,7 +1091,7 @@ int _BuildingClass_Mission_Missile_DOOR_OPENING(BuildingClass* this_ptr)
     /**
      *  Check if the silo opening animation has finished.
      */
-    if (this_ptr->Anims[BANIM_SPECIAL_ONE] == nullptr) {
+    if (this_ptr->Anims[BANIM_SPECIAL_ONE] == nullptr || AnimClassExtension::Is_About_To_End(this_ptr->Anims[BANIM_SPECIAL_ONE])) {
 
         /**
          *  If so, signal that we're ready to fire and play the "holding open" animation.
@@ -1106,7 +1108,7 @@ int _BuildingClass_Mission_Missile_LAUNCH_DOWN(BuildingClass* this_ptr)
     /**
      *  Check if the silo open animation has finished.
      */
-    if (this_ptr->Anims[BANIM_SPECIAL_TWO] == nullptr) {
+    if (this_ptr->Anims[BANIM_SPECIAL_TWO] == nullptr || AnimClassExtension::Is_About_To_End(this_ptr->Anims[BANIM_SPECIAL_TWO])) {
 
         /**
          *  If so, play the closing animation.

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -1061,9 +1061,7 @@ DECLARE_PATCH(_BuildingClass_Grand_Opening_Assign_FreeUnit_LastDockedBuilding_Pa
 
 
 /**
- *  Fix MISSION_MISSILE have the Nuke Silo open/close animations play exactly for one loop.
- *
- *  @author: ZivDero
+ *  An enum for BuildingClass::Mission_Missile missile states
  */
 enum {
     INITIAL,
@@ -1074,7 +1072,12 @@ enum {
 };
 
 
-
+/**
+ *  Play SpecialAnim(Two, Three) as the MultiMissile/ChemMissile
+ *  Nuke open/wait/close animations.
+ *
+ *  @author: ZivDero
+ */
 int _BuildingClass_Mission_Missile_INITIAL(BuildingClass * this_ptr)
 {
     /**

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -1104,12 +1104,17 @@ int _BuildingClass_Mission_Missile_DOOR_OPENING(BuildingClass* this_ptr)
 int _BuildingClass_Mission_Missile_LAUNCH_DOWN(BuildingClass* this_ptr)
 {
     /**
-     *  Free the opening and open animations and play the closing animation.
+     *  Check if the silo open animation has finished.
      */
-    this_ptr->Free_Animation(BANIM_SPECIAL_ONE);
-    this_ptr->Free_Animation(BANIM_SPECIAL_TWO);
-    this_ptr->Play_Animation(BANIM_SPECIAL_THREE, false, 0);
-    this_ptr->Status = DONE_LAUNCH;
+    if (this_ptr->Anims[BANIM_SPECIAL_ONE] == nullptr) {
+
+        /**
+         *  If so, play the closing animation.
+         */
+        this_ptr->Play_Animation(BANIM_SPECIAL_THREE, false, 0);
+        this_ptr->Status = DONE_LAUNCH;
+    }
+
     return 1;
 }
 

--- a/src/extensions/supertype/supertypeext.cpp
+++ b/src/extensions/supertype/supertypeext.cpp
@@ -45,7 +45,8 @@ SuperWeaponTypeClassExtension::SuperWeaponTypeClassExtension(const SuperWeaponTy
     SidebarImage(),
     IsShowTimer(false),
     CameoImageSurface(nullptr),
-    ActionOutOfRange(ACTION_EMPULSE_RANGE)
+    ActionOutOfRange(ACTION_EMPULSE_RANGE),
+    VoxMissileLaunched(VOX_MISSILE_LAUNCHED)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("SuperWeaponTypeClassExtension::SuperWeaponTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -212,6 +213,7 @@ bool SuperWeaponTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     ActionOutOfRange = ini.Get_ActionType(ini_name, "ActionOutOfRange", ActionOutOfRange);
+    VoxMissileLaunched = ini.Get_VoxType(ini_name, "MissileLaunchedVoice", VoxMissileLaunched);
 
     IsInitialized = true;
     

--- a/src/extensions/supertype/supertypeext.h
+++ b/src/extensions/supertype/supertypeext.h
@@ -86,4 +86,9 @@ SuperWeaponTypeClassExtension final : public AbstractTypeClassExtension
          *  Action type used for the cursor when the SW is out of range to fire.
          */
         ActionType ActionOutOfRange;
+
+        /**
+         *  Vox to speak when a missile SW is launched.
+         */
+        VoxType VoxMissileLaunched;
 };


### PR DESCRIPTION
### Special Animations for `MultiMissile` and `ChemMissile` Super Weapons

- Super weapons with `Type=MultiMissile` and `Type=ChemMissile` now make the silo display animations when fired.

- `SpecialAnim` is played before the missile is launched, and is typically the silo opening animation.
- `SpecialAnimTwo` is played in between `SpecialAnim` and `SpecialAnimTwo`, after the missile has been launched, and is typically a looping animation of the silo being open.
- `SpecialAnimThree` is played after `SpecialAnimTwo` and is typically the silo closing animation.

In `ART.INI`:
```ini
[SOMEBUILDING]            ; BuildingType
SpecialAnim=              ; AnimType, the animation to play when the silo is opening.
SpecialAnimDamaged=       ; AnimType, the animation to play when the silo is opening, and the silo is damaged.
SpecialAnimTwo=           ; AnimType, the animation to play when the silo is open.
SpecialAnimTwoDamaged=    ; AnimType, the animation to play when the silo is open, and the silo is damaged.
SpecialAnimThree=         ; AnimType, the animation to play when the silo is closing.
SpecialAnimThreeDamaged=  ; AnimType, the animation to play when the silo is closing, and the silo is damaged.
```