### PR TITLE
[Minor][Doc] 

### DIFF
--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1001,7 +1001,7 @@ LightBlueTint=1       ; float, the blue tint of this terrain objects light.
 The random map generator does not currently support new theater types.
 ```
 - <details>
-    <summary>Basic <code class="docutils literal notranslate"><span class="pre"></span>THEATERS.INI</code></summary>
+    <summary>Basic <code class="docutils literal notranslate"><span class="pre">THEATERS.INI</span></code></summary>
 
     ```ini
     ;============================================================================


### PR DESCRIPTION
@ZivDero 
While implementing effects through HTML syntax is feasible, it inevitably increases maintenance difficulty, as demonstrated by this particular error. xD
However, I have studied the Dropdown mentioned by Kerbiter. Given that the Phobos project requires text localization across multiple language versions, and we previously struggled with the inability to localize `<summary>` tag strings, I promptly implemented this new approach during this week's routine documentation maintenance for Phobos. You can preview the results [here](https://phobos--1611.org.readthedocs.build/en/1611/Whats-New.html#version-tbd-develop-branch-nightly-builds).

Although Vinifera currently has no localization requirements, there's another potential advantage that might interest you: Within Dropdown elements, you can freely use Markdown syntax. The Dropdown syntax is remarkably simple - as straightforward as <code>\`\`\`{{note}}</code> and <code>\`\`\`{{tip}}</code> alert blocks. This approach significantly reduces the likelihood of minor errors like the one addressed in this Pull Request (while not completely eliminating them, it certainly lowers maintenance complexity). You just need to write it like this:

```md
:::{dropdown} Dropdown title
Dropdown content
:::
```

Additionally, beyond basic dropdown syntax, I modified some CSS settings in Phobos to accommodate light/dark theme switching, maintain visual consistency with original styling, prevent dropdown sections from blending with background elements, etc.

What do you think of the results? If you approve, I can submit a separate Pull Request for Vinifera to implement this feature, which could be completed within a day.
Committed to providing support for our friends in Vinifera. ;P