### PR TITLE
Jumpjet Locomotion Improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -132,6 +132,7 @@ This page lists all the individual contributions to the project by their author.
   - Implement various controls to show and customise NavCom queue lines.
   - Implement customizable mouse cursors and actions.
   - Implement a feature for animations to spawn additional animations.
+  - Help with implementing Jumpjet Locomotion improvements.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:
@@ -234,3 +235,4 @@ This page lists all the individual contributions to the project by their author.
   - Add `HideDuringSpecialAnim` for buildings.
   - Add `RoofDeployingAnim` and `UnderRoofDoorAnim` for buildings.
   - Add `SpawnsParticleOffset`.
+  - Implement Jumpjet Locomotion improvements.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -4,6 +4,7 @@ This page lists all the individual contributions to the project by their author.
 
 - **AlexB**:
   - Make OverlayTypes 27 to 38 (fourth Tiberium images) passable by infantry.
+  - Fix a crash when a Jumpjet infantry is flying or trying to take off just when an Ion Storm starts.
 - **Belonit (Gluk-v48)**:
   - Check for Changelog/Documentation/Credits in Pull Requests.
   - Docs dark theme switcher.
@@ -236,3 +237,4 @@ This page lists all the individual contributions to the project by their author.
   - Add `RoofDeployingAnim` and `UnderRoofDoorAnim` for buildings.
   - Add `SpawnsParticleOffset`.
   - Implement Jumpjet Locomotion improvements.
+  - Fix a crash when a Jumpjet infantry is flying or trying to take off just when an Ion Storm starts.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -68,3 +68,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where a visceroid was spawned when poison gas destroyed a non-crewed vehicle, building, or terrain object.
 - Fix a bug where it was impossible to tell infantry to enter cloaked allied transports.
 - Super Weapons with `Type=MultiMissile` and `Type=ChemMissile` now fire using their own weapon when fired from a building.
+- Fix a crash when a Jumpjet infantry is flying or trying to take off just when an Ion Storm starts.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1007,6 +1007,32 @@ In `RULES.INI`:
 DecloakToFire=yes  ; boolean, does this Techno have to decloak before firing?
 ```
 
+### Jumpjet Locomotion Improvements
+
+- Vinifera allows customizing Jumpjet properties per unit.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]                 ; TechnoType
+JumpjetTurnRate=             ; integer, maximum turning rate of the jumpjet unit, defaults to [JumpjetControls]->TurnRate.
+JumpjetSpeed=                ; integer, forward speed of the jumpjet unit, defaults to [JumpjetControls]->Speed.
+JumpjetClimb=                ; float, vertical climb rate of the jumpjet unit, defaults to [JumpjetControls]->Climb.
+JumpjetCruiseHeight=         ; integer, desired cruising height of the jumpjet unit, defaults to [JumpjetControls]->CruiseHeight.
+JumpjetAcceleration=         ; float, acceleration of the jumpjet unit when gaining speed, defaults to [JumpjetControls]->Acceleration.
+JumpjetWobblesPerSecond=     ; float, frequency of wobble oscillation per second for jumpjets, defaults to [JumpjetControls]->WobblesPerSecond.
+JumpjetWobbleDeviation=      ; integer, maximum wobble deviation (in leptons) for jumpjet movement, defaults to [JumpjetControls]->WobbleDeviation.
+JumpjetCloakDetectionRadius= ; integer, radius (in cells) at which the jumpjet unit can detect cloaked objects, defaults to [JumpjetControls]->CloakDetectionRadius.
+```
+
+- Additionally, you can now turn off wobbles for a given unit.
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]            ; TechnoType
+JumpjetNoWobbles=false  ; boolean, whether the jumpjet unit doesn't wobble.
+```
+
+
 ## Terrain
 
 ### Light Sources

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -186,6 +186,7 @@ New:
 - Add `DamageRate` for animations (by ZivDero)
 - Add `HideDuringSpecialAnim` for buildings (by ZivDero)
 - Add `RoofDeployingAnim` and `UnderRoofDoorAnim` for buildings (by ZivDero)
+- Implement Jumpjet Locomotion improvements (by ZivDero, tomsons26)
 
 
 Vanilla fixes:

--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -125,7 +125,7 @@ bool AircraftClassExt::_Unlimbo(Coordinate& coord, Dir256 dir)
          *  When starting at flight level, then give it speed. When landed
          *  then it must be stationary.
          */
-        if (Height == Class->Flight_Level()) {
+        if (HeightAGL == Class->Flight_Level()) {
             Set_Speed(1.0);
         }
         else {
@@ -469,7 +469,7 @@ DECLARE_PATCH(_AircraftClass_Enter_Idle_Mode_Spawner_Patch)
 
     aircrafttypeext = Extension::Fetch<AircraftTypeClassExtension>(this_ptr->Class);
 
-    if (layer != LAYER_GROUND && this_ptr->Height > landingaltitude && !aircrafttypeext->IsMissileSpawn)
+    if (layer != LAYER_GROUND && this_ptr->HeightAGL > landingaltitude && !aircrafttypeext->IsMissileSpawn)
     {
         JMP(0x0040B3C1);
     }

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -562,7 +562,7 @@ void AnimClassExt::_Middle()
      */
     Anim_Spawn_Particles(this);
 
-    if (Height < 30) {
+    if (HeightAGL < 30) {
 
         /*
         **	If this animation leaves scorch marks (e.g., napalm), then do so at this time.
@@ -619,7 +619,7 @@ void AnimClassExt::_Middle()
         }
     }
     else if (Class->IsScorcher) {
-        if (Height < 10) {
+        if (HeightAGL < 10) {
             LandType land = Map[Get_Coord()].Land_Type();
             if (land != LAND_WATER && land != LAND_BEACH && land != LAND_ICE && land != LAND_ROCK) {
                 newanim = new AnimClass(Rule->SmallFire, Center_Coord(), 0, Random_Pick(1, 2));
@@ -653,16 +653,16 @@ DECLARE_PATCH(_AnimClass_Constructor_Layer_Set_Z_Height_Patch)
      */
     if (animtypeext->AttachLayer != LAYER_NONE
         && (animtypeext->AttachLayer == LAYER_AIR || animtypeext->AttachLayer == LAYER_TOP)) {
-        this_ptr->AbsoluteHeight = Rule->FlightLevel;
+        this_ptr->Height = Rule->FlightLevel;
 
     /**
      *  Original code.
      */
     } else if (!this_ptr->Class->IsGroundLayer) {
-        this_ptr->AbsoluteHeight = Rule->FlightLevel;
+        this_ptr->Height = Rule->FlightLevel;
 
     } else {
-        this_ptr->Height = 0;
+        this_ptr->HeightAGL = 0;
     }
 
     JMP(0x00413D63);

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -394,7 +394,7 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
         }
 
         shapenum += (HealthRatio <= Rule->ConditionYellow ? (Class->GateStages + 1) : 0);
-        Techno_Draw_Object(shapefile, shapenum, xdrawpoint, xcliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), zgrad, true, Map[cell].Brightness);
+        Techno_Draw_Object(shapefile, shapenum, xdrawpoint, xcliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(Height), zgrad, true, Map[cell].Brightness);
 
         return;
     }
@@ -435,10 +435,10 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
         **	Actually draw the building shape.
         */
         if ((Class->IsLaserFence && (LaserFenceFrame == 12 || LaserFenceFrame == 8)) || Class->IsFirestormWall) {
-            Techno_Draw_Object(shapefile, Shape_Number(), drawpoint, cliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
+            Techno_Draw_Object(shapefile, Shape_Number(), drawpoint, cliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(Height), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
         }
         else {
-            Techno_Draw_Object(shapefile, Shape_Number() < shapefile->Get_Count() / 2 ? Shape_Number() : shapefile->Get_Count() / 2, drawpoint, cliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_90DEG, true, Map[cell].Brightness + Class->ExtraLight, zshapefile, 0, zdrawpoint);
+            Techno_Draw_Object(shapefile, Shape_Number() < shapefile->Get_Count() / 2 ? Shape_Number() : shapefile->Get_Count() / 2, drawpoint, cliprect, DIR_N, 256, zadjust - TacticalMap->Z_Lepton_To_Pixel(Height), ZGRAD_90DEG, true, Map[cell].Brightness + Class->ExtraLight, zshapefile, 0, zdrawpoint);
         }
     }
 
@@ -449,7 +449,7 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
     **  vehicle before drawing the overlay.
     */
     if (Class->BibShape && BState != BSTATE_CONSTRUCTION) {
-        Techno_Draw_Object(Class->BibShape, Shape_Number(), xdrawpoint, xcliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
+        Techno_Draw_Object(Class->BibShape, Shape_Number(), xdrawpoint, xcliprect, DIR_N, 256, -1 - TacticalMap->Z_Lepton_To_Pixel(Height), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
     }
 
     /*
@@ -463,7 +463,7 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
             under_door_anim = Class->UnderDoorAnim;
         }
         if (under_door_anim != nullptr) {
-            Techno_Draw_Object(under_door_anim, HealthRatio <= Rule->ConditionYellow ? 1 : 0, xdrawpoint, xcliprect, DIR_N, 256, -TacticalMap->Z_Lepton_To_Pixel(AbsoluteHeight), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
+            Techno_Draw_Object(under_door_anim, HealthRatio <= Rule->ConditionYellow ? 1 : 0, xdrawpoint, xcliprect, DIR_N, 256, -TacticalMap->Z_Lepton_To_Pixel(Height), ZGRAD_GROUND, true, Map[cell].Brightness + Class->ExtraLight);
         }
     }
 }
@@ -994,7 +994,7 @@ DECLARE_PATCH(_BuildingClass_Draw_Spied_Cameo_Palette_Patch)
     GET_REGISTER_STATIC(TechnoClass *, factory_obj, eax);
     GET_REGISTER_STATIC(Point2D *, pos_xy, edi);
     GET_REGISTER_STATIC(Rect *, window_rect, ebp);
-    static TechnoTypeClass *technotype;
+    static const TechnoTypeClass *technotype;
     static TechnoTypeClassExtension *technotypeext;
     static const ShapeSet *cameo_shape;
     static Surface *pcx_image;

--- a/src/extensions/bullet/bulletext_hooks.cpp
+++ b/src/extensions/bullet/bulletext_hooks.cpp
@@ -80,7 +80,7 @@ bool BulletClassExt::_Is_Forced_To_Explode(Coordinate& coord)
     */
     if (!Class->IsHigh && cellptr->Overlay != OVERLAY_NONE && OverlayTypeClass::As_Reference(cellptr->Overlay).IsHigh) {
 
-        if (Get_Height() < 100) {
+        if (HeightAGL < 100) {
             coord = Cell_Coord(Coord_Cell(coord));
             return true;
         }
@@ -89,7 +89,7 @@ bool BulletClassExt::_Is_Forced_To_Explode(Coordinate& coord)
     /*
     **  Check for impact on the ground.
     */
-    if (Get_Height() < 0) {
+    if (HeightAGL < 0) {
         return true;
     }
 

--- a/src/extensions/combat/combatext_hooks.cpp
+++ b/src/extensions/combat/combatext_hooks.cpp
@@ -278,7 +278,7 @@ void Get_Explosion_Targets(const Coordinate& coord, TechnoClass* source, int ran
             object = cellptr->Cell_Occupier(isbridge);
             while (object) {
                 if (object != source) {
-                    if (object->Fetch_RTTI() != RTTI_UNIT || !Scen->SpecialFlags.IsHarvesterImmune || !Rule->HarvesterUnit.Is_Present(static_cast<UnitTypeClass*>(object->Class_Of()))) {
+                    if (object->Fetch_RTTI() != RTTI_UNIT || !Scen->SpecialFlags.IsHarvesterImmune || !Rule->HarvesterUnit.Is_Present((UnitTypeClass*)object->Class_Of())) {
                         objects.Delete(object);
                         objects.Add(object);
                     }
@@ -461,7 +461,7 @@ void Vinifera_Explosion_Damage(const Coordinate& coord, int strength, TechnoClas
                  *
                  *  Take distance to ground level to account when damaging buildings.
                  */
-                distance = std::abs(explosion_coord.Z - object->AbsoluteHeight);
+                distance = std::abs(explosion_coord.Z - object->Height);
                 if (distance < LEVEL_LEPTON_H * 2) {
                     distance = 0;
                 }

--- a/src/extensions/foot/footext.cpp
+++ b/src/extensions/foot/footext.cpp
@@ -143,7 +143,7 @@ void FootClassExtension::Set_Last_Flight_Cell(Cell cell)
  *
  *  @author: ZivDero
  */
-Cell FootClassExtension::Get_Last_Flight_Cell()
+Cell FootClassExtension::Get_Last_Flight_Cell() const
 {
     return LastFlightCell;
 }

--- a/src/extensions/foot/footext.h
+++ b/src/extensions/foot/footext.h
@@ -52,7 +52,7 @@ class FootClassExtension : public TechnoClassExtension
         virtual const FootClass *This_Const() const override { return reinterpret_cast<const FootClass *>(TechnoClassExtension::This_Const()); }
 
         virtual void Set_Last_Flight_Cell(Cell cell);
-        virtual Cell Get_Last_Flight_Cell();
+        virtual Cell Get_Last_Flight_Cell() const;
 
     public:
         /**

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -219,7 +219,7 @@ ProdFailType HouseClassExt::_Abandon_Production(RTTIType type, int id)
         if (obj == nullptr)
             return PROD_OK;
 
-        ObjectTypeClass* cls = obj->Class_Of();
+        const ObjectTypeClass* cls = obj->Class_Of();
         if (id != cls->Fetch_Heap_ID())
             return PROD_OK;
     }

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -436,7 +436,7 @@ bool TechnoClassExtension::Can_Passive_Acquire() const
  */
 Coordinate TechnoClassExtension::Fire_Coord(WeaponSlotType which, TPoint3D<int> offset) const
 {
-    TechnoTypeClass *ttype = This()->Techno_Type_Class();
+    const TechnoTypeClass *ttype = This()->Techno_Type_Class();
     const auto weaponinfo = This()->Get_Weapon(which);
 
     Matrix3D matrix;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1936,7 +1936,7 @@ DECLARE_PATCH(_TechnoClass_Refund_Amount_Soylent_Patch)
 {
     GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
     static TechnoTypeClassExtension *technotypext;
-    static TechnoTypeClass *technotype;
+    const static TechnoTypeClass *technotype;
     static int cost;
 
     /**
@@ -2228,7 +2228,7 @@ DECLARE_PATCH(_TechnoClass_Do_Cloak_Cloak_Sound_Patch)
 {
     GET_REGISTER_STATIC(Coordinate *, coord, eax);
     GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
-    static TechnoTypeClass *technotype;
+    const static TechnoTypeClass *technotype;
     static TechnoTypeClassExtension *technotypeext;
     static VocType voc;
 
@@ -2271,7 +2271,7 @@ DECLARE_PATCH(_TechnoClass_Do_Uncloak_Uncloak_Sound_Patch)
 {
     GET_REGISTER_STATIC(Coordinate *, coord, eax);
     GET_REGISTER_STATIC(TechnoClass *, this_ptr, esi);
-    static TechnoTypeClass *technotype;
+    static const TechnoTypeClass *technotype;
     static TechnoTypeClassExtension *technotypeext;
     static VocType voc;
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -99,7 +99,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     _JumpjetAcceleration(-std::numeric_limits<double>::max()),
     _JumpjetWobblesPerSecond(-std::numeric_limits<double>::max()),
     _JumpjetWobbleDeviation(std::numeric_limits<int>::min()),
-    _JumpjetCloakDetectionRadius(std::numeric_limits<int>::min())
+    _JumpjetCloakDetectionRadius(std::numeric_limits<int>::min()),
+    JumpjetNoWobbles(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -250,6 +251,15 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(SpawnsNumber);
     crc(TargetZoneScan);
     crc(IsDecloakToFire);
+    crc(_JumpjetTurnRate);
+    crc(_JumpjetSpeed);
+    crc(_JumpjetClimb);
+    crc(_JumpjetCruiseHeight);
+    crc(_JumpjetAcceleration);
+    crc(_JumpjetWobblesPerSecond);
+    crc(_JumpjetWobbleDeviation);
+    crc(_JumpjetCloakDetectionRadius);
+    crc(JumpjetNoWobbles);
 }
 
 
@@ -380,6 +390,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     _JumpjetWobblesPerSecond = ini.Get_Double(ini_name, "JumpjetWobblesPerSecond", _JumpjetWobblesPerSecond);
     _JumpjetWobbleDeviation = ini.Get_Int(ini_name, "JumpjetWobbleDeviation", _JumpjetWobbleDeviation);
     _JumpjetCloakDetectionRadius = ini.Get_Int(ini_name, "JumpjetCloakDetectionRadius", _JumpjetCloakDetectionRadius);
+    JumpjetNoWobbles = ini.Get_Bool(ini_name, "JumpjetNoWobbles", JumpjetNoWobbles);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -39,6 +39,7 @@
 #include "vinifera_saveload.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "rules.h"
 
 
 /**
@@ -90,7 +91,15 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     RequiredHouses(-1),
     ForbiddenHouses(-1),
     TargetZoneScan(TZST_SAME),
-    IsDecloakToFire(true)
+    IsDecloakToFire(true),
+    _JumpjetTurnRate(std::numeric_limits<int>::min()),
+    _JumpjetSpeed(std::numeric_limits<int>::min()),
+    _JumpjetClimb(-std::numeric_limits<double>::max()),
+    _JumpjetCruiseHeight(std::numeric_limits<int>::min()),
+    _JumpjetAcceleration(-std::numeric_limits<double>::max()),
+    _JumpjetWobblesPerSecond(-std::numeric_limits<double>::max()),
+    _JumpjetWobbleDeviation(std::numeric_limits<int>::min()),
+    _JumpjetCloakDetectionRadius(std::numeric_limits<int>::min())
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -363,5 +372,85 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     TargetZoneScan = _Get_TargetZoneScanType(ini, ini_name, "TargetZoneScan", TargetZoneScan);
     IsDecloakToFire = ini.Get_Bool(ini_name, "DecloakToFire", IsDecloakToFire);
 
+    _JumpjetTurnRate = ini.Get_Int(ini_name, "JumpjetTurnRate", _JumpjetTurnRate);
+    _JumpjetSpeed = ini.Get_Int(ini_name, "JumpjetSpeed", _JumpjetSpeed);
+    _JumpjetClimb = ini.Get_Double(ini_name, "JumpjetClimb", _JumpjetClimb);
+    _JumpjetCruiseHeight = ini.Get_Int(ini_name, "JumpjetCruiseHeight", _JumpjetCruiseHeight);
+    _JumpjetAcceleration = ini.Get_Double(ini_name, "JumpjetAcceleration", _JumpjetAcceleration);
+    _JumpjetWobblesPerSecond = ini.Get_Double(ini_name, "JumpjetWobblesPerSecond", _JumpjetWobblesPerSecond);
+    _JumpjetWobbleDeviation = ini.Get_Int(ini_name, "JumpjetWobbleDeviation", _JumpjetWobbleDeviation);
+    _JumpjetCloakDetectionRadius = ini.Get_Int(ini_name, "JumpjetCloakDetectionRadius", _JumpjetCloakDetectionRadius);
+
     return true;
+}
+
+
+int TechnoTypeClassExtension::Get_Jumpjet_Turn_Rate() const
+{
+    if (_JumpjetTurnRate != std::numeric_limits<int>::min()) {
+        return _JumpjetTurnRate;
+    }
+    return Rule->JumpjetTurnRate;
+}
+
+
+int TechnoTypeClassExtension::Get_Jumpjet_Speed() const
+{
+    if (_JumpjetSpeed != std::numeric_limits<int>::min()) {
+        return _JumpjetSpeed;
+    }
+    return Rule->JumpjetSpeed;
+}
+
+
+double TechnoTypeClassExtension::Get_Jumpjet_Climb() const
+{
+    if (_JumpjetClimb != -std::numeric_limits<double>::max()) {
+        return _JumpjetClimb;
+    }
+    return Rule->JumpjetClimb;
+}
+
+
+int TechnoTypeClassExtension::Get_Jumpjet_Cruise_Height() const
+{
+    if (_JumpjetCruiseHeight != std::numeric_limits<int>::min()) {
+        return _JumpjetCruiseHeight;
+    }
+    return Rule->JumpjetCruiseHeight;
+}
+
+
+double TechnoTypeClassExtension::Get_Jumpjet_Acceleration() const
+{
+    if (_JumpjetAcceleration != -std::numeric_limits<double>::max()) {
+        return _JumpjetAcceleration;
+    }
+    return Rule->JumpjetAcceleration;
+}
+
+
+double TechnoTypeClassExtension::Get_Jumpjet_Wobbles_Per_Second() const
+{
+    if (_JumpjetWobblesPerSecond != -std::numeric_limits<double>::max()) {
+        return _JumpjetWobblesPerSecond;
+    }
+    return Rule->JumpjetWobblesPerSecond;
+}
+
+
+int TechnoTypeClassExtension::Get_Jumpjet_Wobble_Deviation() const
+{
+    if (_JumpjetWobbleDeviation != std::numeric_limits<int>::min()) {
+        return _JumpjetWobbleDeviation;
+    }
+    return Rule->JumpjetWobbleDeviation;
+}
+
+
+int TechnoTypeClassExtension::Get_Jumpjet_Cloak_Detection_Radius() const {
+    if (_JumpjetCloakDetectionRadius != std::numeric_limits<int>::min()) {
+        return _JumpjetCloakDetectionRadius;
+    }
+    return Rule->JumpjetCloakDetectionRadius;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -307,4 +307,6 @@ public:
 
     int Get_Jumpjet_Cloak_Detection_Radius() const;
     __declspec(property(get = Get_Jumpjet_Cloak_Detection_Radius)) int JumpjetCloakDetectionRadius;
+
+    bool JumpjetNoWobbles;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -39,237 +39,272 @@ class BSurface;
 
 class TechnoTypeClassExtension : public ObjectTypeClassExtension
 {
-    public:
-        /**
-         *  IPersistStream
-         */
-        IFACEMETHOD(Load)(IStream *pStm);
-        IFACEMETHOD(Save)(IStream *pStm, BOOL fClearDirty);
-        IFACEMETHOD_(LONG, GetSizeMax)(ULARGE_INTEGER *pcbSize);
+public:
+    /**
+     *  IPersistStream
+     */
+    IFACEMETHOD(Load)(IStream *pStm);
+    IFACEMETHOD(Save)(IStream *pStm, BOOL fClearDirty);
+    IFACEMETHOD_(LONG, GetSizeMax)(ULARGE_INTEGER *pcbSize);
 
-    public:
-        TechnoTypeClassExtension(const TechnoTypeClass *this_ptr);
-        TechnoTypeClassExtension(const NoInitClass &noinit);
-        virtual ~TechnoTypeClassExtension();
+public:
+    TechnoTypeClassExtension(const TechnoTypeClass *this_ptr);
+    TechnoTypeClassExtension(const NoInitClass &noinit);
+    virtual ~TechnoTypeClassExtension();
 
-        virtual void Detach(AbstractClass * target, bool all = true) override;
-        virtual void Object_CRC(CRCEngine &crc) const override;
+    virtual void Detach(AbstractClass * target, bool all = true) override;
+    virtual void Object_CRC(CRCEngine &crc) const override;
 
-        virtual TechnoTypeClass *This() const override { return reinterpret_cast<TechnoTypeClass *>(ObjectTypeClassExtension::This()); }
-        virtual const TechnoTypeClass *This_Const() const override { return reinterpret_cast<const TechnoTypeClass *>(ObjectTypeClassExtension::This_Const()); }
+    virtual TechnoTypeClass *This() const override { return reinterpret_cast<TechnoTypeClass *>(ObjectTypeClassExtension::This()); }
+    virtual const TechnoTypeClass *This_Const() const override { return reinterpret_cast<const TechnoTypeClass *>(ObjectTypeClassExtension::This_Const()); }
 
-        virtual bool Read_INI(CCINIClass &ini) override;
+    virtual bool Read_INI(CCINIClass &ini) override;
 
-    public:
-        /**
-         *  This is the sound effect to play when the unit is cloaking.
-         */
-        VocType CloakSound;
+public:
+    /**
+     *  This is the sound effect to play when the unit is cloaking.
+     */
+    VocType CloakSound;
 
-        /**
-         *  This is the sound effect to play when the unit is decloaking.
-         */
-        VocType UncloakSound;
+    /**
+     *  This is the sound effect to play when the unit is decloaking.
+     */
+    VocType UncloakSound;
 
-        /**
-         *  Can this object shake the screen when it is destroyed?
-         *  (Must meet the rules as specified by Rule->ShakeScreen.
-         */
-        bool IsShakeScreen;
+    /**
+     *  Can this object shake the screen when it is destroyed?
+     *  (Must meet the rules as specified by Rule->ShakeScreen.
+     */
+    bool IsShakeScreen;
 
-        /**
-         *  Is this object immune to EMP (electromagnetic pulse) effects?
-         *  Powered buildings, vehicles and cyborgs are typically disabled
-         *  by EMP, unless this is set for them.
-         */
-        bool IsImmuneToEMP;
+    /**
+     *  Is this object immune to EMP (electromagnetic pulse) effects?
+     *  Powered buildings, vehicles and cyborgs are typically disabled
+     *  by EMP, unless this is set for them.
+     */
+    bool IsImmuneToEMP;
 
-        /**
-         *  Can this object acquire targets that are within its weapons range
-         *  and attack them automatically?
-         */
-        bool IsCanPassiveAcquire;
+    /**
+     *  Can this object acquire targets that are within its weapons range
+     *  and attack them automatically?
+     */
+    bool IsCanPassiveAcquire;
 
-        /**
-         *  Can this object retaliate when hit by enemy fire?
-         */
-        bool IsCanRetaliate;
+    /**
+     *  Can this object retaliate when hit by enemy fire?
+     */
+    bool IsCanRetaliate;
 
-        /**
-         *  Can this object be the target of an attack or move command by the computer?
-         *  Typically, only objects that take damage or can be destroyed are allow to be
-         *  a target. This flag is also subject to "IsLegalTarget" being "true".
-         */
-        bool IsLegalTargetComputer;
+    /**
+     *  Can this object be the target of an attack or move command by the computer?
+     *  Typically, only objects that take damage or can be destroyed are allow to be
+     *  a target. This flag is also subject to "IsLegalTarget" being "true".
+     */
+    bool IsLegalTargetComputer;
 
-        /**
-         *  These values are used to shake the screen when the object is destroyed.
-         */
-        unsigned ShakePixelYHi;
-        unsigned ShakePixelYLo;
-        unsigned ShakePixelXHi;
-        unsigned ShakePixelXLo;
+    /**
+     *  These values are used to shake the screen when the object is destroyed.
+     */
+    unsigned ShakePixelYHi;
+    unsigned ShakePixelYLo;
+    unsigned ShakePixelXHi;
+    unsigned ShakePixelXLo;
 
-        /**
-         *  The graphic class to switch to when this unit is unloading (e.g., at a refinery).
-         */
-        const TechnoTypeClass *UnloadingClass;
+    /**
+     *  The graphic class to switch to when this unit is unloading (e.g., at a refinery).
+     */
+    const TechnoTypeClass *UnloadingClass;
 
-        /**
-         *  The refund value for the unit when it is sold at a Service Depot.
-         */
-        unsigned SoylentValue;
+    /**
+     *  The refund value for the unit when it is sold at a Service Depot.
+     */
+    unsigned SoylentValue;
 
-        /**
-         *  This is the sound effect to play when a passenger enters this unit.
-         */
-        VocType EnterTransportSound;
+    /**
+     *  This is the sound effect to play when a passenger enters this unit.
+     */
+    VocType EnterTransportSound;
 
-        /**
-         *  This is the sound effect to play when a passenger leaves this unit.
-         */
-        VocType LeaveTransportSound;
+    /**
+     *  This is the sound effect to play when a passenger leaves this unit.
+     */
+    VocType LeaveTransportSound;
 
-        /**
-         *  List of voices to use when giving this object a capture order.
-         */
-        TypeList<VocType> VoiceCapture;
+    /**
+     *  List of voices to use when giving this object a capture order.
+     */
+    TypeList<VocType> VoiceCapture;
 
-        /**
-         *  List of voices to use when giving this object an enter order (ie, transport, infiltrate building).
-         */
-        TypeList<VocType> VoiceEnter;
+    /**
+     *  List of voices to use when giving this object an enter order (ie, transport, infiltrate building).
+     */
+    TypeList<VocType> VoiceEnter;
 
-        /**
-         *  List of voices to use when giving this object a unload order.
-         */
-        TypeList<VocType> VoiceDeploy;
+    /**
+     *  List of voices to use when giving this object a unload order.
+     */
+    TypeList<VocType> VoiceDeploy;
 
-        /**
-         *  List of voices to use when giving this object a harvest order.
-         */
-        TypeList<VocType> VoiceHarvest;
+    /**
+     *  List of voices to use when giving this object a harvest order.
+     */
+    TypeList<VocType> VoiceHarvest;
 
-        /**
-         *  Custom index of a pip to be drawn (like the medic pip).
-         */
-        int SpecialPipIndex;
+    /**
+     *  Custom index of a pip to be drawn (like the medic pip).
+     */
+    int SpecialPipIndex;
 
-        /**
-         *  If set to a value greater than 0, this many ammo pips will be drawn, wrapping around incrementing the frame index each time.
-         */
-        int PipWrap;
+    /**
+     *  If set to a value greater than 0, this many ammo pips will be drawn, wrapping around incrementing the frame index each time.
+     */
+    int PipWrap;
 
-        /**
-         *  The rate at which this unit animates when it is standing idle (not moving).
-         */
-        unsigned IdleRate;
+    /**
+     *  The rate at which this unit animates when it is standing idle (not moving).
+     */
+    unsigned IdleRate;
 
-        /**
-         *  Pointer to the cameo image surface.
-         */
-        BSurface *CameoImageSurface;
+    /**
+     *  Pointer to the cameo image surface.
+     */
+    BSurface *CameoImageSurface;
 
-        /**
-         *  Should this be considered a base defense when sorting cameos on the sidebar?
-         */
-        bool IsSortCameoAsBaseDefense;
+    /**
+     *  Should this be considered a base defense when sorting cameos on the sidebar?
+     */
+    bool IsSortCameoAsBaseDefense;
 
-        /**
-         *  Bitfield of houses that can build this type.
-         *  If `RequiredHouses != -1`, only these houses can build it.
-         */
-        long RequiredHouses;
+    /**
+     *  Bitfield of houses that can build this type.
+     *  If `RequiredHouses != -1`, only these houses can build it.
+     */
+    long RequiredHouses;
 
-        /**
-         *  Bitfield of houses that cannot build this type.
-         *  If `ForbiddenHouses != -1`, these houses cannot build it under any circumstances.
-         */
-        long ForbiddenHouses;
+    /**
+     *  Bitfield of houses that cannot build this type.
+     *  If `ForbiddenHouses != -1`, these houses cannot build it under any circumstances.
+     */
+    long ForbiddenHouses;
 
-        /**
-         *  Description for the extended sidebar tooltip.
-         */
-        char Description[200];
+    /**
+     *  Description for the extended sidebar tooltip.
+     */
+    char Description[200];
 
-        /**
-         *  If this property is set to true, this object will not be selected when band box selecting
-         *  if any objects in the selection have it set to false (e. g., harvesters and MCVs won't be selected with tanks).
-         */
-        bool IsFilterFromBandBoxSelection;
+    /**
+     *  If this property is set to true, this object will not be selected when band box selecting
+     *  if any objects in the selection have it set to false (e. g., harvesters and MCVs won't be selected with tanks).
+     */
+    bool IsFilterFromBandBoxSelection;
 
-        /**
-         *  How many crew members should exit this object when it is destroyed?
-         */
-        int CrewCount;
+    /**
+     *  How many crew members should exit this object when it is destroyed?
+     */
+    int CrewCount;
 
-        /**
-         *  If this is a spawned unit, is it a missile?
-         */
-        bool IsMissileSpawn;
+    /**
+     *  If this is a spawned unit, is it a missile?
+     */
+    bool IsMissileSpawn;
 
-        /**
-         *  If this is a spawner (rocket launcher or aircraft carrier), this is the type of object it spawns.
-         */
-        const AircraftTypeClass* Spawns;
+    /**
+     *  If this is a spawner (rocket launcher or aircraft carrier), this is the type of object it spawns.
+     */
+    const AircraftTypeClass* Spawns;
 
-        /**
-         *  The rate at which this spawner's spawned object reload (how much time it takes before they can attack again).
-         */
-        int SpawnReloadRate;
+    /**
+     *  The rate at which this spawner's spawned object reload (how much time it takes before they can attack again).
+     */
+    int SpawnReloadRate;
 
-        /**
-         *  The rate at which the spawner replenishes its destroyed spawned objects.
-         */
-        int SpawnRegenRate;
+    /**
+     *  The rate at which the spawner replenishes its destroyed spawned objects.
+     */
+    int SpawnRegenRate;
 
-        /**
-         *  The rate at which the spawner spawns objects.
-         */
-        int SpawnSpawnRate;
+    /**
+     *  The rate at which the spawner spawns objects.
+     */
+    int SpawnSpawnRate;
 
-        /**
-         *  The rate at which the spawner processes its logic.
-         */
-        int SpawnLogicRate;
+    /**
+     *  The rate at which the spawner processes its logic.
+     */
+    int SpawnLogicRate;
 
-        /**
-         *  How many objects can this spawner spawn?
-         */
-        int SpawnsNumber;
+    /**
+     *  How many objects can this spawner spawn?
+     */
+    int SpawnsNumber;
 
-        /**
-         *  If it can spawn two missiles at once (like the Boomer submarine), this is an extra offset of the second spawn relative to the first.
-         */
-        TPoint3D<int> SecondSpawnOffset;
+    /**
+     *  If it can spawn two missiles at once (like the Boomer submarine), this is an extra offset of the second spawn relative to the first.
+     */
+    TPoint3D<int> SecondSpawnOffset;
 
-        /**
-         *  If the spawn location is to be randomized, by how much?
-         */
-        int MaxRandomSpawnOffset;
+    /**
+     *  If the spawn location is to be randomized, by how much?
+     */
+    int MaxRandomSpawnOffset;
 
-        /**
-         *  Should this unit not be scored, and its loss be counted in trackers?
-         */
-        bool IsDontScore;
+    /**
+     *  Should this unit not be scored, and its loss be counted in trackers?
+     */
+    bool IsDontScore;
 
-        /**
-         *  Is this meant to be spawned by something else (a spawner, or perhaps, off-map like a paradrop plane)?
-         */
-        bool IsSpawned;
+    /**
+     *  Is this meant to be spawned by something else (a spawner, or perhaps, off-map like a paradrop plane)?
+     */
+    bool IsSpawned;
 
-        /**
-         *  Optional override for the cost that is used for determining the techno's build time.
-         */
-        int BuildTimeCost;
+    /**
+     *  Optional override for the cost that is used for determining the techno's build time.
+     */
+    int BuildTimeCost;
 
-        /**
-         *  Defines how the techno treats targets outside of its zone when scanning for targets.
-         */
-        TargetZoneScanType TargetZoneScan;
+    /**
+     *  Defines how the techno treats targets outside of its zone when scanning for targets.
+     */
+    TargetZoneScanType TargetZoneScan;
 
-        /**
-         *  Does this object need to decloak before firing?
-         */
-        bool IsDecloakToFire;
+    /**
+     *  Does this object need to decloak before firing?
+     */
+    bool IsDecloakToFire;
+
+private:
+    int _JumpjetTurnRate;
+    int _JumpjetSpeed;
+    double _JumpjetClimb;
+    int _JumpjetCruiseHeight;
+    double _JumpjetAcceleration;
+    double _JumpjetWobblesPerSecond;
+    int _JumpjetWobbleDeviation;
+    int _JumpjetCloakDetectionRadius;
+
+public:
+    int Get_Jumpjet_Turn_Rate() const;
+    __declspec(property(get = Get_Jumpjet_Turn_Rate)) int JumpjetTurnRate;
+
+    int Get_Jumpjet_Speed() const;
+    __declspec(property(get = Get_Jumpjet_Speed)) int JumpjetSpeed;
+
+    double Get_Jumpjet_Climb() const;
+    __declspec(property(get = Get_Jumpjet_Climb)) double JumpjetClimb;
+
+    int Get_Jumpjet_Cruise_Height() const;
+    __declspec(property(get = Get_Jumpjet_Cruise_Height)) int JumpjetCruiseHeight;
+
+    double Get_Jumpjet_Acceleration() const;
+    __declspec(property(get = Get_Jumpjet_Acceleration)) double JumpjetAcceleration;
+
+    double Get_Jumpjet_Wobbles_Per_Second() const;
+    __declspec(property(get = Get_Jumpjet_Wobbles_Per_Second)) double JumpjetWobblesPerSecond;
+
+    int Get_Jumpjet_Wobble_Deviation() const;
+    __declspec(property(get = Get_Jumpjet_Wobble_Deviation)) int JumpjetWobbleDeviation;
+
+    int Get_Jumpjet_Cloak_Detection_Radius() const;
+    __declspec(property(get = Get_Jumpjet_Cloak_Detection_Radius)) int JumpjetCloakDetectionRadius;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -274,6 +274,10 @@ public:
     bool IsDecloakToFire;
 
 private:
+
+    /**
+     *  These are backing fields for properties below.
+     */
     int _JumpjetTurnRate;
     int _JumpjetSpeed;
     double _JumpjetClimb;
@@ -284,29 +288,57 @@ private:
     int _JumpjetCloakDetectionRadius;
 
 public:
+
+    /**
+     *  Maximum turning rate of the jumpjet unit.
+     */
     int Get_Jumpjet_Turn_Rate() const;
     __declspec(property(get = Get_Jumpjet_Turn_Rate)) int JumpjetTurnRate;
 
+    /**
+     *  Forward speed of the jumpjet unit.
+     */
     int Get_Jumpjet_Speed() const;
     __declspec(property(get = Get_Jumpjet_Speed)) int JumpjetSpeed;
 
+    /**
+     *  Vertical climb rate of the jumpjet unit.
+     */
     double Get_Jumpjet_Climb() const;
     __declspec(property(get = Get_Jumpjet_Climb)) double JumpjetClimb;
 
+    /**
+     *  Desired cruising height of the jumpjet unit.
+     */
     int Get_Jumpjet_Cruise_Height() const;
     __declspec(property(get = Get_Jumpjet_Cruise_Height)) int JumpjetCruiseHeight;
 
+    /**
+     *  Acceleration of the jumpjet unit when gaining speed.
+     */
     double Get_Jumpjet_Acceleration() const;
     __declspec(property(get = Get_Jumpjet_Acceleration)) double JumpjetAcceleration;
 
+    /**
+     *  Frequency of wobble oscillation per second for jumpjets.
+     */
     double Get_Jumpjet_Wobbles_Per_Second() const;
     __declspec(property(get = Get_Jumpjet_Wobbles_Per_Second)) double JumpjetWobblesPerSecond;
 
+    /**
+     *  Maximum wobble deviation (in leptons) for jumpjet movement.
+     */
     int Get_Jumpjet_Wobble_Deviation() const;
     __declspec(property(get = Get_Jumpjet_Wobble_Deviation)) int JumpjetWobbleDeviation;
 
+    /**
+     *  Radius at which the jumpjet unit can detect cloaked objects.
+     */
     int Get_Jumpjet_Cloak_Detection_Radius() const;
     __declspec(property(get = Get_Jumpjet_Cloak_Detection_Radius)) int JumpjetCloakDetectionRadius;
 
+    /**
+     *  Whether the jumpjet unit doesn't wobble.
+     */
     bool JumpjetNoWobbles;
 };

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -211,7 +211,7 @@ void UnitClassExt::_Draw_Voxel(unsigned int frame, int key, Rect& rect, Point2D&
     if (typeext->WaterAlt
         && Map[Get_Coord()].Land_Type() == LAND_WATER
         && !IsOnBridge
-        && Height < LEVEL_LEPTON_H)
+        && HeightAGL < LEVEL_LEPTON_H)
     {
         voxel = &typeext->WaterVoxel;
         cache = &typeext->WaterVoxelIndex;
@@ -676,7 +676,7 @@ DECLARE_PATCH(_UnitClass_Draw_Shape_Turret_Facing_Patch)
 
     frame_number = 0;
 
-    unittype = reinterpret_cast<UnitTypeClass *>(this_ptr->Techno_Type_Class());
+    unittype = (UnitTypeClass *)this_ptr->Techno_Type_Class();
     
     /**
      *  All turrets have 32 facings in Tiberian Sun.
@@ -850,7 +850,7 @@ DECLARE_PATCH(_UnitClass_Per_Cell_Process_AutoHarvest_Assign_Harvest_Mission_Pat
     /**
      *  Is the unit we are processing a harvester?
      */
-    unittype = reinterpret_cast<UnitTypeClass *>(this_ptr->Class_Of());
+    unittype = (UnitTypeClass *)this_ptr->Class_Of();
     if (unittype->IsToHarvest || unittype->IsToVeinHarvest) {
 
         /**

--- a/src/new/aircrafttracker/aircrafttracker_hooks.cpp
+++ b/src/new/aircrafttracker/aircrafttracker_hooks.cpp
@@ -163,7 +163,7 @@ void FlyLocomotionClassExt::_Take_Off()
             AircraftTracker->Track(LinkedTo);
         }
 
-        if (LinkedTo->Height == 0) {
+        if (LinkedTo->HeightAGL == 0) {
             LinkedTo->PrimaryFacing.Set(LinkedTo->SecondaryFacing.Desired());
         }
 
@@ -202,7 +202,7 @@ DECLARE_PATCH(_FlyLocomotionClass_Movement_AI_AircraftTracker_Patch2)
     AircraftTracker->Untrack(linked_to);
 
     // Stolen instruction
-    linked_to->Height = 0;
+    linked_to->HeightAGL = 0;
 
     JMP(0x0049A087);
 }

--- a/src/new/locomotion/newjumpjetlocomotion.cpp
+++ b/src/new/locomotion/newjumpjetlocomotion.cpp
@@ -77,6 +77,7 @@ IFACEMETHODIMP NewJumpjetLocomotionClass::Link_To_Object(void* object)
     Facing.Set_Desired(DirType(0x4000));
     Facing.Set(DirType(0x4000));
     JumpjetCloakDetectionRadius = type_ext->JumpjetCloakDetectionRadius;
+    JumpjetNoWobbles = type_ext->JumpjetNoWobbles;
     return BASECLASS::Link_To_Object(object);
 }
 
@@ -449,7 +450,7 @@ void NewJumpjetLocomotionClass::Movement_AI()
 
     bool at_destination = LinkedTo->Get_Cell() == HeadToCoord.As_Cell();
 
-    if (CurrentState == HOVERING || CurrentState == CRUISING) {
+    if ((CurrentState == HOVERING || CurrentState == CRUISING) && !JumpjetNoWobbles) {
         CurrentWobble += DEG_TO_RAD(360) / (15.0 / JumpjetWobblesPerSecond);
     } else {
         CurrentWobble = 0;

--- a/src/new/locomotion/newjumpjetlocomotion.cpp
+++ b/src/new/locomotion/newjumpjetlocomotion.cpp
@@ -110,7 +110,10 @@ IFACEMETHODIMP_(bool) NewJumpjetLocomotionClass::Process()
 
         if (IonStorm_Is_Active()) {
             if (CurrentState != GROUNDED) {
-                LinkedTo->Take_Damage(LinkedTo->Strength, 0, Rule->C4Warhead, nullptr, true, true);
+                ResultType result = LinkedTo->Take_Damage(LinkedTo->Strength, 0, Rule->C4Warhead, nullptr, true, true);
+                if (result == RESULT_DESTROYED) {
+                    return false;
+                }
             }
         }
 

--- a/src/new/locomotion/newjumpjetlocomotion.cpp
+++ b/src/new/locomotion/newjumpjetlocomotion.cpp
@@ -25,17 +25,17 @@
  *                 If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#include	"newjumpjetlocomotion.h"
+#include "newjumpjetlocomotion.h"
 
 #include <algorithm>
-#include	<new>
+#include <new>
 
 #include "aircrafttracker.h"
-#include	"rules.h"
-#include	"foot.h"
-#include	"mouse.h"
-#include	"cell.h"
-#include	"building.h"
+#include "rules.h"
+#include "foot.h"
+#include "mouse.h"
+#include "cell.h"
+#include "building.h"
 #include "coord.h"
 #include "extension.h"
 #include "footext.h"

--- a/src/new/locomotion/newjumpjetlocomotion.cpp
+++ b/src/new/locomotion/newjumpjetlocomotion.cpp
@@ -1,0 +1,566 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          NEWJUMPJETLOCOMOTION.CPP
+ *
+ *  @authors       ZivDero, tomsons26
+ *
+ *  @brief         Jumpjet locomotion re-implementation.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include	"newjumpjetlocomotion.h"
+
+#include	<new>
+#include	"rules.h"
+#include	"foot.h"
+#include	"mouse.h"
+#include	"cell.h"
+#include	"building.h"
+#include "coord.h"
+#include "house.h"
+#include "ionstorm.h"
+
+
+NewJumpjetLocomotionClass::NewJumpjetLocomotionClass() :
+    BASECLASS(),
+    HeadToCoord(COORD_NONE),
+    IsMoving(false),
+    CurrentState(GROUNDED),
+    Facing(Rule->JumpjetTurnRate),
+    CurrentSpeed(0.0),
+    TargetSpeed(0.0),
+    FlightLevel(0),
+    CurrentWobble(0.0),
+    IsLanding(false)
+{
+
+}
+
+
+IFACEMETHODIMP_(bool) NewJumpjetLocomotionClass::Is_Moving()
+{
+    return IsMoving;
+}
+
+
+IFACEMETHODIMP_(Coordinate) NewJumpjetLocomotionClass::Destination()
+{
+    if (Is_Moving()) {
+        return HeadToCoord;
+    } else {
+        return COORD_NONE;
+    }
+}
+
+
+IFACEMETHODIMP_(bool) NewJumpjetLocomotionClass::Process()
+{
+    LayerType layer = In_Which_Layer();
+
+    if (Is_Moving() || Is_Moving_Now()) {
+        Movement_AI();
+        if (!LinkedTo->IsActive) {
+            return false;
+        }
+
+        if (IonStorm_Is_Active()) {
+            if (CurrentState != GROUNDED) {
+                LinkedTo->Take_Damage(LinkedTo->Strength, 0, Rule->C4Warhead, nullptr, true, true);
+            }
+        }
+
+        switch (CurrentState) {
+            case GROUNDED:
+                Process_Grounded();
+                break;
+
+            case ASCENDING:
+                Process_Ascent();
+                break;
+
+            case HOVERING:
+                Process_Hover();
+                break;
+
+            case CRUISING:
+                Process_Cruise();
+                break;
+
+            case DESCENDING:
+                Process_Descent();
+                break;
+        }
+
+        if (LinkedTo->IsSelected && LinkedTo->House != PlayerPtr) {
+            if (Map.Is_Shrouded(LinkedTo->PositionCoord) || (Scen->SpecialFlags.IsFogOfWar && Map.Is_Fogged(LinkedTo->PositionCoord))) {
+                LinkedTo->Unselect();
+            }
+        }
+
+        if (!LinkedTo->IsDiscoveredByPlayer && LinkedTo->House != PlayerPtr) {
+            if (!Map.Is_Shrouded(LinkedTo->PositionCoord)) {
+                LinkedTo->Revealed(PlayerPtr);
+            }
+        }
+    }
+
+    if (In_Which_Layer() != layer) {
+        Map.Submit(LinkedTo);
+    }
+
+    return false;
+}
+
+
+IFACEMETHODIMP_(void) NewJumpjetLocomotionClass::Move_To(Coordinate to)
+{
+    if (HeadToCoord != COORD_NONE && CurrentState != GROUNDED && IsLanding) {
+        LinkedTo->Clear_Occupy_Bit(HeadToCoord);
+        IsLanding = false;
+    }
+
+    HeadToCoord = to;
+
+    if (to != COORD_NONE) {
+        Cell cell = Map.Nearby_Location(to.As_Cell(), LinkedTo->TClass->Speed, -1, MZONE_FLYER, Map[to].IsUnderBridge);
+        Coordinate free = Closest_Free_Spot(cell.As_Coord());
+        if (free != COORD_NONE) {
+            HeadToCoord = free;
+            LinkedTo->NavCom = &Map[HeadToCoord];
+            IsMoving = true;
+            if (CurrentState == DESCENDING) {
+                CurrentState = ASCENDING;
+                FlightLevel = Rule->JumpjetCruiseHeight;
+            }
+        }
+    } else {
+        IsMoving = false;
+    }
+}
+
+
+IFACEMETHODIMP_(void) NewJumpjetLocomotionClass::Stop_Moving()
+{
+    if (IsMoving) {
+        if (HeadToCoord != COORD_NONE && CurrentState != GROUNDED && IsLanding) {
+            LinkedTo->Clear_Occupy_Bit(HeadToCoord);
+            IsLanding = false;
+        }
+        Cell cell = LinkedTo->PositionCoord.As_Cell();
+        Cell nearby = Map.Nearby_Location(cell, SPEED_TRACK);
+        if (nearby != CELL_NONE) {
+            Coordinate nearby_coord = nearby.As_Coord();
+            nearby_coord.Z = Map.Get_Height_GL(nearby_coord);
+            if (Map[nearby].IsUnderBridge) {
+                nearby_coord.Z += BRIDGE_LEPTON_HEIGHT;
+            }
+            Move_To(nearby_coord);
+        } else {
+            LinkedTo->Take_Damage(LinkedTo->Strength, 0, Rule->C4Warhead, nullptr, true, true);
+            HeadToCoord = COORD_NONE;
+        }
+    }
+}
+
+
+IFACEMETHODIMP_(void) NewJumpjetLocomotionClass::Do_Turn(DirType Coordinate)
+{
+    LinkedTo->PrimaryFacing.Set(Coordinate);
+}
+
+
+IFACEMETHODIMP_(HRESULT) NewJumpjetLocomotionClass::GetClassID(CLSID * pClassID)
+{
+    if (pClassID == nullptr) {
+        return E_POINTER;
+    }
+
+    *pClassID = __uuidof(this);
+
+    return S_OK;
+}
+
+
+IFACEMETHODIMP_(HRESULT) NewJumpjetLocomotionClass::Load(IStream * stream)
+{
+    HRESULT result = BASECLASS::Locomotion_Load(stream);
+    if (SUCCEEDED(result)) {
+        new (this) NewJumpjetLocomotionClass(NoInitClass());
+    }
+    return result;
+}
+
+
+IFACEMETHODIMP_(LayerType) NewJumpjetLocomotionClass::In_Which_Layer()
+{
+    int height = LinkedTo->HeightAGL;
+    if (!LinkedTo->IsOnBridge) {
+        if (Map[LinkedTo->Get_Coord()].IsUnderBridge && height >= BRIDGE_LEPTON_HEIGHT && !LinkedTo->IsFalling) {
+            height -= BRIDGE_LEPTON_HEIGHT;
+        }
+    }
+
+    if (height == 0) {
+        return LAYER_GROUND;
+    } else if (height < Rule->JumpjetCruiseHeight) {
+        return LAYER_AIR;
+    } else {
+        return LAYER_TOP;
+    }
+}
+
+
+void NewJumpjetLocomotionClass::Process_Grounded()
+{
+    if (Is_Moving()) {
+        LinkedTo->Set_Speed(1.0);
+        Facing.Set(LinkedTo->PrimaryFacing.Current());
+        CurrentSpeed = 0;
+        TargetSpeed = 0;
+        FlightLevel = Rule->JumpjetCruiseHeight;
+        if (!IonStorm_Is_Active()) {
+            CurrentState = ASCENDING;
+        }
+    }
+}
+
+
+void NewJumpjetLocomotionClass::Process_Ascent()
+{
+    int height = LinkedTo->HeightAGL;
+    if (!LinkedTo->IsOnBridge) {
+        if (Map[LinkedTo->Get_Coord()].IsUnderBridge && height >= BRIDGE_LEPTON_HEIGHT) {
+            height -= BRIDGE_LEPTON_HEIGHT;
+        }
+    }
+
+    if (height >= FlightLevel) {
+        CurrentState = HOVERING;
+    } else if (height > FlightLevel / 4) {
+        TargetSpeed = Rule->JumpjetSpeed;
+        Facing.Set_Desired(Direction(LinkedTo->PositionCoord, HeadToCoord));
+    }
+}
+
+
+void NewJumpjetLocomotionClass::Process_Hover()
+{
+    if (Is_Moving()) {
+        Coordinate headto = HeadToCoord;
+        Coordinate position = LinkedTo->PositionCoord;
+        if (Point2D(headto.X, headto.Y) == Point2D(position.X, position.Y)) {
+            if (LinkedTo->TarCom == nullptr) {
+                CurrentState = DESCENDING;
+            }
+        } else {
+            Facing.Set_Desired(Direction(LinkedTo->PositionCoord, HeadToCoord));
+            CurrentState = CRUISING;
+        }
+    }
+}
+
+
+void NewJumpjetLocomotionClass::Process_Cruise()
+{
+    Coordinate position = LinkedTo->PositionCoord;
+    Facing.Set_Desired(Direction(position, HeadToCoord));
+
+    int distance = Point2D(position.X, position.Y).Distance_To(Point2D(HeadToCoord.X, HeadToCoord.Y));
+    if (distance < 20) {
+        CurrentSpeed = 0;
+        TargetSpeed = 0;
+        position.X = HeadToCoord.X;
+        position.Y = HeadToCoord.Y;
+        bool down = LinkedTo->IsDown;
+        LinkedTo->IsDown = false;
+        LinkedTo->Set_Coord(position);
+        LinkedTo->IsDown = down;
+        if (LinkedTo->TarCom == nullptr) {
+            FlightLevel = 0;
+            CurrentState = DESCENDING;
+        } else {
+            CurrentState = HOVERING;
+        }
+    } else if (distance < CELL_LEPTON) {
+        TargetSpeed = Rule->JumpjetSpeed * 0.3;
+        if (LinkedTo->TarCom == nullptr) {
+            FlightLevel = static_cast<int>(Rule->JumpjetCruiseHeight * 0.75);
+        }
+    } else if (distance < CELL_LEPTON * 2) {
+        TargetSpeed = Rule->JumpjetSpeed * 0.5;
+    } else {
+        TargetSpeed = Rule->JumpjetSpeed;
+        FlightLevel = Rule->JumpjetCruiseHeight;
+    }
+}
+
+
+void NewJumpjetLocomotionClass::Process_Descent()
+{
+    CellClass * cellptr = &Map[HeadToCoord];
+    MoveType move = LinkedTo->Can_Enter_Cell(cellptr);
+    int spot = CellClass::Spot_Index(HeadToCoord);
+    bool stop = true;
+
+    if ((cellptr->Is_Spot_Free(spot, cellptr->IsUnderBridge) || IsLanding) &&
+        (Map[HeadToCoord].IsUnderBridge || move <= MOVE_MOVING_BLOCK && (move != MOVE_MOVING_BLOCK || IsLanding))) {
+        
+        if (!IsLanding) {
+            IsLanding = true;
+            LinkedTo->Set_Occupy_Bit(HeadToCoord);
+        }
+
+        FlightLevel = 0;
+
+        int height = LinkedTo->HeightAGL;
+        if (!LinkedTo->IsOnBridge) {
+            if (Map[LinkedTo->Get_Coord()].IsUnderBridge && height >= BRIDGE_LEPTON_HEIGHT) {
+                height -= BRIDGE_LEPTON_HEIGHT;
+            }
+        }
+
+        if (height == 0) {
+            LinkedTo->Set_Speed(0.0);
+            LinkedTo->Mark(MARK_UP);
+            LinkedTo->Set_Coord(HeadToCoord);
+
+            if (LinkedTo->PositionCoord.Z > Map.Get_Height_GL(LinkedTo->PositionCoord)) {
+                if (Map[LinkedTo->Get_Coord()].IsUnderBridge) {
+                    LinkedTo->IsOnBridge = true;
+                }
+            }
+
+            LinkedTo->Mark(MARK_DOWN);
+            HeadToCoord = COORD_NONE;
+            IsMoving = false;
+            LinkedTo->Assign_Destination(nullptr);
+            LinkedTo->Per_Cell_Process(PCP_END);
+
+            if (LinkedTo != nullptr && LinkedTo->IsActive && !LinkedTo->IsInLimbo && !LinkedTo->IsFalling) {
+                LinkedTo->Look();
+                CurrentState = GROUNDED;
+                IsLanding = false;
+            }
+        }
+        stop = false;
+    }
+
+    if (stop) Stop_Moving();
+}
+
+
+IFACEMETHODIMP_(bool) NewJumpjetLocomotionClass::Is_Moving_Now()
+{
+    if (CurrentState != GROUNDED && CurrentState != HOVERING) {
+        return true;
+    }
+    return false;
+}
+
+
+void NewJumpjetLocomotionClass::Movement_AI()
+{
+    bool need_to_mark = CurrentState != HOVERING && CurrentState != CRUISING;
+    bool was_down = LinkedTo->IsDown;
+
+    if (need_to_mark) {
+        LinkedTo->Mark(MARK_UP);
+    } else {
+        LinkedTo->IsDown = false;
+    }
+
+    if (TargetSpeed > CurrentSpeed) {
+        CurrentSpeed += Rule->JumpjetAcceleration;
+        CurrentSpeed = std::min(CurrentSpeed, static_cast<double>(Rule->JumpjetSpeed));
+    }
+    if (TargetSpeed < CurrentSpeed) {
+        CurrentSpeed -= Rule->JumpjetAcceleration * 1.5;
+        CurrentSpeed = std::max(CurrentSpeed, 0.0);
+    }
+
+    LinkedTo->Set_Speed(CurrentSpeed / Rule->JumpjetSpeed);
+
+    bool at_destination = LinkedTo->Get_Cell() == HeadToCoord.As_Cell();
+
+    if (CurrentState == HOVERING || CurrentState == CRUISING) {
+        CurrentWobble += DEG_TO_RAD(360) / (15.0 / Rule->JumpjetWobblesPerSecond);
+    } else {
+        CurrentWobble = 0;
+    }
+
+    int desired_height = std::sin(CurrentWobble) * Rule->JumpjetWobbleDeviation + FlightLevel;
+    int height = LinkedTo->Height;
+    int ground_height = Map.Get_Height_GL(LinkedTo->PositionCoord);
+
+    if (Map[LinkedTo->Get_Coord()].IsUnderBridge && LinkedTo->PositionCoord.Z >= ground_height + 4 * LEVEL_LEPTON_H) {
+        ground_height += BRIDGE_LEPTON_HEIGHT;
+    }
+
+    int height_diff = 0;
+    if (CurrentState != DESCENDING && CurrentState != GROUNDED && !at_destination) {
+        height_diff = height - Desired_Flight_Level();
+    } else {
+        height_diff = height - ground_height;
+    }
+
+    bool moved = false;
+    if (height_diff < desired_height) {
+        int height_agl = LinkedTo->HeightAGL;
+        if (Map[LinkedTo->Get_Coord()].IsUnderBridge && !LinkedTo->IsOnBridge) {
+            if (LinkedTo->PositionCoord.Z >= Map.Get_Height_GL(LinkedTo->PositionCoord) + BRIDGE_LEPTON_HEIGHT) {
+                height_agl -= BRIDGE_LEPTON_HEIGHT;
+            }
+        }
+        if (height_agl == 0) {
+            LinkedTo->Clear_Occupy_Bit(LinkedTo->PositionCoord);
+            LinkedTo->IsOnBridge = false;
+        }
+        height += Rule->JumpjetClimb;
+        moved = true;
+    }
+    if (height_diff > desired_height) {
+        height -= Rule->JumpjetClimb;
+        if (height <= ground_height) {
+            height = ground_height;
+        }
+        moved = true;
+        height_diff = std::max(height_diff, 0);
+    }
+
+    if (LinkedTo->Get_Cell() != HeadToCoord.As_Cell()) {
+        if (height_diff < desired_height / 2) {
+            CurrentSpeed *= 0.9;
+        }
+        if (height_diff < desired_height / 4) {
+            CurrentSpeed *= 0.9;
+        }
+    }
+
+    if (moved) {
+        LinkedTo->Height = height;
+        if (need_to_mark) {
+            LinkedTo->Mark(MARK_UP);
+        }
+    }
+
+    Coordinate new_coord = Coord_Move(LinkedTo->PositionCoord, Facing.Current(), CurrentSpeed);
+    LinkedTo->Set_Coord(new_coord);
+
+    if (LinkedTo != nullptr) {
+        const int & rad = Rule->JumpjetCloakDetectionRadius;
+        for (int x = -rad; x <= rad; x++) {
+            for (int y = -rad; y <= rad; y++) {
+                CellClass * cellptr = &Map[Cell(x, y) + new_coord.As_Cell()];
+                if (cellptr != nullptr) {
+                    ObjectClass * occupier = cellptr->Cell_Occupier(false);
+                    while (occupier != nullptr) {
+                        TechnoClass * tech = dynamic_cast<TechnoClass *>(occupier);
+                        if (tech != nullptr) {
+                            tech->Do_Shimmer();
+                        }
+                        occupier = occupier->Next;
+                    }
+                    occupier = cellptr->Cell_Occupier(true);
+                    while (occupier != nullptr) {
+                        TechnoClass * tech = dynamic_cast<TechnoClass *>(occupier);
+                        if (tech != nullptr) {
+                            tech->Do_Shimmer();
+                        }
+                        occupier = occupier->Next;
+                    }
+                }
+            }
+        }
+    }
+
+    CellClass * cellptr = &Map[new_coord];
+    BuildingClass * building = cellptr->Cell_Building();
+    if (building && building->Class->IsFirestormWall && building->House->IsFirestormActive) {
+        building->Crossing_Firestorm(LinkedTo, true);
+    }
+
+    LinkedTo->PrimaryFacing.Set(Facing.Current());
+
+    if (need_to_mark) {
+        LinkedTo->Mark(MARK_DOWN);
+    } else {
+        LinkedTo->IsDown = was_down;
+    }
+}
+
+
+Coordinate NewJumpjetLocomotionClass::Closest_Free_Spot(Coordinate const & to) const
+{
+    Coordinate closest = Map.Closest_Free_Spot(to);
+    if (closest != COORD_NONE) {
+        closest.Z = Map.Get_Height_GL(closest);
+        if (Map[closest].IsUnderBridge) {
+            closest.Z += BRIDGE_LEPTON_HEIGHT;
+        }
+    }
+    return closest;
+}
+
+
+int NewJumpjetLocomotionClass::Desired_Flight_Level() const
+{
+    Coordinate Coordinate = LinkedTo->PositionCoord;
+
+    int height = Map[Coordinate].Occupier_Height();
+    if (Map[Coordinate].IsUnderBridge) {
+        height += BRIDGE_LEPTON_HEIGHT;
+    }
+
+    if (CurrentSpeed > 0) {
+        Coordinate = Adjacent_Cell(Coordinate, static_cast<FacingType>(Facing.Current().Get_Facing<8>()));
+        int adjancent_height = Map[Coordinate].Occupier_Height();
+        if (Map[Coordinate].IsUnderBridge) {
+            height += BRIDGE_LEPTON_HEIGHT;
+        }
+        if (adjancent_height > height) {
+            return adjancent_height;
+        }
+        return(height + adjancent_height) / 2;
+    }
+    return height;
+}
+
+
+IFACEMETHODIMP_(void) NewJumpjetLocomotionClass::Mark_All_Occupation_Bits(MarkType mark)
+{
+    if (mark == MARK_UP) {
+        Coordinate headto = Head_To_Coord();
+        if (headto != COORD_NONE && (CurrentState == GROUNDED || IsLanding)) {
+            LinkedTo->Clear_Occupy_Bit(headto);
+            IsLanding = false;
+        }
+    }
+}
+
+
+IFACEMETHODIMP_(Coordinate) NewJumpjetLocomotionClass::Head_To_Coord()
+{
+    if (CurrentState == GROUNDED) {
+        return LinkedTo->Get_Coord();
+    } else {
+        return HeadToCoord;
+    }
+}
+

--- a/src/new/locomotion/newjumpjetlocomotion.h
+++ b/src/new/locomotion/newjumpjetlocomotion.h
@@ -96,6 +96,7 @@ NewJumpjetLocomotionClass : public LocomotionClass
         double JumpjetAcceleration;
         double JumpjetWobblesPerSecond;
         int JumpjetWobbleDeviation;
+        bool JumpjetNoWobbles;
         int JumpjetCloakDetectionRadius;
 
         Coordinate HeadToCoord;

--- a/src/new/locomotion/newjumpjetlocomotion.h
+++ b/src/new/locomotion/newjumpjetlocomotion.h
@@ -89,18 +89,69 @@ NewJumpjetLocomotionClass : public LocomotionClass
         int Desired_Flight_Level() const;
 
     private:
+        /**
+         *  Turn rate of the jumpjet unit.
+         */
         int JumpjetTurnRate;
+
+        /**
+         *  Maximum forward speed of the jumpjet unit in leptons per tick.
+         */
         int JumpjetSpeed;
+
+        /**
+         *  Vertical climb rate per tick for jumpjet ascent and descent.
+         */
         double JumpjetClimb;
+
+        /**
+         *  Desired cruising height (in leptons) for the jumpjet unit.
+         */
         int JumpjetCruiseHeight;
+
+        /**
+         *  Acceleration applied when changing the jumpjet's movement speed.
+         */
         double JumpjetAcceleration;
+
+        /**
+         *  Frequency in Hz of the jumpjet's wobble effect while flying.
+         */
         double JumpjetWobblesPerSecond;
+
+        /**
+         *  Maximum deviation of jumpjet vertical wobble (in leptons).
+         */
         int JumpjetWobbleDeviation;
+
+        /**
+         *  Whether this jumpjet unit doesn't wobble during flight.
+         */
         bool JumpjetNoWobbles;
+
+        /**
+         *  Radius (in cells) within which the jumpjet can detect cloaked units.
+         */
         int JumpjetCloakDetectionRadius;
 
+        /**
+         *  The destination coordinate the jumpjet is moving toward.
+         */
         Coordinate HeadToCoord;
+
+        /**
+         *  Indicates whether the jumpjet is currently moving toward a target.
+         */
         bool IsMoving;
+
+        /**
+         *  Represents the current flight state of the jumpjet.
+         *  - GROUNDED: Landed and idle
+         *  - ASCENDING: Taking off
+         *  - HOVERING: Stationary at cruise height
+         *  - CRUISING: Moving toward destination at cruise height
+         *  - DESCENDING: Attempting to land
+         */
         enum {
             GROUNDED,
             ASCENDING,
@@ -108,10 +159,34 @@ NewJumpjetLocomotionClass : public LocomotionClass
             CRUISING,
             DESCENDING
         } CurrentState;
+
+        /**
+         *  Current facing direction of the jumpjet.
+         */
         FacingClass Facing;
+
+        /**
+         *  Current movement speed of the jumpjet, in leptons per tick.
+         */
         double CurrentSpeed;
+
+        /**
+         *  Desired speed the jumpjet is accelerating or decelerating toward.
+         */
         double TargetSpeed;
+
+        /**
+         *  Desired height above ground level for the jumpjet during cruise.
+         */
         int FlightLevel;
+
+        /**
+         *  Phase value used to compute wobble displacement during flight.
+         */
         double CurrentWobble;
+
+        /**
+         *  Indicates whether the jumpjet is currently in the process of landing.
+         */
         bool IsLanding;
 };

--- a/src/new/locomotion/newjumpjetlocomotion.h
+++ b/src/new/locomotion/newjumpjetlocomotion.h
@@ -52,6 +52,7 @@ NewJumpjetLocomotionClass : public LocomotionClass
         /**
          *  ILocomotion methods.
          */
+        IFACEMETHOD(Link_To_Object)(void* object);
         IFACEMETHOD_(bool, Is_Moving)() override;
         IFACEMETHOD_(Coordinate, Destination)() override;
         IFACEMETHOD_(Coordinate, Head_To_Coord)() override;
@@ -88,6 +89,15 @@ NewJumpjetLocomotionClass : public LocomotionClass
         int Desired_Flight_Level() const;
 
     private:
+        int JumpjetTurnRate;
+        int JumpjetSpeed;
+        double JumpjetClimb;
+        int JumpjetCruiseHeight;
+        double JumpjetAcceleration;
+        double JumpjetWobblesPerSecond;
+        int JumpjetWobbleDeviation;
+        int JumpjetCloakDetectionRadius;
+
         Coordinate HeadToCoord;
         bool IsMoving;
         enum {

--- a/src/new/locomotion/newjumpjetlocomotion.h
+++ b/src/new/locomotion/newjumpjetlocomotion.h
@@ -1,0 +1,106 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          NEWJUMPJETLOCOMOTION.H
+ *
+ *  @authors       ZivDero, tomsons26
+ *
+ *  @brief         Jumpjet locomotion re-implementation.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "locomotion.h"
+#include "facing.h"
+#include "vinifera_defines.h"
+
+
+class DECLSPEC_UUID(CLSID_NEWJUMPJET_LOCOMOTOR)
+NewJumpjetLocomotionClass : public LocomotionClass
+{
+        typedef LocomotionClass BASECLASS;
+
+    public:
+
+        /**
+         *  IPersist methods.
+         */
+        IFACEMETHOD_(HRESULT, GetClassID)(CLSID * retval) override;
+
+        /**
+         *  IPersistStream methods.
+         */
+        IFACEMETHOD_(HRESULT, Load)(IStream * stream) override;
+        
+        /**
+         *  ILocomotion methods.
+         */
+        IFACEMETHOD_(bool, Is_Moving)() override;
+        IFACEMETHOD_(Coordinate, Destination)() override;
+        IFACEMETHOD_(Coordinate, Head_To_Coord)() override;
+        IFACEMETHOD_(bool, Process)() override;
+        IFACEMETHOD_(void, Move_To)(Coordinate to) override;
+        IFACEMETHOD_(void, Stop_Moving)() override;
+        IFACEMETHOD_(void, Do_Turn)(DirType coord) override;
+        IFACEMETHOD_(LayerType, In_Which_Layer)() override;
+        IFACEMETHOD_(bool, Is_Moving_Now)() override;
+        IFACEMETHOD_(void, Mark_All_Occupation_Bits)(MarkType mark) override;
+
+        /**
+         *  LocomotionClass methods.
+         */
+        virtual int Get_Object_Size(bool oldsave = false) const override {return sizeof(*this);}
+
+        /**
+         *  Constructors, Destructors, and overloaded operators.
+         */
+        NewJumpjetLocomotionClass();
+        NewJumpjetLocomotionClass(NoInitClass const & x) : BASECLASS(x), Facing(x) {}
+        virtual ~NewJumpjetLocomotionClass() override = default;
+
+        /**
+         *  Member function prototypes.
+         */
+        void Process_Grounded();
+        void Process_Ascent();
+        void Process_Hover();
+        void Process_Cruise();
+        void Process_Descent();
+        void Movement_AI();
+        Coordinate Closest_Free_Spot(Coordinate const & to) const;
+        int Desired_Flight_Level() const;
+
+    private:
+        Coordinate HeadToCoord;
+        bool IsMoving;
+        enum {
+            GROUNDED,
+            ASCENDING,
+            HOVERING,
+            CRUISING,
+            DESCENDING
+        } CurrentState;
+        FacingClass Facing;
+        double CurrentSpeed;
+        double TargetSpeed;
+        int FlightLevel;
+        double CurrentWobble;
+        bool IsLanding;
+};

--- a/src/new/locomotion/rocketlocomotion.cpp
+++ b/src/new/locomotion/rocketlocomotion.cpp
@@ -305,7 +305,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
              *  If the rocket has reached its cruising altitude, proceed to flight.
              *  Save the distance to the destination for lazy curve rockets.
              */
-            if (LinkedTo->Height >= rocket->Altitude)
+            if (LinkedTo->HeightAGL >= rocket->Altitude)
             {
                 MissionState = RocketMissionState::Flight;
                 Coordinate center_coord = LinkedTo->Center_Coord();
@@ -322,7 +322,7 @@ IFACEMETHODIMP_(bool) RocketLocomotionClass::Process()
             /**
              *  Check if we're still above ground. If not, explode.
              */
-            if (LinkedTo->Height > 0)
+            if (LinkedTo->HeightAGL > 0)
             {
                 /**
                  *  Keep accelerating towards the maximum speed.
@@ -670,7 +670,7 @@ bool RocketLocomotionClass::Time_To_Explode(const RocketTypeClass* rocket)
             /**
              *  Nope, too early.
              */
-            if (LinkedTo->Height > 0)
+            if (LinkedTo->HeightAGL > 0)
                 return false;
         }
     }

--- a/src/new/locomotion/rocketlocomotion.h
+++ b/src/new/locomotion/rocketlocomotion.h
@@ -6,7 +6,7 @@
  *
  *  @file          ROCKETLOCOMOTION.H
  *
- *  @authors       CCHyper
+ *  @authors       ZivDero
  *
  *  @brief         Rocket locomotion implementation.
  *
@@ -53,25 +53,25 @@ public:
     /**
      *  IPersist
      */
-    IFACEMETHOD(GetClassID)(CLSID* pClassID);
+    IFACEMETHOD(GetClassID)(CLSID* pClassID) override;
 
     /**
      *  IPersistStream
      */
-    IFACEMETHOD(Load)(IStream* pStm);
+    IFACEMETHOD(Load)(IStream* pStm) override;
 
     /**
      *  ILocomotion
      */
-    IFACEMETHOD_(bool, Is_Moving)();
-    IFACEMETHOD_(Coordinate, Destination)();
-    IFACEMETHOD_(Matrix3D, Draw_Matrix)(int *key);
-    IFACEMETHOD_(Point2D, Shadow_Point)();
-    IFACEMETHOD_(bool, Process)();
-    IFACEMETHOD_(void, Move_To)(Coordinate to);
-    IFACEMETHOD_(void, Stop_Moving)();
-    IFACEMETHOD_(LayerType, In_Which_Layer)();
-    IFACEMETHOD_(bool, Is_Moving_Now)();
+    IFACEMETHOD_(bool, Is_Moving)() override;
+    IFACEMETHOD_(Coordinate, Destination)() override;
+    IFACEMETHOD_(Matrix3D, Draw_Matrix)(int *key) override;
+    IFACEMETHOD_(Point2D, Shadow_Point)() override;
+    IFACEMETHOD_(bool, Process)() override;
+    IFACEMETHOD_(void, Move_To)(Coordinate to) override;
+    IFACEMETHOD_(void, Stop_Moving)() override;
+    IFACEMETHOD_(LayerType, In_Which_Layer)() override;
+    IFACEMETHOD_(bool, Is_Moving_Now)() override;
 
     RocketLocomotionClass();
     ~RocketLocomotionClass() override = default;

--- a/src/vinifera/vinifera_defines.h
+++ b/src/vinifera/vinifera_defines.h
@@ -60,6 +60,7 @@
  */
 #define CLSID_TEST_LOCOMOTOR                "501DEF92-C7ED-448E-8FEB-7908DCE73377"
 #define CLSID_ROCKET_LOCOMOTOR              "B7B49766-E576-11d3-9BD9-00104B972FE8"
+#define CLSID_NEWJUMPJET_LOCOMOTOR          "92612C46-F71F-11D1-AC9F-006008055BB5" // This is the same as vanilla JumpjetLocomotion. This way, we silently replace it.
 
 
 /**

--- a/src/vinifera/vinifera_functions.cpp
+++ b/src/vinifera/vinifera_functions.cpp
@@ -60,6 +60,7 @@
 
 #include "aircrafttracker.h"
 #include "rocketlocomotion.h"
+#include "newjumpjetlocomotion.h"
 #include "setup_hooks.h"
 
 
@@ -843,6 +844,7 @@ bool Vinifera_Register_Com_Objects()
      */
     REGISTER_CLASS(TestLocomotionClass);
     REGISTER_CLASS(RocketLocomotionClass);
+    REGISTER_CLASS(NewJumpjetLocomotionClass);
 
     /**
      *  New types.

--- a/src/vinifera/vinifera_hooks.cpp
+++ b/src/vinifera/vinifera_hooks.cpp
@@ -891,4 +891,6 @@ void Vinifera_Hooks()
     //Patch_Call(0x005D6BEC, &_On_Load_Clear_Scenario_Intercept); // Load_All
 
     Patch_Jump(0x004FCD70, &LayerClassExt::_Submit);
+
+    Patch_Jump(0x00600A6D, 0x00600AAA); // Skip registering vanilla JumpjetLocomotionClass in WinMain
 }


### PR DESCRIPTION
- This PR allows customizing Jumpjet properties per unit.

In `RULES.INI`:
```ini
[SOMETECHNO]                 ; TechnoType
JumpjetTurnRate=             ; integer, maximum turning rate of the jumpjet unit, defaults to [JumpjetControls]->TurnRate.
JumpjetSpeed=                ; integer, forward speed of the jumpjet unit, defaults to [JumpjetControls]->Speed.
JumpjetClimb=                ; float, vertical climb rate of the jumpjet unit, defaults to [JumpjetControls]->Climb.
JumpjetCruiseHeight=         ; integer, desired cruising height of the jumpjet unit, defaults to [JumpjetControls]->CruiseHeight.
JumpjetAcceleration=         ; float, acceleration of the jumpjet unit when gaining speed, defaults to [JumpjetControls]->Acceleration.
JumpjetWobblesPerSecond=     ; float, frequency of wobble oscillation per second for jumpjets, defaults to [JumpjetControls]->WobblesPerSecond.
JumpjetWobbleDeviation=      ; integer, maximum wobble deviation (in leptons) for jumpjet movement, defaults to [JumpjetControls]->WobbleDeviation.
JumpjetCloakDetectionRadius= ; integer, radius (in cells) at which the jumpjet unit can detect cloaked objects, defaults to [JumpjetControls]->CloakDetectionRadius.
```

- Additionally, you can now turn off wobbles for a given unit.

In `RULES.INI`:
```ini
[SOMETECHNO]            ; TechnoType
JumpjetNoWobbles=false  ; boolean, whether the jumpjet unit doesn't wobble.
```


Resolves #484, partially addresses #1189, resolves #75