### PR TITLE
Animation improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -233,3 +233,4 @@ This page lists all the individual contributions to the project by their author.
   - Add `DamageRate` for animations.
   - Add `HideDuringSpecialAnim` for buildings.
   - Add `RoofDeployingAnim` and `UnderRoofDoorAnim` for buildings.
+  - Add `SpawnsParticleOffset`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -229,3 +229,7 @@ This page lists all the individual contributions to the project by their author.
   - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building.
   - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now have the building display Special animations.
   - Allow customizing "Missile Launched" voice per super weapon.
+  - Add `Shadow` for animations.
+  - Add `DamageRate` for animations.
+  - Add `HideDuringSpecialAnim` for buildings.
+  - Add `RoofDeployingAnim` and `UnderRoofDoorAnim` for buildings.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -90,7 +90,7 @@ Layer=<none>                ; LayerType, the map layer this animation is in when
 SpawnsParticle=<none>       ; ParticleType, the particle to spawn at the mid-point of this animation.
                             ; This accepts any entry from the [Particles] list from RULES.INI.
 NumParticles=0              ; integer, the number of particles to spawn (as defined by SpawnsParticle=).
-SpawnsParticleOffset=0,0,0  ; 3 integers, an offset to be added to the firing FLH for the every second spawn's location.
+SpawnsParticleOffset=0,0,0  ; 3 integers, an offset to be added to the spawner particles' coordinates.
 Shadow=no                   ; boolean, does this animation show a shadow?
 ```
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -101,7 +101,7 @@ Shadow=no              ; boolean, does this animation show a shadow?
 In `ART.INI`:
 ```ini
 [AnimType]    ; AnimType
-DamageRate=0  ; integer, the rate at which this animation deals damage. Defaults to `Rate`.
+DamageRate=-1 ; integer, the rate at which this animation deals damage. Defaults to `Rate`.
 ```
 
 ## Buildings

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -80,17 +80,18 @@ ExplosionDamage=0  ; integer, if positive, the animation will spawn an explosion
 
 In `ART.INI`:
 ```ini
-[SOMEANIM]             ; AnimType
-HideIfNoTiberium=no    ; boolean, should this animation be hidden if the holding cell does not contain Tiberium?
-ForceBigCraters=no     ; boolean, are the craters spawned by this animation when it ends much larger than normal?
-ZAdjust=0              ; integer, fudge to this animation's Z-axis (depth). Positive values move the animation "away from the screen"/"closer to the ground", negative values do the opposite.
-Layer=<none>           ; LayerType, the map layer this animation is in when attached to an object.
-                       ; Available Options: underground, surface, ground, air, and top.
-                       ; NOTE: This will override the value of Surface= which forces a layer of ground.
-SpawnsParticle=<none>  ; ParticleType, the particle to spawn at the mid-point of this animation.
-                       ; This accepts any entry from the [Particles] list from RULES.INI.
-NumParticles=0         ; integer, the number of particles to spawn (as defined by SpawnsParticle=).
-Shadow=no              ; boolean, does this animation show a shadow?
+[SOMEANIM]                  ; AnimType
+HideIfNoTiberium=no         ; boolean, should this animation be hidden if the holding cell does not contain Tiberium?
+ForceBigCraters=no          ; boolean, are the craters spawned by this animation when it ends much larger than normal?
+ZAdjust=0                   ; integer, fudge to this animation's Z-axis (depth). Positive values move the animation "away from the screen"/"closer to the ground", negative values do the opposite.
+Layer=<none>                ; LayerType, the map layer this animation is in when attached to an object.
+                            ; Available Options: underground, surface, ground, air, and top.
+                            ; NOTE: This will override the value of Surface= which forces a layer of ground.
+SpawnsParticle=<none>       ; ParticleType, the particle to spawn at the mid-point of this animation.
+                            ; This accepts any entry from the [Particles] list from RULES.INI.
+NumParticles=0              ; integer, the number of particles to spawn (as defined by SpawnsParticle=).
+SpawnsParticleOffset=0,0,0  ; 3 integers, an offset to be added to the firing FLH for the every second spawn's location.
+Shadow=no                   ; boolean, does this animation show a shadow?
 ```
 
 ### Damage Rate

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -57,7 +57,7 @@ If the animation moves, delayed animations that it spawns will appear where it w
 In `ART.INI`:
 ```ini
 [AnimType]     ; AnimType
-MiddleFrame=   ; integer, the frame number in which the animation system will perform various logics (e.g. spawn craters, scorch marks, fires). Defaults to auto-detect based on the largest frame of the shape file. A special value of -1 can be used to tell the animation system to use the exact middle frame of the shape file (if shape file has 30 frames, frame 15 will be used).
+MiddleFrame=   ; list of integers, the frame numbers in which the animation system will perform various logics (e.g. spawn craters, scorch marks, fires). Defaults to auto-detect based on the largest frame of the shape file. A special value of -1 can be used to tell the animation system to use the exact middle frame of the shape file (if shape file has 30 frames, frame 15 will be used).
 ```
 
 ```{note}
@@ -90,6 +90,18 @@ Layer=<none>           ; LayerType, the map layer this animation is in when atta
 SpawnsParticle=<none>  ; ParticleType, the particle to spawn at the mid-point of this animation.
                        ; This accepts any entry from the [Particles] list from RULES.INI.
 NumParticles=0         ; integer, the number of particles to spawn (as defined by SpawnsParticle=).
+Shadow=no              ; boolean, does this animation show a shadow?
+```
+
+### Damage Rate
+
+- Vinifera allows the animation to deal damage at a rate independent of main visual logic rate.
+- The calculation is the same as for `Rate=`, that is, the animation will deal damage every `900 / DamageRate` frames, rounded down.
+
+In `ART.INI`:
+```ini
+[AnimType]    ; AnimType
+DamageRate=0  ; integer, the rate at which this animation deals damage. Defaults to `Rate`.
 ```
 
 ## Buildings
@@ -153,6 +165,25 @@ SpecialAnimTwo=           ; AnimType, the animation to play when the silo is ope
 SpecialAnimTwoDamaged=    ; AnimType, the animation to play when the silo is open, and the silo is damaged.
 SpecialAnimThree=         ; AnimType, the animation to play when the silo is closing.
 SpecialAnimThreeDamaged=  ; AnimType, the animation to play when the silo is closing, and the silo is damaged.
+```
+
+- Additionally, the main building shape may be hidden when any of the special anims is playing.
+
+In `ART.INI`:
+```ini
+[SOMEBUILDING]            ; BuildingType
+HideDuringSpecialAnim=no  ; boolean, should the main shape of the building be hidden when any special anim is playing.
+```
+
+### Roof War Factory Animations
+
+- Vinifera allows war factories to display a roof opening animation when a unit using the Jump Jet locomotor is produced, similar to Red Alert 2.
+
+In `ART.INI`:
+```ini
+[SOMEBUILDING]      ; BuildingType
+RoofDeployingAnim=  ; AnimType, the animation of the open roof when a Jump Jet is exiting the factory.
+UnderRoofDoorAnim=  ; AnimType, the animation of the rest of the building when a Jump Jet is exiting the factory.
 ```
 
 ## Harvesters

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -182,6 +182,10 @@ New:
 - Implement `ExplosionDamage` for animations (by ZivDero, Rampastring)
 - Implement `InfantryModifier`, `VehicleModifier`, `AircraftModifier`, `BuildingModifier`, `TerrainModifier` (by ZivDero)
 - Implement `Volumetric`, `SnapToCellCenter` (by ZivDero)
+- Add `Shadow` for animations (by ZivDero)
+- Add `DamageRate` for animations (by ZivDero)
+- Add `HideDuringSpecialAnim` for buildings (by ZivDero)
+- Add `RoofDeployingAnim` and `UnderRoofDoorAnim` for buildings (by ZivDero)
 
 
 Vanilla fixes:

--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -280,7 +280,7 @@ DECLARE_PATCH(_AircraftClass_Mission_Unload_Transport_Detach_Sound_Patch)
          */
         technotypeext = Extension::Fetch<TechnoTypeClassExtension>(this_ptr->Techno_Type_Class());
         if (technotypeext->LeaveTransportSound != VOC_NONE) {
-            Sound_Effect(technotypeext->LeaveTransportSound, this_ptr->Coord);
+            Static_Sound(technotypeext->LeaveTransportSound, this_ptr->Coord);
         }
 
     }

--- a/src/extensions/anim/animext.cpp
+++ b/src/extensions/anim/animext.cpp
@@ -43,13 +43,16 @@
  *  @author: CCHyper
  */
 AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
-    ObjectClassExtension(this_ptr)
+    ObjectClassExtension(this_ptr),
+    DamageStage()
 {
     //if (this_ptr) EXT_DEBUG_TRACE("AnimClassExtension::AnimClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
     AnimExtensions.Add(this);
 
     if (this_ptr) {
+        const auto animtypeext = Extension::Fetch<AnimTypeClassExtension>(This()->Class);
+
         if (This()->Class->Stages == -1) {
             This()->Class->Stages = This()->Class->Get_Image_Data()->Get_Count();
             if (Extension::Fetch<AnimTypeClassExtension>(This()->Class)->IsShadow) {
@@ -60,6 +63,9 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
         if (This()->Class->LoopEnd == -1) {
             This()->Class->LoopEnd = This()->Class->Stages;
         }
+
+        int damagedelay = animtypeext->DamageDelay == -1 ? This()->Fetch_Rate() : animtypeext->DamageDelay;
+        DamageStage.Set_Rate(damagedelay);
     }
 }
 
@@ -70,7 +76,8 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
  *  @author: CCHyper
  */
 AnimClassExtension::AnimClassExtension(const NoInitClass &noinit) :
-    ObjectClassExtension(noinit)
+    ObjectClassExtension(noinit),
+    DamageStage(noinit)
 {
     //EXT_DEBUG_TRACE("AnimClassExtension::AnimClassExtension(NoInitClass) - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }

--- a/src/extensions/anim/animext.cpp
+++ b/src/extensions/anim/animext.cpp
@@ -64,7 +64,7 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
             This()->Class->LoopEnd = This()->Class->Stages;
         }
 
-        int damagedelay = animtypeext->DamageDelay == -1 ? This()->Fetch_Rate() : animtypeext->DamageDelay;
+        int damagedelay = animtypeext->DamageRate == -1 ? This()->Fetch_Rate() : animtypeext->DamageRate;
         DamageStage.Set_Rate(damagedelay);
     }
 }

--- a/src/extensions/anim/animext.cpp
+++ b/src/extensions/anim/animext.cpp
@@ -53,6 +53,11 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
     if (this_ptr) {
         const auto animtypeext = Extension::Fetch<AnimTypeClassExtension>(This()->Class);
 
+        /**
+         *  If we don't have End= and LoopEnd= set, set them now.
+         *  Vanilla does this in the AnimClass constructor, but we move it here
+         *  so that we have access to the extension.
+         */
         if (This()->Class->Stages == -1) {
             This()->Class->Stages = This()->Class->Get_Image_Data()->Get_Count();
             if (Extension::Fetch<AnimTypeClassExtension>(This()->Class)->IsShadow) {
@@ -64,6 +69,9 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
             This()->Class->LoopEnd = This()->Class->Stages;
         }
 
+        /**
+         *  Initialize the delay stage counter.
+         */
         int damagedelay = animtypeext->DamageRate == -1 ? This()->Fetch_Rate() : animtypeext->DamageRate;
         DamageStage.Set_Rate(damagedelay);
     }

--- a/src/extensions/anim/animext.cpp
+++ b/src/extensions/anim/animext.cpp
@@ -54,9 +54,9 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
         const auto animtypeext = Extension::Fetch<AnimTypeClassExtension>(This()->Class);
 
         /**
-         *  If we don't have End= and LoopEnd= set, set them now.
-         *  Vanilla does this in the AnimClass constructor, but we move it here
-         *  so that we have access to the extension.
+         *  Reimplement part of the vanilla constructor below.
+         *  Anim extensions are created earlier, so we move par of the code here
+         *  so that we have access to the extension at this point.
          */
         if (This()->Class->Stages == -1) {
             This()->Class->Stages = animtypeext->Stage_Count();
@@ -65,6 +65,21 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
         if (This()->Class->LoopEnd == -1) {
             This()->Class->LoopEnd = This()->Class->Stages;
         }
+
+        int delay = This()->Class->Delay;
+        if (This()->Class->RandomRateMin != 0 || This()->Class->RandomRateMax != 0) {
+            if (This()->Class->RandomRateMin <= This()->Class->RandomRateMax) {
+                delay = Random_Pick(This()->Class->RandomRateMin, This()->Class->RandomRateMax);
+            }
+        }
+        if (This()->Class->IsNormalized) {
+            This()->Set_Rate(Options.Normalize_Delay(delay));
+        }
+        else {
+            This()->Set_Rate(delay);
+        }
+
+        This()->Set_Stage(0);
 
         /**
          *  Initialize the delay stage counter.

--- a/src/extensions/anim/animext.cpp
+++ b/src/extensions/anim/animext.cpp
@@ -59,10 +59,7 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
          *  so that we have access to the extension.
          */
         if (This()->Class->Stages == -1) {
-            This()->Class->Stages = This()->Class->Get_Image_Data()->Get_Count();
-            if (Extension::Fetch<AnimTypeClassExtension>(This()->Class)->IsShadow) {
-                This()->Class->Stages /= 2;
-            }
+            This()->Class->Stages = animtypeext->Stage_Count();
         }
 
         if (This()->Class->LoopEnd == -1) {

--- a/src/extensions/anim/animext.cpp
+++ b/src/extensions/anim/animext.cpp
@@ -48,6 +48,19 @@ AnimClassExtension::AnimClassExtension(const AnimClass *this_ptr) :
     //if (this_ptr) EXT_DEBUG_TRACE("AnimClassExtension::AnimClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
     AnimExtensions.Add(this);
+
+    if (this_ptr) {
+        if (This()->Class->Stages == -1) {
+            This()->Class->Stages = This()->Class->Get_Image_Data()->Get_Count();
+            if (Extension::Fetch<AnimTypeClassExtension>(This()->Class)->IsShadow) {
+                This()->Class->Stages /= 2;
+            }
+        }
+
+        if (This()->Class->LoopEnd == -1) {
+            This()->Class->LoopEnd = This()->Class->Stages;
+        }
+    }
 }
 
 

--- a/src/extensions/anim/animext.h
+++ b/src/extensions/anim/animext.h
@@ -75,5 +75,8 @@ AnimClassExtension final : public ObjectClassExtension
         bool Spawn_Animations(const Coordinate &coord, const TypeList<AnimTypeClass *> &animlist, const TypeList<int> &countlist, const TypeList<int> &minlist, const TypeList<int> &maxlist, const TypeList<int>& delaylist);
 
     public:
+        /**
+         *  Separate StageClass instance for damage dealing, to separate it from visual stages.
+         */
         StageClass DamageStage;
 };

--- a/src/extensions/anim/animext.h
+++ b/src/extensions/anim/animext.h
@@ -75,4 +75,5 @@ AnimClassExtension final : public ObjectClassExtension
         bool Spawn_Animations(const Coordinate &coord, const TypeList<AnimTypeClass *> &animlist, const TypeList<int> &countlist, const TypeList<int> &minlist, const TypeList<int> &maxlist, const TypeList<int>& delaylist);
 
     public:
+        StageClass DamageStage;
 };

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -314,8 +314,7 @@ void AnimClassExt::_AI()
         */
         Mark(MARK_UP_FORCED);
 
-        if (!IsDisabled && StageClass::Graphic_Logic()) {
-            int stage = Fetch_Stage();
+        if (!IsDisabled && animext->DamageStage.Graphic_Logic()) {
 
             /*
             **	If this animation is attached to another object and it is a
@@ -343,6 +342,10 @@ void AnimClassExt::_AI()
                     }
                 }
             }
+        }
+
+        if (!IsDisabled && StageClass::Graphic_Logic()) {
+            int stage = Fetch_Stage();
 
             /*
             **	During the biggest stage (covers the most ground), perform any ground altering
@@ -430,6 +433,8 @@ void AnimClassExt::_AI()
                             Set_Rate(delay);
                         }
                         Set_Stage(Class->Start);
+                        int damagedelay = animtypeext->DamageDelay == -1 ? Fetch_Rate() : animtypeext->DamageDelay;
+                        animext->DamageStage.Set_Rate(damagedelay);
                         Start();
                     }
                     else {

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -293,10 +293,7 @@ void AnimClassExt::_AI()
         }
 
         if (Class->Stages == -1) {
-            Class->Stages = Class->Get_Image_Data()->Get_Count();
-            if (animtypeext->IsShadow) {
-                Class->Stages /= 2;
-            }
+            Class->Stages = animtypeext->Stage_Count();
         }
         if (Class->LoopEnd == -1) {
             Class->LoopEnd = Class->Stages;
@@ -411,10 +408,7 @@ void AnimClassExt::_AI()
                         Class = Class->ChainTo;
 
                         if (Class->Stages == -1) {
-                            Class->Stages = Class->Get_Image_Data()->Get_Count();
-                            if (animtypeext->IsShadow) {
-                                Class->Stages /= 2;
-                            }
+                            Class->Stages = animtypeext->Stage_Count();
                         }
                         if (Class->LoopEnd == -1) {
                             Class->LoopEnd = Class->Stages;

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -394,6 +394,8 @@ void AnimClassExt::_AI()
                 }
                 else {
 
+                    animext->End();
+
                     /*
                     **	The animation should end now, but first check to see if
                     **	it needs to chain into another animation. If so, then the
@@ -401,8 +403,6 @@ void AnimClassExt::_AI()
                     **	new form.
                     */
                     if (Class->ChainTo != nullptr) {
-
-                        animext->End();
 
                         Class = Class->ChainTo;
 

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -733,7 +733,8 @@ void Draw_Shape_Proxy(
             int shadow_shapenum = shapenum + shapefile->Get_Count() / 2;
             Point2D shadow_point = point - Point2D(0, _CurrentlyDrawnAnim->Class->YDrawOffset);
             int shadow_height_offset = height_offset - _CurrentlyDrawnAnim->ZAdjust - _CurrentlyDrawnAnim->Class->YDrawOffset;
-            ShapeFlags_Type shadow_flags = flags & ~(SHAPE_Z_REMAP | SHAPE_DARKEN | SHAPE_TRANS75 | SHAPE_CENTER | SHAPE_WIN_REL) | (SHAPE_DARKEN | SHAPE_CENTER | SHAPE_WIN_REL);
+            ShapeFlags_Type shadow_flags = flags & ~SHAPE_FLAT;
+            shadow_flags = (shadow_flags & ~SHAPE_TRANS75) | (SHAPE_DARKEN | SHAPE_CENTER | SHAPE_WIN_REL);
 
             Draw_Shape(surface, convert, shapefile, shadow_shapenum, shadow_point, window, shadow_flags, nullptr, shadow_height_offset);
         }

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -350,7 +350,7 @@ void AnimClassExt::_AI()
                 int frame = Class->Start + stage;
                 const ShapeSet* image = Get_Image_Data();
 
-                if (animtypeext->MiddleFrames.Is_Present(frame) || (animtypeext->MiddleFrames.Is_Present(-1) && image != nullptr && frame == image->Get_Count() / 2)) {
+                if (frame != 0 && (animtypeext->MiddleFrames.Is_Present(frame) || (animtypeext->MiddleFrames.Is_Present(-1) && image != nullptr && frame == image->Get_Count() / 2))) {
                     Middle();
                 }
             }

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -438,7 +438,6 @@ void AnimClassExt::_AI()
 }
 
 
-
 /**
  *  Get the center coord of a anim. This is required as we can not allocate
  *  on the stack and Center_Coord returns Coordinate value.
@@ -748,4 +747,5 @@ void AnimClassExtension_Hooks()
     Patch_Jump(0x00414B42, &_AnimClass_Draw_It_Shadow_Patch);
     Patch_Call(0x00414BA9, &Draw_Shape_Proxy);
     Patch_Jump(0x00414E80, &AnimClassExt::_AI);
+    Patch_Jump(0x00413C89, 0x00413CBF);
 }

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -346,12 +346,13 @@ void AnimClassExt::_AI()
             **	naturally rather than "popping" into existence while in plain sight.
             */
             if (animtypeext->MiddleFrames.Count() && !IsDebris) {
-
                 int frame = Class->Start + stage;
                 const ShapeSet* image = Get_Image_Data();
 
-                if (frame != 0 && (animtypeext->MiddleFrames.Is_Present(frame) || (animtypeext->MiddleFrames.Is_Present(-1) && image != nullptr && frame == image->Get_Count() / 2))) {
-                    Middle();
+                if (frame != 0) {
+                    if (animtypeext->MiddleFrames.Is_Present(frame) || (animtypeext->MiddleFrames.Is_Present(-1) && image != nullptr && frame == image->Get_Count() / 2)) {
+                        Middle();
+                    }
                 }
             }
 
@@ -466,7 +467,7 @@ void AnimClassExt::_Start()
     **	perform this action now. Subsequent checks against this stage value starts with the
     **	second frame of the animation.
     */
-    if (!Class->Biggest) {
+    if (animtypeext->MiddleFrames.Is_Present(0)) {
         Middle();
     }
 

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -167,7 +167,6 @@ void AnimClassExt::_AI()
         if (!cellptr || !cellptr->Get_Tiberium_Value()) {
             IsInvisible = true;
         }
-
     }
 
     if (IsDebris) {
@@ -377,8 +376,7 @@ void AnimClassExt::_AI()
                 if (Loops) {
                     if (Class->IsReverse) {
                         Set_Stage(Class->LoopEnd);
-                    }
-                    else {
+                    } else {
                         Set_Stage(Class->LoopStart - Class->Start);
                     }
                     if (Class->RandomLoopDelayMin != 0 || Class->RandomLoopDelayMax != 0) {
@@ -428,12 +426,11 @@ void AnimClassExt::_AI()
                         }
                         if (Class->IsNormalized) {
                             Set_Rate(Options.Normalize_Delay(delay));
-                        }
-                        else {
+                        } else {
                             Set_Rate(delay);
                         }
                         Set_Stage(Class->Start);
-                        int damagedelay = animtypeext->DamageDelay == -1 ? Fetch_Rate() : animtypeext->DamageDelay;
+                        int damagedelay = animtypeext->DamageRate == -1 ? Fetch_Rate() : animtypeext->DamageRate;
                         animext->DamageStage.Set_Rate(damagedelay);
                         Start();
                     }

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -136,6 +136,11 @@ static void Do_Anim_Damage(AnimClass* anim, int damage)
 }
 
 
+/**
+ *  Reimplementation of AnimClass::AI.
+ *
+ *  @author: ZivDero
+ */
 void AnimClassExt::_AI()
 {
     const auto animext = Extension::Fetch<AnimClassExtension>(this);
@@ -442,6 +447,11 @@ void AnimClassExt::_AI()
 }
 
 
+/**
+ *  Reimplementation of AnimClass::Start.
+ *
+ *  @author: ZivDero
+ */
 void AnimClassExt::_Start()
 {
     const auto animext = Extension::Fetch<AnimClassExtension>(this);
@@ -521,6 +531,11 @@ static void Anim_Spawn_Particles(AnimClass* this_ptr)
 }
 
 
+/**
+ *  Reimplementation of AnimClass::Middle.
+ *
+ *  @author: ZivDero
+ */
 void AnimClassExt::_Middle()
 {
     const auto animext = Extension::Fetch<AnimClassExtension>(this);
@@ -662,6 +677,12 @@ DECLARE_PATCH(_AnimClass_Constructor_Layer_Set_Z_Height_Patch)
 }
 
 
+/**
+ *  Saves the currently drawn animation before the call to Draw_Shape
+ *  in AnimClass::Draw_It so that we can use it later.
+ *
+ *  @author: ZivDero
+ */
 static AnimClass* _CurrentlyDrawnAnim = nullptr;
 DECLARE_PATCH(_AnimClass_Draw_It_Shadow_Patch)
 {
@@ -676,6 +697,12 @@ DECLARE_PATCH(_AnimClass_Draw_It_Shadow_Patch)
 }
 
 
+/**
+ *  Proxy for Draw_Shape that lets up draw an animation's shadow
+ *  without hunting for arguments.
+ *
+ *  @author: ZivDero
+ */
 void Draw_Shape_Proxy(
     Surface& surface,
     ConvertClass& convert,
@@ -694,15 +721,31 @@ void Draw_Shape_Proxy(
 {
     Draw_Shape(surface, convert, shapefile, shapenum, point, window, flags, remap, height_offset, zgrad, intensity, z_shapefile, z_shapenum, z_off);
 
+    /**
+     *  Make sure that we have a valid animation saved just in case.
+     */
     if (_CurrentlyDrawnAnim != nullptr && _CurrentlyDrawnAnim->Class != nullptr) {
         const auto typeext = Extension::Fetch<AnimTypeClassExtension>(_CurrentlyDrawnAnim->Class);
+
+        /**
+         *  Draw the shadow.
+         */
         if (typeext->IsShadow) {
+
+            /**
+             *  We can deduce the necessary arguments for the draw call based on the ones that were passed in.
+             */
             int shadow_shapenum = shapenum + shapefile->Get_Count() / 2;
             Point2D shadow_point = point - Point2D(0, _CurrentlyDrawnAnim->Class->YDrawOffset);
             int shadow_height_offset = height_offset - _CurrentlyDrawnAnim->ZAdjust - _CurrentlyDrawnAnim->Class->YDrawOffset;
             ShapeFlags_Type shadow_flags = flags & ~(SHAPE_Z_REMAP | SHAPE_DARKEN | SHAPE_TRANS75 | SHAPE_CENTER | SHAPE_WIN_REL) | (SHAPE_DARKEN | SHAPE_CENTER | SHAPE_WIN_REL);
+
             Draw_Shape(surface, convert, shapefile, shadow_shapenum, shadow_point, window, shadow_flags, nullptr, shadow_height_offset);
         }
+
+        /**
+         *  Clean up the saved anim.
+         */
         _CurrentlyDrawnAnim = nullptr;
     }
 }

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -141,14 +141,6 @@ void AnimClassExt::_AI()
     const auto animext = Extension::Fetch<AnimClassExtension>(this);
     const auto animtypeext = Extension::Fetch<AnimTypeClassExtension>(Class);
 
-    /**
-     *  We have flagged that this animation's type needs to have
-     *  its biggest frame recalculated, do that.
-     */
-    if (Class->Biggest == -1) {
-        animtypeext->Set_Biggest_Frame();
-    }
-
     if (Class->IsFlamingGuy) {
         Flaming_Guy_AI();
         ObjectClass::AI();
@@ -351,8 +343,14 @@ void AnimClassExt::_AI()
             **	action required. This masks craters and scorch marks, so that they appear
             **	naturally rather than "popping" into existence while in plain sight.
             */
-            if (Class->Biggest && Class->Start + stage == Class->Biggest && !IsDebris) {
-                Middle();
+            if (animtypeext->MiddleFrames.Count() && !IsDebris) {
+
+                int frame = Class->Start + stage;
+                const ShapeSet* image = Get_Image_Data();
+
+                if (animtypeext->MiddleFrames.Is_Present(frame) || (animtypeext->MiddleFrames.Is_Present(-1) && image != nullptr && frame == image->Get_Count() / 2)) {
+                    Middle();
+                }
             }
 
             if (Class->IsPingPong) {

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -764,5 +764,4 @@ void AnimClassExtension_Hooks()
     Patch_Jump(0x00414E80, &AnimClassExt::_AI);
     Patch_Jump(0x00415D60, &AnimClassExt::_Start);
     Patch_Jump(0x00415F40, &AnimClassExt::_Middle);
-    Patch_Jump(0x00413C89, 0x00413CBF); // Skip setting Class->Stages and Class->LoopEnd in the constructor, let it happen in AI instead.
 }

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -512,15 +512,12 @@ static void Anim_Spawn_Particles(AnimClass* this_ptr)
 
         for (int i = 0; i < animtypeext->NumberOfParticles; ++i) {
 
-            Coordinate spawn_coord = this_ptr->Coord;
+            Coordinate spawn_coord = this_ptr->Get_Coord() + Coordinate(animtypeext->ParticleSpawnOffset.X, animtypeext->ParticleSpawnOffset.Y, animtypeext->ParticleSpawnOffset.Z);
 
             /**
              *  Spawn a new particle at this anims coord.
              */
-            MasterParticle->Spawn_Particle(
-                (ParticleTypeClass*)ParticleTypeClass::As_Pointer(animtypeext->ParticleToSpawn),
-                spawn_coord);
-
+            MasterParticle->Spawn_Particle(ParticleTypes[animtypeext->ParticleToSpawn], spawn_coord);
         }
     }
 }

--- a/src/extensions/anim/animext_init.cpp
+++ b/src/extensions/anim/animext_init.cpp
@@ -204,5 +204,6 @@ void AnimClassExtension_Init()
     Patch_Jump(0x00413C79, &_AnimClass_Constructor_Patch);
     Patch_Jump(0x004142A6, &_AnimClass_Default_Constructor_Patch);
     Patch_Jump(0x0041441F, 0x00414475); // This jump goes from duplicate code in the destructor to our patch, removing the need for two hooks.
+    Patch_Jump(0x00413C89, 0x00413D3E); // Skip part of the AnimClass constructor that's re-implemented in the extension constructor.
     Patch_Jump(0x004142CB, &_AnimClass_Destructor_Patch);
 }

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -49,6 +49,7 @@ AnimTypeClassExtension::AnimTypeClassExtension(const AnimTypeClass *this_ptr) :
     AttachLayer(LAYER_NONE),
     ParticleToSpawn(PARTICLE_NONE),
     NumberOfParticles(0),
+    ParticleSpawnOffset(0, 0, 0),
     StartAnims(),
     StartAnimsCount(),
     StartAnimsMinimum(),
@@ -362,6 +363,7 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
     AttachLayer = ini.Get_LayerType(ini_name, "Layer", AttachLayer);
     ParticleToSpawn = ini.Get_ParticleType(ini_name, "SpawnsParticle", ParticleToSpawn);
     NumberOfParticles = ini.Get_Int(ini_name, "NumParticles", NumberOfParticles);
+    ParticleSpawnOffset = ini.Get_Point(ini_name, "SpawnsParticleOffset", ParticleSpawnOffset);
 
     StartAnims = ini.Get_Anims(ini_name, "StartAnims", StartAnims);
     StartAnimsCount = ini.Get_Integers(ini_name, "StartAnimsCount", StartAnimsCount);

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -66,7 +66,8 @@ AnimTypeClassExtension::AnimTypeClassExtension(const AnimTypeClass *this_ptr) :
     EndAnimsDelay(),
     MiddleFrame(-1),
     ExplosionDamage(0),
-    IsShadow(false)
+    IsShadow(false),
+    DamageDelay(-1)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("AnimTypeClassExtension::AnimTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -72,6 +72,9 @@ AnimTypeClassExtension::AnimTypeClassExtension(const AnimTypeClass *this_ptr) :
     //if (this_ptr) EXT_DEBUG_TRACE("AnimTypeClassExtension::AnimTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
     AnimTypeExtensions.Add(this);
+
+    // The half-way frame is the middle frame by default.
+    MiddleFrames.Add(-1);
 }
 
 
@@ -424,7 +427,7 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
      */
     MiddleFrames = ini.Get_Integers(ini_name, "MiddleFrame", MiddleFrames);
     for (int& frame : MiddleFrames) {
-        frame = std::clamp(frame, -1, This()->Image->Get_Count() - 1);
+        frame = std::clamp(frame, -1, ((This()->Image != nullptr) ? (This()->Image->Get_Count() - 1) : 0));
     }
 
     ExplosionDamage = ini.Get_Int(ini_name, "ExplosionDamage", ExplosionDamage);

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -67,7 +67,7 @@ AnimTypeClassExtension::AnimTypeClassExtension(const AnimTypeClass *this_ptr) :
     MiddleFrame(-1),
     ExplosionDamage(0),
     IsShadow(false),
-    DamageDelay(-1)
+    DamageRate(-1)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("AnimTypeClassExtension::AnimTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -423,6 +423,11 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
 
     ExplosionDamage = ini.Get_Int(ini_name, "ExplosionDamage", ExplosionDamage);
     IsShadow = ini.Get_Bool(ini_name, "Shadow", IsShadow);
+
+    int delay = DamageRate = ini.Get_Int(ini_name, "DamageRate", -1);
+    if (delay != -1) {
+        DamageRate = (delay > 0) ? 900 / delay : 0;
+    }
 
     IsInitialized = true;
 

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -65,7 +65,8 @@ AnimTypeClassExtension::AnimTypeClassExtension(const AnimTypeClass *this_ptr) :
     EndAnimsMaximum(),
     EndAnimsDelay(),
     MiddleFrame(-1),
-    ExplosionDamage(0)
+    ExplosionDamage(0),
+    IsShadow(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("AnimTypeClassExtension::AnimTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -420,6 +421,7 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     ExplosionDamage = ini.Get_Int(ini_name, "ExplosionDamage", ExplosionDamage);
+    IsShadow = ini.Get_Bool(ini_name, "Shadow", IsShadow);
 
     IsInitialized = true;
 

--- a/src/extensions/animtype/animtypeext.cpp
+++ b/src/extensions/animtype/animtypeext.cpp
@@ -439,3 +439,21 @@ bool AnimTypeClassExtension::Read_INI(CCINIClass &ini)
 
     return true;
 }
+
+
+/**
+ *  Returns the default stage count for this animation.
+ *
+ *  @author: ZivDero
+ */
+int AnimTypeClassExtension::Stage_Count() const
+{
+    int stages = 0;
+    if (This()->Get_Image_Data() != nullptr) {
+        stages = This()->Get_Image_Data()->Get_Count();
+    }
+    if (IsShadow) {
+        stages /= 2;
+    }
+    return stages;
+}

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -67,6 +67,8 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
 
         virtual bool Read_INI(CCINIClass &ini) override;
 
+        int Stage_Count() const;
+
     public:
         /**
          *  If the cell in which this animation is placed does not contain

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -101,7 +101,12 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
         /**
          *  The number of the particle to spawn.
          */
-        unsigned NumberOfParticles;
+        int NumberOfParticles;
+
+        /**
+         *  The coordinate offset of the spawned particle.
+         */
+        Point3D ParticleSpawnOffset;
 
         /**
          *  List of animations to spawn at the logical start of this animation.

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -67,9 +67,6 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
 
         virtual bool Read_INI(CCINIClass &ini) override;
 
-        void Set_Biggest_Frame();
-        static void All_Set_Biggest_Frame();
-
     public:
         /**
          *  If the cell in which this animation is placed does not contain
@@ -134,7 +131,7 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
         /**
          *  The middle (biggest) frame, if set by the user.
          */
-        int MiddleFrame;
+        TypeList<int> MiddleFrames;
 
         /**
          *  If positive, the animation will spawn an explosion during its biggest frame dealing this much damage.

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -131,7 +131,7 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
         TypeList<int> EndAnimsDelay;
 
         /**
-         *  The middle (biggest) frame, if set by the user.
+         *  The middle (biggest) frames.
          */
         TypeList<int> MiddleFrames;
 

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -142,4 +142,5 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
         int ExplosionDamage;
 
         bool IsShadow;
+        int DamageDelay;
 };

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -142,5 +142,5 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
         int ExplosionDamage;
 
         bool IsShadow;
-        int DamageDelay;
+        int DamageRate;
 };

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -138,6 +138,13 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
          */
         int ExplosionDamage;
 
+        /**
+         *  Does this animation have a shadow?
+         */
         bool IsShadow;
+
+        /**
+         *  A separate rate at which the anim deals damage.
+         */
         int DamageRate;
 };

--- a/src/extensions/animtype/animtypeext.h
+++ b/src/extensions/animtype/animtypeext.h
@@ -140,4 +140,6 @@ AnimTypeClassExtension final : public ObjectTypeClassExtension
          *  If positive, the animation will spawn an explosion during its biggest frame dealing this much damage.
          */
         int ExplosionDamage;
+
+        bool IsShadow;
 };

--- a/src/extensions/animtype/animtypeext_hooks.cpp
+++ b/src/extensions/animtype/animtypeext_hooks.cpp
@@ -89,8 +89,7 @@ void AnimTypeClassExt::_Load_Image(TheaterType theater)
     if (!IsDemandLoad && Image == nullptr) {
         if (IsTheater) {
             Fetch_Normal_Image();
-        }
-        else {
+        } else {
             char fullname[_MAX_FNAME + _MAX_EXT];
             _makepath(fullname, nullptr, nullptr, Graphic_Name(), ".SHP");
             Theater_Naming_Convention(fullname, theater);
@@ -98,12 +97,14 @@ void AnimTypeClassExt::_Load_Image(TheaterType theater)
         }
     }
 
-    ShapeSet const* shape = Image;
-    if (shape != nullptr) {
+    if (Stages == 0) {
         Stages = -1;
-        LoopEnd = -1;
-        Biggest = -1;
     }
+    if (LoopEnd == 0) {
+        LoopEnd = -1;
+    }
+
+    Biggest = -1;
 }
 
 

--- a/src/extensions/animtype/animtypeext_hooks.cpp
+++ b/src/extensions/animtype/animtypeext_hooks.cpp
@@ -84,6 +84,11 @@ void AnimTypeClassExt::_Free_Image()
 }
 
 
+/**
+ *  Reimplementation of AnimTypeClass::Load_Image.
+ *
+ *  @author: ZivDero
+ */
 void AnimTypeClassExt::_Load_Image(TheaterType theater)
 {
     if (!IsDemandLoad && Image == nullptr) {
@@ -97,6 +102,10 @@ void AnimTypeClassExt::_Load_Image(TheaterType theater)
         }
     }
 
+    /**
+     *  The game would calculate Stages and LoopEnd now, set them to -1
+     *  instead to be calcalated in AnimClass::AI.
+     */
     if (Stages == 0) {
         Stages = -1;
     }
@@ -104,6 +113,9 @@ void AnimTypeClassExt::_Load_Image(TheaterType theater)
         LoopEnd = -1;
     }
 
+    /**
+     *  No longer important as we use the MiddleFrames type list now.
+     */
     Biggest = -1;
 }
 

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -455,7 +455,7 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
         /*
         **  Draw the weapon factory custom overlay graphic.
         */
-        if (Mission == MISSION_UNLOAD) {
+        if (Get_Mission() == MISSION_UNLOAD) {
             ShapeSet const* under_door_anim;
             if (open_roof) {
                 under_door_anim = type_ext->UnderRoofDoorAnim;

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -835,7 +835,7 @@ DECLARE_PATCH(_BuildingClass_Mission_Open_Gate_Open_Sound_Patch)
     /**
      *  Play the sound effect at the buildings location.
      */
-    Sound_Effect(voc, *coord);
+    Static_Sound(voc, *coord);
 
     JMP_REG(edx, 0x00433BC8);
 }
@@ -870,7 +870,7 @@ DECLARE_PATCH(_BuildingClass_Mission_Open_Gate_Close_Sound_Patch)
     /**
      *  Play the sound effect at the buildings location.
      */
-    Sound_Effect(voc, *coord);
+    Static_Sound(voc, *coord);
 
     /**
      *  Function return (0).

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -396,75 +396,74 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
         shapenum += (HealthRatio <= Rule->ConditionYellow ? (Class->GateStages + 1) : 0);
         Techno_Draw_Object(shapefile, shapenum, xdrawpoint, xcliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), zgrad, true, Map[cell].Land);
 
+        return;
     }
-    else {
 
-        if (Get_Mission() == MISSION_UNLOAD) {
-            if (open_roof) {
-                if (type_ext->RoofDeployingAnim != nullptr) {
-                    shapefile = type_ext->RoofDeployingAnim;
-                    zadjust = 0;
-                }
-            }
-            else {
-                if (Class->DeployingAnim != nullptr) {
-                    shapefile = Class->DeployingAnim;
-                    zadjust = 0;
-                }
-            }
-
-        }
-
-        Point2D drawpoint = xdrawpoint;
-        int height = drawpoint.Y + shapefile->Get_Height() / 2;
-
-        Rect cliprect = xcliprect;
-        cliprect.Height = std::min(cliprect.Height, height);
-
-        zdrawpoint += Class->ZShapePointMove;
-        zdrawpoint -= TacticalMap->func_60F270(Point2D((Class->Width() * CELL_LEPTON_W) - CELL_LEPTON_W, (Class->Height() * CELL_LEPTON_H) - CELL_LEPTON_H));
-
-        ShapeSet const* zshapefile = BuildingTypeClass::BuildingZShape;
-        if (Class->Width() >= 6) {
-            zshapefile = nullptr;
-        }
-
-        if (cliprect.Height > 0) {
-
-            /*
-            **	Actually draw the building shape.
-            */
-            if ((Class->IsLaserFence && (LaserFenceFrame == 12 || LaserFenceFrame == 8)) || Class->IsFirestormWall) {
-                Techno_Draw_Object(shapefile, Shape_Number(), drawpoint, cliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
-            }
-            else {
-                Techno_Draw_Object(shapefile, Shape_Number() < shapefile->Get_Count() / 2 ? Shape_Number() : shapefile->Get_Count() / 2, drawpoint, cliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_90DEG, true, Map[cell].Brightness + Class->ExtraLight, zshapefile, 0, zdrawpoint);
+    if (Get_Mission() == MISSION_UNLOAD) {
+        if (open_roof) {
+            if (type_ext->RoofDeployingAnim != nullptr) {
+                shapefile = type_ext->RoofDeployingAnim;
+                zadjust = 0;
             }
         }
+        else {
+            if (Class->DeployingAnim != nullptr) {
+                shapefile = Class->DeployingAnim;
+                zadjust = 0;
+            }
+        }
+    }
+
+    Point2D drawpoint = xdrawpoint;
+    int height = drawpoint.Y + shapefile->Get_Height() / 2;
+
+    Rect cliprect = xcliprect;
+    cliprect.Height = std::min(cliprect.Height, height);
+
+    zdrawpoint += Class->ZShapePointMove;
+    Point2D zsizeoffset((Class->Width() * CELL_LEPTON_W) - CELL_LEPTON_W, (Class->Height() * CELL_LEPTON_H) - CELL_LEPTON_H);
+    zdrawpoint -= TacticalMap->func_60F270(zsizeoffset);
+
+    ShapeSet const* zshapefile = BuildingTypeClass::BuildingZShape;
+    if (Class->Width() >= 6) {
+        zshapefile = nullptr;
+    }
+
+    if (cliprect.Height > 0) {
 
         /*
-        **  Patch for adding overlay onto weapon factory.  Only add the overlay if
-        **  the building has more than 1 hp.  Also, if the building's in radio
-        **  contact, he must be unloading a constructed vehicle, so draw that
-        **  vehicle before drawing the overlay.
+        **	Actually draw the building shape.
         */
-        if (Class->BibShape && BState != BSTATE_CONSTRUCTION) {
-            Techno_Draw_Object(Class->BibShape, Shape_Number(), xdrawpoint, xcliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
+        if ((Class->IsLaserFence && (LaserFenceFrame == 12 || LaserFenceFrame == 8)) || Class->IsFirestormWall) {
+            Techno_Draw_Object(shapefile, Shape_Number(), drawpoint, cliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
         }
+        else {
+            Techno_Draw_Object(shapefile, Shape_Number() < shapefile->Get_Count() / 2 ? Shape_Number() : shapefile->Get_Count() / 2, drawpoint, cliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_90DEG, true, Map[cell].Brightness + Class->ExtraLight, zshapefile, 0, zdrawpoint);
+        }
+    }
 
-        /*
-        **  Draw the weapon factory custom overlay graphic.
-        */
-        if (Get_Mission() == MISSION_UNLOAD) {
-            ShapeSet const* under_door_anim;
-            if (open_roof) {
-                under_door_anim = type_ext->UnderRoofDoorAnim;
-            } else {
-                under_door_anim = Class->UnderDoorAnim;
-            }
-            if (under_door_anim != nullptr) {
-                Techno_Draw_Object(under_door_anim, HealthRatio <= Rule->ConditionYellow ? 1 : 0, xdrawpoint, xcliprect, DIR_N, 256, -TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
-            }
+    /*
+    **  Patch for adding overlay onto weapon factory.  Only add the overlay if
+    **  the building has more than 1 hp.  Also, if the building's in radio
+    **  contact, he must be unloading a constructed vehicle, so draw that
+    **  vehicle before drawing the overlay.
+    */
+    if (Class->BibShape && BState != BSTATE_CONSTRUCTION) {
+        Techno_Draw_Object(Class->BibShape, Shape_Number(), xdrawpoint, xcliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
+    }
+
+    /*
+    **  Draw the weapon factory custom overlay graphic.
+    */
+    if (Get_Mission() == MISSION_UNLOAD) {
+        ShapeSet const* under_door_anim;
+        if (open_roof) {
+            under_door_anim = type_ext->UnderRoofDoorAnim;
+        } else {
+            under_door_anim = Class->UnderDoorAnim;
+        }
+        if (under_door_anim != nullptr) {
+            Techno_Draw_Object(under_door_anim, HealthRatio <= Rule->ConditionYellow ? 1 : 0, xdrawpoint, xcliprect, DIR_N, 256, -TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
         }
     }
 }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -1423,9 +1423,9 @@ DECLARE_PATCH(_BuildingClass_entry_370_RoofDoorAnim_Patch2)
     btypeext = Extension::Fetch<BuildingTypeClassExtension>(building->Class);
 
     if (Should_Open_Roof(building)) {
-        shapefile = building->Class->DoorAnim;
-    } else {
         shapefile = btypeext->RoofDoorAnim;
+    } else {
+        shapefile = building->Class->DoorAnim;
     }
 
     _asm popad

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -339,6 +339,11 @@ void BuildingClassExt::_Detach_Anim(AnimClass* anim)
 }
 
 
+/**
+ *  Reimplementation of BuildingClass::Draw_It.
+ *
+ *  @author: ZivDero
+ */
 void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect)
 {
     Cell cell = Get_Cell();
@@ -1385,6 +1390,11 @@ DECLARE_PATCH(_BuildingClass_Mission_Missile_LAUNCH_DOWN_Voice_Patch)
 }
 
 
+/**
+ *  Should the factory open the roof as opposed to the door?
+ *
+ *  @author: ZivDero
+ */
 bool Should_Open_Roof(BuildingClass* building)
 {
     if (building->Get_Mission() == MISSION_UNLOAD) {
@@ -1397,6 +1407,11 @@ bool Should_Open_Roof(BuildingClass* building)
 }
 
 
+/**
+ *  Patches to make the factory show the roof door opening anim for JJs.
+ *
+ *  @author: ZivDero
+ */
 DECLARE_PATCH(_BuildingClass_entry_370_RoofDoorAnim_Patch1)
 {
     GET_REGISTER_STATIC(BuildingClass*, building, ebp);
@@ -1477,6 +1492,6 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x00432729, &_BuildingClass_Mission_Missile_DOOR_OPENING_Patch);
     Patch_Jump(0x00432957, &_BuildingClass_Mission_Missile_LAUNCH_DOWN_Patch);
     Patch_Jump(0x00432937, &_BuildingClass_Mission_Missile_LAUNCH_DOWN_Voice_Patch);
-    Patch_Jump(0x00427CD8, &_BuildingClass_entry_370_RoofDoorAnim_Patch1);
-    Patch_Jump(0x00427DF5, &_BuildingClass_entry_370_RoofDoorAnim_Patch2);
+    //Patch_Jump(0x00427CD8, &_BuildingClass_entry_370_RoofDoorAnim_Patch1);
+    //Patch_Jump(0x00427DF5, &_BuildingClass_entry_370_RoofDoorAnim_Patch2);
 }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -26,6 +26,8 @@
  *
  ******************************************************************************/
 #include "buildingext_hooks.h"
+
+#include <algorithm>
 #include "buildingext_init.h"
 #include "buildingext.h"
 #include "buildingtypeext.h"
@@ -69,10 +71,12 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "jumpjetlocomotion.h"
 #include "rulesext.h"
 #include "super.h"
 #include "supertypeext.h"
 #include "vox.h"
+#include "tactical.h"
 
 
 /**
@@ -91,6 +95,7 @@ public:
     int _How_Many_Survivors() const;
     int _Shape_Number() const;
     void _Detach_Anim(AnimClass* anim);
+    void _Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect);
 };
 
 
@@ -309,6 +314,7 @@ void BuildingClassExt::_Detach_Anim(AnimClass* anim)
                             Begin_Anim(BANIM_SPECIAL_TWO, Get_Health_Ratio() <= Rule->ConditionYellow, 0);
                         }
                     }
+                    IsToDisplay = true;
                     break;
 
                 case BANIM_SPECIAL_TWO:
@@ -317,11 +323,142 @@ void BuildingClassExt::_Detach_Anim(AnimClass* anim)
                             Begin_Anim(BANIM_SPECIAL_THREE, Get_Health_Ratio() <= Rule->ConditionYellow, 0);
                         }
                     }
+                    IsToDisplay = true;
+                    break;
+
+                case BANIM_SPECIAL_THREE:
+                    IsToDisplay = true;
                     break;
 
                 default:
                     break;
                 }
+            }
+        }
+    }
+}
+
+
+void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect)
+{
+    Cell cell = Get_Cell();
+
+    /*
+    **  The shape file to use for rendering depends on whether the building
+    **  is undergoing construction or not.
+    */
+    ShapeSet const* shapefile = Get_Image_Data();
+    if (shapefile == nullptr) return;
+
+    if (Class->IsInvisibleInGame) return;
+
+    const auto type_ext = Extension::Fetch<BuildingTypeClassExtension>(Class);
+    if (type_ext->IsHideDuringSpecialAnim && (Anims[BANIM_SPECIAL_ONE] || Anims[BANIM_SPECIAL_TWO] || Anims[BANIM_SPECIAL_THREE])) return;
+
+    bool open_roof = false;
+    if (Get_Mission() == MISSION_UNLOAD) {
+        TechnoClass* radio = Contact_With_Whom();
+        if (radio != nullptr && (radio->Techno_Type_Class()->Locomotor == __uuidof(JumpjetLocomotionClass))) {
+            open_roof = true;
+        }
+    }
+
+    Point2D zdrawpoint(144, 172);
+    int zadjust = Class->NormalZAdjust;
+
+    if (Get_Mission() == MISSION_OPEN && !Door.Func1()) {
+
+        int shapenum = static_cast<int>(Door.Get_Percent_Complete() * Class->GateStages);
+        if (Door.Is_Door_Closing()) {
+            shapenum = Class->GateStages - shapenum;
+        }
+        if (Door.Is_Door_Closed()) {
+            shapenum = 0;
+        }
+        if (Door.Is_Door_Open()) {
+            shapenum = Class->GateStages - 1;
+        }
+        shapenum = std::min(shapenum, Class->GateStages - 1);
+        shapenum = std::max(shapenum, 0);
+
+        shapefile = Get_Image_Data();
+
+        ZGradientType zgrad = ZGRAD_GROUND;
+        if (shapenum < Class->GateStages / 2) {
+            zgrad = ZGRAD_90DEG;
+        }
+
+        shapenum += (HealthRatio <= Rule->ConditionYellow ? (Class->GateStages + 1) : 0);
+        Techno_Draw_Object(shapefile, shapenum, xdrawpoint, xcliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), zgrad, true, Map[cell].Land);
+
+    }
+    else {
+
+        if (Get_Mission() == MISSION_UNLOAD) {
+            if (open_roof) {
+                if (type_ext->RoofDeployingAnim != nullptr) {
+                    shapefile = type_ext->RoofDeployingAnim;
+                    zadjust = 0;
+                }
+            }
+            else {
+                if (Class->DeployingAnim != nullptr) {
+                    shapefile = Class->DeployingAnim;
+                    zadjust = 0;
+                }
+            }
+
+        }
+
+        Point2D drawpoint = xdrawpoint;
+        int height = drawpoint.Y + shapefile->Get_Height() / 2;
+
+        Rect cliprect = xcliprect;
+        cliprect.Height = std::min(cliprect.Height, height);
+
+        zdrawpoint += Class->ZShapePointMove;
+        zdrawpoint -= TacticalMap->func_60F270(Point2D((Class->Width() * CELL_LEPTON_W) - CELL_LEPTON_W, (Class->Height() * CELL_LEPTON_H) - CELL_LEPTON_H));
+
+        ShapeSet const* zshapefile = BuildingTypeClass::BuildingZShape;
+        if (Class->Width() >= 6) {
+            zshapefile = nullptr;
+        }
+
+        if (cliprect.Height > 0) {
+
+            /*
+            **	Actually draw the building shape.
+            */
+            if ((Class->IsLaserFence && (LaserFenceFrame == 12 || LaserFenceFrame == 8)) || Class->IsFirestormWall) {
+                Techno_Draw_Object(shapefile, Shape_Number(), drawpoint, cliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
+            }
+            else {
+                Techno_Draw_Object(shapefile, Shape_Number() < shapefile->Get_Count() / 2 ? Shape_Number() : shapefile->Get_Count() / 2, drawpoint, cliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_90DEG, true, Map[cell].Brightness + Class->ExtraLight, zshapefile, 0, zdrawpoint);
+            }
+        }
+
+        /*
+        **  Patch for adding overlay onto weapon factory.  Only add the overlay if
+        **  the building has more than 1 hp.  Also, if the building's in radio
+        **  contact, he must be unloading a constructed vehicle, so draw that
+        **  vehicle before drawing the overlay.
+        */
+        if (Class->BibShape && BState != BSTATE_CONSTRUCTION) {
+            Techno_Draw_Object(Class->BibShape, Shape_Number(), xdrawpoint, xcliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
+        }
+
+        /*
+        **  Draw the weapon factory custom overlay graphic.
+        */
+        if (Mission == MISSION_UNLOAD) {
+            ShapeSet const* under_door_anim;
+            if (open_roof) {
+                under_door_anim = type_ext->UnderRoofDoorAnim;
+            } else {
+                under_door_anim = Class->UnderDoorAnim;
+            }
+            if (under_door_anim != nullptr) {
+                Techno_Draw_Object(under_door_anim, HealthRatio <= Rule->ConditionYellow ? 1 : 0, xdrawpoint, xcliprect, DIR_N, 256, -TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
             }
         }
     }
@@ -1199,6 +1336,8 @@ DECLARE_PATCH(_BuildingClass_Mission_Missile_INITIAL_Patch)
 
     delay = _BuildingClass_Mission_Missile_INITIAL(this_ptr);
 
+    this_ptr->IsToDisplay = true;
+
     _asm mov eax, delay
     JMP_REG(edi, 0x00432721);
 }
@@ -1282,6 +1421,7 @@ void BuildingClassExtension_Hooks()
     //Patch_Jump(0x00429220, &BuildingClassExt::_Shape_Number);
     Patch_Jump(0x0042E53C, 0x0042E56F); // Jump a check for the PurchasePrice of a building for spawning its FreeUnit in Grand_Opening
     Patch_Jump(0x00436410, &BuildingClassExt::_Detach_Anim);
+    Patch_Jump(0x004275B0, &BuildingClassExt::_Draw_It);
     Patch_Jump(0x00433F1D, &_BuildingCLass_Detach_Detach_Anim_Patch);
     Patch_Jump(0x00432709, &_BuildingClass_Mission_Missile_INITIAL_Patch);
     Patch_Jump(0x00432729, &_BuildingClass_Mission_Missile_DOOR_OPENING_Patch);

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -226,6 +226,11 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
 }
 
 
+/**
+ *  Fetches the extra building graphics.
+ *
+ *  @author: ZivDero
+ */
 void BuildingTypeClassExtension::Fetch_Building_Normal_Image(TheaterType theater)
 {
     char fullname[MAX_PATH];
@@ -234,7 +239,7 @@ void BuildingTypeClassExtension::Fetch_Building_Normal_Image(TheaterType theater
     ArtINI.Get_String(This()->GraphicName, "RoofDeployingAnim", "", buffer, sizeof(buffer));
     if (strlen(buffer) != 0) {
         _makepath(fullname, nullptr, nullptr, buffer, ".SHP");
-        This()->Theater_Naming_Convention(fullname, theater); // note, This() may be invalid here, but even though Theater_Naming_Convention is thiscall, it doesn't actually use `this`.
+        This()->Theater_Naming_Convention(fullname, theater);
         RoofDeployingAnim = static_cast<ShapeSet const*>(MixFileClass::Retrieve(fullname));
     }
 

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -33,6 +33,7 @@
 #include "extension.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "scenario.h"
 
 
 /**
@@ -51,7 +52,11 @@ BuildingTypeClassExtension::BuildingTypeClassExtension(const BuildingTypeClass *
     IsStartupCashOneTime(false),
     IsResetBudgetOnCapture(false),
     IsEligibleForAllyBuilding(false),
-    EngineerChance(0)
+    EngineerChance(0),
+    IsHideDuringSpecialAnim(false),
+    RoofDeployingAnim(nullptr),
+    RoofDoorAnim(nullptr),
+    UnderRoofDoorAnim(nullptr)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("BuildingTypeClassExtension::BuildingTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -211,8 +216,39 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
     IsResetBudgetOnCapture = ini.Get_Bool(ini_name, "ProduceCashResetOnCapture", IsResetBudgetOnCapture);
 
     IsEligibleForAllyBuilding = ini.Get_Bool(ini_name, "EligibleForAllyBuilding", IsEligibleForAllyBuilding);
+    IsHideDuringSpecialAnim = ArtINI.Get_Bool(ini_name, "HideDuringSpecialAnim", IsHideDuringSpecialAnim);
+
+    Fetch_Building_Normal_Image(Scen->Theater);
 
     IsInitialized = true;
 
     return true;
+}
+
+
+void BuildingTypeClassExtension::Fetch_Building_Normal_Image(TheaterType theater)
+{
+    char fullname[MAX_PATH];
+    char buffer[64];
+
+    ArtINI.Get_String(This()->GraphicName, "RoofDeployingAnim", "", buffer, sizeof(buffer));
+    if (strlen(buffer) != 0) {
+        _makepath(fullname, nullptr, nullptr, buffer, ".SHP");
+        This()->Assign_Theater_Name(fullname, theater); // note, This() may be invalid here, but even though Theater_Naming_Convention is thiscall, it doesn't actually use `this`.
+        RoofDeployingAnim = static_cast<ShapeSet const*>(MixFileClass::Retrieve(fullname));
+    }
+
+    ArtINI.Get_String(This()->GraphicName, "RoofDoorAnim", "", buffer, sizeof(buffer));
+    if (strlen(buffer) != 0) {
+        _makepath(fullname, nullptr, nullptr, buffer, ".SHP");
+        This()->Assign_Theater_Name(fullname, theater);
+        RoofDoorAnim = static_cast<ShapeSet const*>(MixFileClass::Retrieve(fullname));
+    }
+
+    ArtINI.Get_String(This()->GraphicName, "UnderRoofDoorAnim", "", buffer, sizeof(buffer));
+    if (strlen(buffer) != 0) {
+        _makepath(fullname, nullptr, nullptr, buffer, ".SHP");
+        This()->Assign_Theater_Name(fullname, theater);
+        UnderRoofDoorAnim = static_cast<ShapeSet const*>(MixFileClass::Retrieve(fullname));
+    }
 }

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -234,21 +234,21 @@ void BuildingTypeClassExtension::Fetch_Building_Normal_Image(TheaterType theater
     ArtINI.Get_String(This()->GraphicName, "RoofDeployingAnim", "", buffer, sizeof(buffer));
     if (strlen(buffer) != 0) {
         _makepath(fullname, nullptr, nullptr, buffer, ".SHP");
-        This()->Assign_Theater_Name(fullname, theater); // note, This() may be invalid here, but even though Theater_Naming_Convention is thiscall, it doesn't actually use `this`.
+        This()->Theater_Naming_Convention(fullname, theater); // note, This() may be invalid here, but even though Theater_Naming_Convention is thiscall, it doesn't actually use `this`.
         RoofDeployingAnim = static_cast<ShapeSet const*>(MixFileClass::Retrieve(fullname));
     }
 
     ArtINI.Get_String(This()->GraphicName, "RoofDoorAnim", "", buffer, sizeof(buffer));
     if (strlen(buffer) != 0) {
         _makepath(fullname, nullptr, nullptr, buffer, ".SHP");
-        This()->Assign_Theater_Name(fullname, theater);
+        This()->Theater_Naming_Convention(fullname, theater);
         RoofDoorAnim = static_cast<ShapeSet const*>(MixFileClass::Retrieve(fullname));
     }
 
     ArtINI.Get_String(This()->GraphicName, "UnderRoofDoorAnim", "", buffer, sizeof(buffer));
     if (strlen(buffer) != 0) {
         _makepath(fullname, nullptr, nullptr, buffer, ".SHP");
-        This()->Assign_Theater_Name(fullname, theater);
+        This()->Theater_Naming_Convention(fullname, theater);
         UnderRoofDoorAnim = static_cast<ShapeSet const*>(MixFileClass::Retrieve(fullname));
     }
 }

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -114,10 +114,17 @@ BuildingTypeClassExtension final : public TechnoTypeClassExtension
          */
         int EngineerChance;
 
+        /**
+         *  Should the building hide its main shape during the special anims?
+         *  Usually used for missile silos so that anims that don't completely
+         *  hide the main shape don't look glitched.
+         */
         bool IsHideDuringSpecialAnim;
 
+        /**
+         *  New shapes for roof door anims.
+         */
         const ShapeSet* RoofDeployingAnim;
         const ShapeSet* RoofDoorAnim;
         const ShapeSet* UnderRoofDoorAnim;
-
 };

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -61,6 +61,8 @@ BuildingTypeClassExtension final : public TechnoTypeClassExtension
 
         virtual bool Read_INI(CCINIClass &ini) override;
 
+        void Fetch_Building_Normal_Image(TheaterType theater);
+
     public:
         /**
          *  This is the sound effect to play when the animation of the gate is rising.
@@ -111,4 +113,11 @@ BuildingTypeClassExtension final : public TechnoTypeClassExtension
          *  The percent chance for an engineer to exit this building as its crew.
          */
         int EngineerChance;
+
+        bool IsHideDuringSpecialAnim;
+
+        const ShapeSet* RoofDeployingAnim;
+        const ShapeSet* RoofDoorAnim;
+        const ShapeSet* UnderRoofDoorAnim;
+
 };

--- a/src/extensions/buildingtype/buildingtypeext_hooks.cpp
+++ b/src/extensions/buildingtype/buildingtypeext_hooks.cpp
@@ -248,6 +248,11 @@ int BuildingTypeClassExt::_Cost_Of(HouseClass* house)
 }
 
 
+/**
+ *  Patch to fetch the new building images.
+ *
+ *  Author: ZivDero
+ */
 DECLARE_PATCH(_BuildingTypeClass_Init_Fetch_Image_Patch)
 {
     GET_REGISTER_STATIC(BuildingTypeClass*, btype, esi);

--- a/src/extensions/buildingtype/buildingtypeext_hooks.cpp
+++ b/src/extensions/buildingtype/buildingtypeext_hooks.cpp
@@ -247,6 +247,22 @@ int BuildingTypeClassExt::_Cost_Of(HouseClass* house)
     return TechnoTypeClass::Cost_Of(house);
 }
 
+
+DECLARE_PATCH(_BuildingTypeClass_Init_Fetch_Image_Patch)
+{
+    GET_REGISTER_STATIC(BuildingTypeClass*, btype, esi);
+    GET_REGISTER_STATIC(TheaterType, theater, edi);
+
+    btype->Fetch_Building_Normal_Image(theater);
+
+    static BuildingTypeClassExtension* bext;
+    bext = Extension::Fetch<BuildingTypeClassExtension>(btype);
+    bext->Fetch_Building_Normal_Image(theater);
+
+    JMP(0x0043FDC7);
+}
+
+
 /**
  *  Main function for patching the hooks.
  */
@@ -270,4 +286,5 @@ void BuildingTypeClassExtension_Hooks()
     Patch_Jump(0x0043F936, &_BuildingTypeClass_DTOR_Free_Buildup_Image_Patch);
     Patch_Jump(0x00440000, &BuildingTypeClassExt::_Raw_Cost);
     Patch_Jump(0x00440080, &BuildingTypeClassExt::_Cost_Of);
+    Patch_Jump(0x0043FDBF, &_BuildingTypeClass_Init_Fetch_Image_Patch);
 }

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -194,7 +194,7 @@ DECLARE_PATCH(_InfantryClass_Per_Cell_Process_Transport_Attach_Sound_Patch)
      */
     radio_technotypeext = Extension::Fetch<TechnoTypeClassExtension>(techno->Techno_Type_Class());
     if (radio_technotypeext->EnterTransportSound != VOC_NONE) {
-        Sound_Effect(radio_technotypeext->EnterTransportSound, techno->Coord);
+        Static_Sound(radio_technotypeext->EnterTransportSound, techno->Coord);
     }
 
     JMP(0x004D3A87);

--- a/src/extensions/objecttype/objecttypeext_hooks.cpp
+++ b/src/extensions/objecttype/objecttypeext_hooks.cpp
@@ -66,7 +66,7 @@ static class ObjectTypeClassExt : public ObjectTypeClass
 
 
 /**
- *  Reimplementation of ObjectTypeClass::Assign_Theater_Name to support new theater types.
+ *  Reimplementation of ObjectTypeClass::Theater_Naming_Convention to support new theater types.
  * 
  *  @author: CCHyper
  */
@@ -128,7 +128,7 @@ void ObjectTypeClassExt::_Assign_Theater_Name(char *fname, TheaterType theater)
 
 
 /**
- *  This patch replaces an inlined instance of ObjectTypeClass::Assign_Theater_Name
+ *  This patch replaces an inlined instance of ObjectTypeClass::Theater_Naming_Convention
  *  with a direct call.
  * 
  *  @author: CCHyper
@@ -139,7 +139,7 @@ DECLARE_PATCH(_ObjectTypeClass_Load_Theater_Art_Assign_Theater_Name_Theater_Patc
     LEA_STACK_STATIC(char *, fullname, esp, 0x0C);
     LEA_STACK_STATIC(char *, destbuffer, esp, 0x08);
 
-    this_ptr->Assign_Theater_Name(fullname, Scen->Theater);
+    this_ptr->Theater_Naming_Convention(fullname, Scen->Theater);
 
     JMP(0x005889E2);
 }

--- a/src/extensions/tactical/tacticalext_hooks.cpp
+++ b/src/extensions/tactical/tacticalext_hooks.cpp
@@ -780,7 +780,7 @@ DECLARE_PATCH(_Tactical_Render_Overlay_Patch)
          *  Play the one time notification sound if defined.
          */
         if (TacticalMapExtension->InfoTextNotifySound != VOC_NONE) {
-            Sound_Effect(TacticalMapExtension->InfoTextNotifySound, TacticalMapExtension->InfoTextNotifySoundVolume);
+            Voice_Sound_Effect(TacticalMapExtension->InfoTextNotifySound, TacticalMapExtension->InfoTextNotifySoundVolume);
             TacticalMapExtension->InfoTextNotifySound = VOC_NONE;
         }
         

--- a/src/extensions/taction/tactionext_hooks.cpp
+++ b/src/extensions/taction/tactionext_hooks.cpp
@@ -88,7 +88,7 @@ bool TActionClassExt::_Play_Sound_At_Random_Waypoint(HouseClass *house, ObjectCl
      */
     Cell rnd_cell = cell_list[Random_Pick<unsigned int>(0, std::size(cell_list) - 1)];
 
-    Sound_Effect(Data.Sound, Cell_Coord(rnd_cell, true));
+    Static_Sound(Data.Sound, Cell_Coord(rnd_cell, true));
 
     return true;
 }

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -2254,7 +2254,7 @@ DECLARE_PATCH(_TechnoClass_Do_Cloak_Cloak_Sound_Patch)
     /**
      *  Play the sound effect at the objects location.
      */
-    Sound_Effect(voc, *coord);
+    Static_Sound(voc, *coord);
 
     JMP(0x00633C8B);
 }
@@ -2297,7 +2297,7 @@ DECLARE_PATCH(_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch)
     /**
      *  Play the sound effect at the objects location.
      */
-    Sound_Effect(voc, *coord);
+    Static_Sound(voc, *coord);
 
     JMP(0x00633BE7);
 }

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -482,7 +482,7 @@ DECLARE_PATCH(_UnitClass_Mission_Unload_Transport_Detach_Sound_Patch)
      */
     radio_technotypeext = Extension::Fetch<TechnoTypeClassExtension>(this_ptr->Techno_Type_Class());
     if (radio_technotypeext->LeaveTransportSound != VOC_NONE) {
-        Sound_Effect(radio_technotypeext->LeaveTransportSound, this_ptr->Coord);
+        Static_Sound(radio_technotypeext->LeaveTransportSound, this_ptr->Coord);
     }
 
     /**

--- a/src/new/aircrafttracker/aircrafttracker_hooks.cpp
+++ b/src/new/aircrafttracker/aircrafttracker_hooks.cpp
@@ -167,7 +167,7 @@ void FlyLocomotionClassExt::_Take_Off()
             LinkedTo->PrimaryFacing.Set(LinkedTo->SecondaryFacing.Desired());
         }
 
-        Sound_Effect(LinkedTo->Techno_Type_Class()->AuxSound1, LinkedTo->Get_Coord());
+        Static_Sound(LinkedTo->Techno_Type_Class()->AuxSound1, LinkedTo->Get_Coord());
     }
 }
 

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -268,7 +268,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
                 if (rocket->TakeoffAnim)
                     new AnimClass(rocket->TakeoffAnim, LinkedTo->Coord, 2, 1, SHAPE_WIN_REL | SHAPE_CENTER, -10);
 
-                Sound_Effect(LinkedTo->Techno_Type_Class()->AuxSound1, LinkedTo->Coord);
+                Static_Sound(LinkedTo->Techno_Type_Class()->AuxSound1, LinkedTo->Coord);
             }
             /**
              *  Otherwise, keep tilting.
@@ -446,7 +446,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
                 const auto linked_ext = Extension::Fetch<FootClassExtension>(LinkedTo);
                 if (linked_ext->Get_Last_Flight_Cell() == CELL_NONE)
                 {
-                    Sound_Effect(LinkedTo->Techno_Type_Class()->AuxSound1, LinkedTo->Coord);
+                    Static_Sound(LinkedTo->Techno_Type_Class()->AuxSound1, LinkedTo->Coord);
                     AircraftTracker->Track(LinkedTo);
                 }
 

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -309,7 +309,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
             {
                 MissionState = RocketMissionState::Flight;
                 Coordinate center_coord = LinkedTo->Center_Coord();
-                ApogeeDistance = (center_coord.As_Cell() - DestinationCoord.As_Cell()).Length();
+                ApogeeDistance = (Cell(center_coord.X, center_coord.Y) - Cell(DestinationCoord.X, DestinationCoord.Y)).Length();
             }
             break;
         }
@@ -347,7 +347,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
                      *  compared to how far it was when it reached its cruising altitude.
                      */
                     const Coordinate center_coord = LinkedTo->Center_Coord();
-                    const double dist = (center_coord.As_Cell() - DestinationCoord.As_Cell()).Length();
+                    const double dist = (Cell(center_coord.X, center_coord.Y) - Cell(DestinationCoord.X, DestinationCoord.Y)).Length();
                     const double ratio = dist / ApogeeDistance;
 
                     CurrentPitch = rocket->PitchFinal * ratio * DEG_TO_RAD(90) + Get_Next_Pitch() * (1 - ratio);
@@ -366,7 +366,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
                     /**
                      *  If we're there, proceed to closing in.
                      */
-                    const int horizontal_distance = (LinkedTo->Center_Coord().As_Cell() - DestinationCoord.As_Cell()).Length();
+                    const int horizontal_distance = (Cell(LinkedTo->Center_Coord().X, LinkedTo->Center_Coord().Y) - Cell(DestinationCoord.X, DestinationCoord.Y)).Length();
                     const int vertical_distance = LinkedTo->Center_Coord().Z - DestinationCoord.Z;
                     if (horizontal_distance <= vertical_distance * rocket->CloseEnoughFactor)
                         MissionState = RocketMissionState::ClosingIn;

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -699,6 +699,8 @@ void Vinifera_Post_Load_Game()
         const BuildingTypeClass* buildingtype = BuildingTypes[i];
         Extension::Fetch<BuildingTypeClassExtension>(buildingtype)->Fetch_Building_Normal_Image(Scen->Theater);
     }
+
+    AnimTypeClassExtension::All_Set_Biggest_Frame();
 }
 
 
@@ -929,7 +931,6 @@ bool Vinifera_Load_Game(const char* file_name)
     SwizzleManager.Reset();
     Post_Load_Game();
     Vinifera_Post_Load_Game();
-    AnimTypeClassExtension::All_Set_Biggest_Frame();
     Map.Init_IO();
     Map.Activate(1);
     Map.Set_Dimensions();

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -699,8 +699,6 @@ void Vinifera_Post_Load_Game()
         const BuildingTypeClass* buildingtype = BuildingTypes[i];
         Extension::Fetch<BuildingTypeClassExtension>(buildingtype)->Fetch_Building_Normal_Image(Scen->Theater);
     }
-
-    AnimTypeClassExtension::All_Set_Biggest_Frame();
 }
 
 

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -129,6 +129,7 @@
 
 #include "aircrafttracker.h"
 #include "animtypeext.h"
+#include "buildingtypeext.h"
 #include "hooker.h"
 #include "language.h"
 #include "loadoptions.h"
@@ -682,7 +683,7 @@ bool Vinifera_Remap_Extension_Pointers()
  *
  *  @author: ZivDero
  */
-void Put_Storage_Pointers()
+void Vinifera_Post_Load_Game()
 {
     for (int i = 0; i < Technos.Count(); i++) {
         const TechnoClass* techno = Technos[i];
@@ -692,6 +693,11 @@ void Put_Storage_Pointers()
     for (int i = 0; i < Houses.Count(); i++) {
         const HouseClass* house = Houses[i];
         Extension::Fetch<HouseClassExtension>(house)->Put_Storage_Pointers();
+    }
+
+    for (int i = 0; i < BuildingTypes.Count(); i++) {
+        const BuildingTypeClass* buildingtype = BuildingTypes[i];
+        Extension::Fetch<BuildingTypeClassExtension>(buildingtype)->Fetch_Building_Normal_Image(Scen->Theater);
     }
 }
 
@@ -922,7 +928,7 @@ bool Vinifera_Load_Game(const char* file_name)
 
     SwizzleManager.Reset();
     Post_Load_Game();
-    Put_Storage_Pointers();
+    Vinifera_Post_Load_Game();
     AnimTypeClassExtension::All_Set_Biggest_Frame();
     Map.Init_IO();
     Map.Activate(1);

--- a/src/vinifera/vinifera_saveload.h
+++ b/src/vinifera/vinifera_saveload.h
@@ -95,7 +95,7 @@ extern unsigned ViniferaGameVersion;
 bool Vinifera_Put_All(IStream *pStm, bool save_net = false);
 bool Vinifera_Get_All(IStream *pStm, bool load_net = false);
 bool Vinifera_Remap_Extension_Pointers();
-void Put_Storage_Pointers();
+void Vinifera_Post_Load_Game();
 bool Vinifera_Save_Game(const char* file_name, const char* descr, bool);
 bool Vinifera_Load_Game(const char* file_name);
 void SaveGame_Hooks();


### PR DESCRIPTION
This PR brings a few improvements to animations and building drawing.

- `MiddleFrame` has been converted into a list.
- `Shadow` allows specifying if the animation draws a shadow.

- This PR allows the animation to deal damage at a rate independent of main visual logic rate.
- The calculation is the same as for `Rate=`, that is, the animation will deal damage every `900 / DamageRate` frames, rounded down.

In `ART.INI`:
```ini
[AnimType]    ; AnimType
DamageRate=-1  ; integer, the rate at which this animation deals damage. Defaults to `Rate`.
```

- The main building shape may be hidden when any of the special anims is playing.

In `ART.INI`:
```ini
[SOMEBUILDING]            ; BuildingType
HideDuringSpecialAnim=no  ; boolean, should the main shape of the building be hidden when any special anim is playing.
```

- This PR allows war factories to display a roof opening animation when a unit using the Jump Jet locomotor is produced, similar to Red Alert 2.

In `ART.INI`:
```ini
[SOMEBUILDING]      ; BuildingType
RoofDeployingAnim=  ; AnimType, the animation of the open roof when a Jump Jet is exiting the factory.
UnderRoofDoorAnim=  ; AnimType, the animation of the rest of the building when a Jump Jet is exiting the factory.
```