### PR TITLE
Some edits to the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ desktop.ini
 *.tmp
 *.bak
 *.idb
+
+# Docs
+docs/_build/

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -17,7 +17,7 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the game would crash when attempting to generate a random map if the `Neutral` or `Special` HouseTypes are not found.
 - Fix a bug where the game would crash when attempting to generate a random map if there are fewer than 4 HouseTypes defined.
 - Fix a limitation where the game could only choose between the first two HouseTypes for the AI players. Now, all HouseTypes with `Multiplay=yes` will be considered.
-- Fix a bug where the `Cloakable=yes` had no effect on AircraftTypes. 
+- Fix a bug where the `Cloakable=yes` had no effect on AircraftTypes.
 - Fix a bug where `CloakStop` had no effect on the cloaking behaviour.
 - Fix a bug where pre-placed crates and crates spawned by a destroyed truck will trigger a respawn when they are picked up.
 - Increase the string buffer size from 128 to 2048 characters for when reading and writing Owners from INI.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -16,8 +16,8 @@ This page describes every change in Vinifera that wasn't categorized into a prop
 
 - Harvesters are now considered when executing the "Guard" command. They have a special case when assigned with the Guard mission that tells them to find the nearest Tiberium patch and begin harvesting.
 - Harvesters now auto harvest when built from the war factory.
-- Vinifera changes the default value of `IsScoreShuffle` to true. 
-- Vinifera changes the default value of `AllowHiResModes` to true. 
+- Vinifera changes the default value of `IsScoreShuffle` to true.
+- Vinifera changes the default value of `AllowHiResModes` to true.
 
 ### Starting Unit Placement
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -160,7 +160,7 @@ SpecialAnimThreeDamaged=  ; AnimType, the animation to play when the silo is clo
 - In the original game, harvesters always prefer free refineries over occupied ones, even if the free refinery was much farther away than the occupied refinery. Vinifera fixes this so that harvesters now prefer queueing to occupied refineries if they are much closer than free refineries. The distance for this preference is customizable.
 
 In `RULES.INI`:
-```
+```ini
 [General]
 ; When looking for refineries, harvesters will prefer a distant free
 ; refinery over a closer occupied refinery if the refineries' distance
@@ -226,7 +226,7 @@ SpawnDelay=3  ; unsigned integer, the number of frames between each of the spawn
 
 In `RULES.INI`:
 ```ini
-[SOMEBULLET]
+[SOMEBULLET]  ; BulletType
 Torpedo=yes   ; boolean, is this projectile considered a torpedo?
 ```
 
@@ -335,7 +335,7 @@ Vanilla cursors are always present implicitly, but their properties **can** be o
 ```
 
 - <details>
-    <summary>Basic `MOUSE.INI`</summary>
+    <summary>Basic <code class="docutils literal notranslate"><span class="pre">MOUSE.INI</span></code></summary>
 
     ```ini
     ;============================================================================
@@ -364,7 +364,7 @@ Vanilla cursors are always present implicitly, but their properties **can** be o
     ;      HotspotX = left, center, right
     ;      HotspotY = top, middle, bottom
     ;
-    ; NOTE: 
+    ; NOTE:
     ;   A SmallFrame value of "-1" means it will use the normal pointer when
     ;   the mouse is over the radar panel.
 
@@ -449,8 +449,8 @@ Vanilla actions are always present implicitly, but their properties **can** be o
 ```
 
 - <details>
-    <summary>Basic `ACTION.INI`</summary>
-    
+    <summary>Basic <code class="docutils literal notranslate"><span class="pre">ACTION.INI</span></code></summary>
+
     ```ini
     ;============================================================================
     ; ACTION.INI
@@ -730,7 +730,7 @@ CrewCount=1   ; integer, how many crew will exit this unit.
 This tag does not apply to buildings.
 ```
 
-### Alternative Water Image 
+### Alternative Water Image
 
 - `WaterAlt` can now be used to control whether a voxel unit uses a different model when in water, similar to the APC in vanilla.
 
@@ -946,7 +946,7 @@ DontScore=no  ; boolean, should this Techno not count towards promotion and mult
 
 In `RULES.INI`:
 ```ini
-[SOMETECHNO]
+[SOMETECHNO]      ; TechnoType
 BuildTimeCost=300 ; integer, specifies the object's build time.
                   ; for example, setting this to 300 makes the object build as fast as a 300-cost object, regardless of its actual cost.
 ```
@@ -963,7 +963,7 @@ With `TargetZoneScan=Any`, the AI considers all targets valid, regardless of zon
 
 In `RULES.INI`:
 ```ini
-[SOMETECHNO]
+[SOMETECHNO]           ; TechnoType
 TargetZoneScan=InRange ; InRange, Any, or Same. Same - matches original game behaviour and is the default. InRange - considers targets in other movement zones that are within weapon range. Any - ignore zone checks altogether.
 ```
 
@@ -1001,7 +1001,7 @@ LightBlueTint=1       ; float, the blue tint of this terrain objects light.
 The random map generator does not currently support new theater types.
 ```
 - <details>
-    <summary>Basic `THEATERS.INI`</summary>
+    <summary>Basic <code class="docutils literal notranslate"><span class="pre"></span>THEATERS.INI</code></summary>
 
     ```ini
     ;============================================================================
@@ -1078,7 +1078,7 @@ The random map generator does not currently support new theater types.
 
 - <details>
     <summary>Sample new theater</summary>
-    
+
     ```ini
     [TheaterTypes]
     3=DESERT
@@ -1110,7 +1110,7 @@ The random map generator does not currently support new theater types.
 In `THEME.INI`:
 ```ini
 [SOMETHEME]      ; ThemeType
-RequiredAddon=0  ; AddonType, the addon required to be active for this theme to be available. Currently, only 0 (none) and 1 (Firestorm) are supported. 
+RequiredAddon=0  ; AddonType, the addon required to be active for this theme to be available. Currently, only 0 (none) and 1 (Firestorm) are supported.
 ```
 
 ## Tiberiums
@@ -1179,8 +1179,8 @@ WeedPipIndex=1  ; integer, the pip index used for Weeds.
 
 In `RULES.INI`:
 ```ini
-[SOMEUNIT]
-TransformsInto=OTHERUNIT
+[SOMEUNIT]                   ; UnitType
+TransformsInto=OTHERUNIT     ; UnitType
 ```
 
 - Additionally, the unit can be configured to require full charge to be able to transform, reusing the charge mechanic from the vanilla Mobile EMP Cannon. To do this, give the unit `TransformRequiresFullCharge=yes`.

--- a/docs/User-Interface.md
+++ b/docs/User-Interface.md
@@ -321,7 +321,7 @@ TargetLaserDropShadowColor=0,0,0   ; RGB color, color to draw target lasers' dro
 TargetLaserTime=15                 ; integer, time in frames the target laser should be drawn for when the unit fires.
 ```
 
-<img src="https://github.com/user-attachments/assets/d961fd81-d112-4bbc-b567-972beb011736" width="425"/> <img src="https://github.com/user-attachments/assets/a1feaa46-6232-4997-945c-10cde807ccb0" width="425"/> 
+<img src="https://github.com/user-attachments/assets/d961fd81-d112-4bbc-b567-972beb011736" width="425"/> <img src="https://github.com/user-attachments/assets/a1feaa46-6232-4997-945c-10cde807ccb0" width="425"/>
 
 - Additionally, you can also enable lines to be drawn indicating the unit's current navigation queue.
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -20,21 +20,21 @@ This page lists the history of changes across stable Vinifera releases and also 
 - Removal of ts-patches [tiberium_stuff](https://github.com/CnCNet/ts-patches/blob/master/src/tiberium_stuff.asm) and [tiberium_damage](https://github.com/CnCNet/ts-patches/blob/master/src/tiberium_damage.asm) is required for this to work properly. Please keep in mind that Power once again behaves like in vanilla in regards to chain explosions and should be set to reasonable values, while `DamageToInfantry` should be used to customize Tiberium's damage to infantry.
 
 % ### New user settings in `SUN.ini`
-% 
+%
 % - These are new user setting keys added by various features in Vinifera. Most of them can be found in either in [user inteface](User-Interface.md) or [miscellaneous](Miscellaneous.md) sections. Search functionality can be used to find them quickly if % needed.
-% 
+%
 % ```ini
-% 
+%
 % ```
-% 
+%
 % ### For Map Editor (Final Sun)
-% 
+%
 % <details>
 %   <summary>Click to show</summary>
-% 
+%
 %   In `FAData.ini`:
 %   ```ini
-% 
+%
 %   ```
 % </details>
 


### PR DESCRIPTION
Do not use markdown syntax <code>\`code style\`</code> within `<summary></summary>`, as they will not be parsed correctly. You can directly use HTML instead.

<details>
  <summary>Basic `ACTION.INI`</summary>
TEXT
 </details>
<details>
  <summary>Basic <code class="docutils literal notranslate"><span class="pre">ACTION.INI</span></code></summary>
TEXT
 </details>

> [!Note]
> The `docutils literal notranslate` is the CSS class used for `code styling` in the *sphinx_rtd_theme*.

In *sphinx_rtd_theme*, `[Section]` headings without subsequent comments are distinguished using different colors. These can be considered fixed names rather than representing specific categories. No matter what, it's best to avoid creating a chaotic effect.

The ini block in the ***Harvesters*** paragraph was not marked with a code language type, resulting in incorrect styling being applied.

If someone need to run the `sphinx-build` command locally, based on the current configuration in `conf.py`, the `_build/` directory should be excluded from Git version control.

BTW, do I need to modify the Pull Request description? The *Contributing.md* file doesn't seem to provide much guidance.
