### PR TITLE
Implement OpportunityFire

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -248,3 +248,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix a crash when a Jumpjet infantry is flying or trying to take off just when an Ion Storm starts.
   - Allow up to 65535 OverlayTypes in maps using `NewINIFormat=5`.
   - Implement naval yards.
+  - Implement `OpportunityFire`.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1100,6 +1100,16 @@ MultipleFactoryCap=0                   ; integer, the maximum number of factorie
 While the default value for `WorstLowPowerBuildRateCoefficient` is `0.5`, vanilla `RULES.INI` contains a value of `0.3`. To address this, when reading unmodified `RULES.INI`, the value will be changed to `0.5`. For modified `RULES.INI` files, please make sure to adjust the value.
 ```
 
+### OpportunityFire
+
+- The `OpportunityFire` key has been backported from Red Alert 2, and controls whether this unit can fire whilst performing other actions (e.g. moving). For further details, see the article on [ModEnc²](https://modenc2.markjfox.net/OpportunityFire).
+
+In `RULES.INI`:
+```ini
+[SOMETECHNO]        ; TechnoType
+OpportunityFire=no  ; boolean, can this unit fire whilst performing other actions?
+```
+
 ## Terrain
 
 ### Light Sources

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -186,13 +186,14 @@ New:
 - Add `HideDuringSpecialAnim` for buildings (by ZivDero)
 - Add `RoofDeployingAnim` and `UnderRoofDoorAnim` for buildings (by ZivDero)
 - Implement Jumpjet Locomotion improvements (by ZivDero, tomsons26)
-- Allow up to 65535 OverlayTypes in maps using `NewINIFormat=5` (by ZivDero)
+- Allow up to 65535 `OverlayTypes` in maps using `NewINIFormat=5` (by ZivDero)
 - Implement naval yards (by ZivDero, CCHyper, Rampastring)
 - Implement exclusive factories (by ZivDero)
-- Change the behavior MultipleFactory and implements build speed overrides (by CCHyper)
+- Change the behavior `MultipleFactory` and implement build speed overrides (by CCHyper)
 - Implement `StopSound` for `AnimTypes` and `VoxelAnimTypes` (by CCHyper)
-- Implement 'OmniFire' for WeaponTypes (by CCHyper)
-- Implement MeteorShowerCommandClass and MeteorImpactCommandClass (by CCHyper)
+- Implement 'OmniFire' for `WeaponTypes` (by CCHyper)
+- Implement `MeteorShowerCommandClass` and `MeteorImpactCommandClass` (by CCHyper)
+- Implement `OpportunityFire` (by ZivDero)
 
 
 Vanilla fixes:

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -556,6 +556,11 @@ int TechnoClassExtension::Time_To_Build() const
 }
 
 
+/**
+ *  Can this unit opportunity fire?
+ *
+ *  @author: ZivDero
+ */
 bool TechnoClassExtension::Can_Opportunity_Fire() const
 {
     if (This()->TarCom != nullptr && !This()->House->Is_Human_Player() && This()->Is_Foot()) {
@@ -577,6 +582,11 @@ bool TechnoClassExtension::Can_Opportunity_Fire() const
 }
 
 
+/**
+ *  Perform opportunity fire.
+ *
+ *  @author: ZivDero
+ */
 bool TechnoClassExtension::Opportunity_Fire()
 {
     if (Can_Opportunity_Fire()) {

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -440,6 +440,8 @@ bool TechnoClassExtension::Can_Passive_Acquire() const
          */
         return Techno_Type_Class_Ext()->IsCanPassiveAcquire;
     }
+
+    return false;
 }
 
 

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -97,7 +97,13 @@ class TechnoClassExtension : public RadioClassExtension
          */
         TechnoClass* SpawnOwner;
 
+        /**
+         *  Is this object's current target an opportunity fire target?
+         */
         bool HasOpportunityFireTarget;
 
+        /**
+         *  When has this unit last received a target? (not comprehensive)
+         */
         int LastTargetFrame;
 };

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -69,6 +69,8 @@ class TechnoClassExtension : public RadioClassExtension
         void Put_Storage_Pointers();
 
         int Time_To_Build() const;
+        bool Can_Opportunity_Fire() const;
+        bool Opportunity_Fire();
 
     private:
         const TechnoTypeClass *Techno_Type_Class() const;
@@ -94,4 +96,8 @@ class TechnoClassExtension : public RadioClassExtension
          *  The object that spawned this object.
          */
         TechnoClass* SpawnOwner;
+
+        bool HasOpportunityFireTarget;
+
+        int LastTargetFrame;
 };

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1330,6 +1330,11 @@ int TechnoClassExt::_Time_To_Build() const
 }
 
 
+/**
+ *  Reimplementation of TechnoClass::Assign_Target.
+ *
+ *  @author: ZivDero
+ */
 void TechnoClassExt::_Assign_Target(AbstractClass* target)
 {
     Extension::Fetch(this)->HasOpportunityFireTarget = false;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -122,6 +122,7 @@ public:
     Coordinate _Fire_Coord(WeaponSlotType which) const;
     void _Record_The_Kill(TechnoClass* source);
     int _Time_To_Build() const;
+    void _Assign_Target(AbstractClass * target);
 };
 
 
@@ -526,30 +527,26 @@ bool TechnoClassExt::_Spawner_Fire_At(AbstractClass * target, WeaponTypeClass* w
  */
 bool TechnoClassExt::_Target_Something_Nearby(Coordinate& coord, ThreatType threat)
 {
+    auto extension = Extension::Fetch(this);
+
+    extension->LastTargetFrame = Frame;
+
     /**
      *  Determine that if there is an existing target it is still legal
      *  and within range.
      */
-    if (Target_Legal(TarCom))
-    {
-        // This bit is roughly ported from YR but is missing `ShouldLoseTargetNow`
-        if (threat & THREAT_RANGE)
-        {
-            WeaponSlotType primary = What_Weapon_Should_I_Use(TarCom);
-            FireErrorType fire = Can_Fire(TarCom, primary);
+    if (TarCom != nullptr && extension->HasOpportunityFireTarget) {
+        WeaponSlotType primary = What_Weapon_Should_I_Use(TarCom);
+        FireErrorType fire = Can_Fire(TarCom, primary);
 
-            if (fire == FIRE_CANT)
-            {
-                SpawnManagerClass* spawn_manager = Extension::Fetch(this)->SpawnManager;
-                if (spawn_manager)
-                    spawn_manager->Abandon_Target();
+        if (fire == FIRE_CANT) {
+            if (extension->SpawnManager) {
+                extension->SpawnManager->Abandon_Target();
+            }
+            Assign_Target(nullptr);
 
-                Assign_Target(nullptr);
-            }
-            else if (fire == FIRE_ILLEGAL || fire == FIRE_RANGE)
-            {
-                Assign_Target(nullptr);
-            }
+        } else if (fire == FIRE_ILLEGAL || fire == FIRE_RANGE) {
+            Assign_Target(nullptr);
         }
     }
 
@@ -592,22 +589,45 @@ void TechnoClassExt::_Stun()
 
 
 /**
- *  Wrapper function to patch the call in TechnoClass::AI to call
- *  SpawnManagerClass::AI.
+ *  Wrapper function around MissionClass::AI call in TechnoClass::AI
+ *  to conveniently insert code.
  *
  *  @author: ZivDero
  */
 void TechnoClassExt::_Mission_AI()
 {
-    MissionClass::AI();
-
-    if (!IsActive)
-        return;
-
     const auto extension = Extension::Fetch(this);
 
-    if (extension->SpawnManager)
+    if (TarCom != nullptr && extension->HasOpportunityFireTarget) {
+        if (CurrentMission == MISSION_SLEEP ||
+            CurrentMission == MISSION_ENTER ||
+            CurrentMission == MISSION_STOP ||
+            CurrentMission == MISSION_AMBUSH ||
+            CurrentMission == MISSION_UNLOAD ||
+            CurrentMission == MISSION_CONSTRUCTION ||
+            CurrentMission == MISSION_DECONSTRUCTION ||
+            CurrentMission == MISSION_REPAIR ||
+            CurrentMission == MISSION_MISSILE ||
+            CurrentMission == MISSION_HARMLESS ||
+            CurrentMission == MISSION_OPEN) {
+
+            Assign_Target(nullptr);
+        }
+    }
+
+    MissionClass::AI();
+
+    if (!IsActive) {
+        return;
+    }
+
+    if (CurrentMission == MISSION_MOVE || CurrentMission == MISSION_HARVEST || CurrentMission == MISSION_GUARD) {
+        extension->Opportunity_Fire();
+    }
+
+    if (extension->SpawnManager) {
         extension->SpawnManager->AI();
+    }
 }
 
 
@@ -1307,6 +1327,44 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
 int TechnoClassExt::_Time_To_Build() const
 {
     return Extension::Fetch(this)->Time_To_Build();
+}
+
+
+void TechnoClassExt::_Assign_Target(AbstractClass* target)
+{
+    Extension::Fetch(this)->HasOpportunityFireTarget = false;
+
+    if (target == TarCom) return;
+
+    if (target == nullptr) {
+        target = nullptr;
+    } else {
+
+        /*
+        **  Prevent targeting of self.
+        */
+        if (target == this) {
+            target = &Map[PositionCoord];
+        } else {
+
+            /*
+            **  Make sure that the target is not already dead.
+            */
+            ObjectClass* object = dynamic_cast<ObjectClass*>(target);
+            if (object != nullptr && (object->IsActive == false || object->Strength == 0)) {
+                target = nullptr;
+            }
+        }
+    }
+
+    /*
+    **  Set the unit's targeting computer.
+    */
+    TarCom = target;
+
+    if (target == nullptr) {
+        CurrentBurstIndex = 0;
+    }
 }
 
 
@@ -2716,4 +2774,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x00633745, (uintptr_t)0x00633762); // Do not trigger "Discovered by Player" when an object is destroyed
     Patch_Jump(0x0062D218, &_TechnoClass_Evaluate_Object_Zone_Evaluation_TargetZoneScanType_Patch);
     Patch_Jump(0x0062A970, &TechnoClassExt::_Time_To_Build);
+    Patch_Jump(0x0062FD70, &TechnoClassExt::_Assign_Target);
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -428,7 +428,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsNaval = ini.Get_Bool(ini_name, "Naval", IsNaval);
 
     BuiltAt = TGet_TypeList(ini, ini_name, "BuiltAt", BuiltAt);
-    IsOpportunityFire = ini.Get_Bool(ini_name, "IsOpportunityFire", IsOpportunityFire);
+    IsOpportunityFire = ini.Get_Bool(ini_name, "OpportunityFire", IsOpportunityFire);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -103,7 +103,8 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     JumpjetNoWobbles(false),
     IsNaval(false),
     BuiltAt(),
-    BuildTimeMultiplier(1.0f)
+    BuildTimeMultiplier(1.0f),
+    IsOpportunityFire(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -290,6 +291,7 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(JumpjetNoWobbles);
     crc(IsNaval);
     crc(BuiltAt.Count());
+    crc(IsOpportunityFire);
 }
 
 
@@ -426,6 +428,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsNaval = ini.Get_Bool(ini_name, "Naval", IsNaval);
 
     BuiltAt = TGet_TypeList(ini, ini_name, "BuiltAt", BuiltAt);
+    IsOpportunityFire = ini.Get_Bool(ini_name, "IsOpportunityFire", IsOpportunityFire);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -361,5 +361,8 @@ public:
      */
     float BuildTimeMultiplier;
 
+    /**
+     *  Can this object pick up targets withing its range automatically (opportunity fire)?
+     */
     bool IsOpportunityFire;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -362,7 +362,7 @@ public:
     float BuildTimeMultiplier;
 
     /**
-     *  Can this object pick up targets withing its range automatically (opportunity fire)?
+     *  Can this object pick up targets within its range automatically (opportunity fire)?
      */
     bool IsOpportunityFire;
 };

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -360,4 +360,6 @@ public:
      *  This is an individual control of the build time for this object.
      */
     float BuildTimeMultiplier;
+
+    bool IsOpportunityFire;
 };


### PR DESCRIPTION
### OpportunityFire

- The `OpportunityFire` key has been backported from Red Alert 2, and controls whether this unit can fire whilst performing other actions (e.g. moving). For further details, see the article on [ModEnc²](https://modenc2.markjfox.net/OpportunityFire).

In `RULES.INI`:
```ini
[SOMETECHNO]        ; TechnoType
OpportunityFire=no  ; boolean, can this unit fire whilst performing other actions?
```