### PR TITLE
[Minor] Pecify the required version number for the sphinx-design dependency

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -134,6 +134,8 @@ This page lists all the individual contributions to the project by their author.
   - Implement a feature for animations to spawn additional animations.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
+- **Noble Fish**:
+  - Document proofreading and formatting/styling assistance.
 - **MarkJFox**:
   - Graphics for the new sidebar fitting vanilla sidebar.
 - **[Phobos Contributors](https://github.com/Phobos-developers/Phobos/blob/develop/CREDITS.md)**:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 myst-parser==3.0.1
 Sphinx==7.1.2
 sphinx-rtd-theme==2.0.0
-sphinx-design
+sphinx-design==0.6.1


### PR DESCRIPTION
Kerb warned me that failing to specify the exact version number might lead to random crashes under certain circumstances. Consequently, I opted for this particular version number that has been verified to work stably, which is the same version employed by the Phobos project.