### PR TITLE
Fix being able to reset burst by halting the unit

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -252,3 +252,4 @@ This page lists all the individual contributions to the project by their author.
   - Implement prerequisite groups.
   - Fix a bug where upgrades did not always work properly as prerequisites.
   - Fix a bug where upgrades did not work as `AuxBuilding` on Super Weapons.
+  - Fix a bug where you could use a stop command to reset a unit's burst.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -72,3 +72,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Add the "Underground" layer to the tactical display Next and Prev search.
 - Fix a bug where upgrades did not always work properly as prerequisites.
 - Fix a bug where upgrades did not work as `AuxBuilding` on Super Weapons.
+- Fix a bug where you could use a stop command to reset a unit's burst.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -270,6 +270,7 @@ Vanilla fixes:
 - Add the "Underground" layer to the tactical display Next and Prev search (by CCHyper)
 - Fix a bug where upgrades did not always work properly as prerequisites (by ZivDero)
 - Fix a bug where upgrades did not work as `AuxBuilding` on Super Weapons (by ZivDero)
+- Fix a bug where you could use a stop command to reset a unit's burst (by ZivDero)
 
 :::
 

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -621,7 +621,7 @@ Coordinate TechnoClassExtension::Fire_Coord(WeaponSlotType which, TPoint3D<int> 
     const TPoint3D<int> flh = weaponinfo->FireFLH + offset;
 
     const float trans_x = static_cast<float>(flh.X + ttype->TurretOffset);
-    const float trans_y = static_cast<float>(flh.Y * (This()->CurrentBurstIndex % 2 == 0 ? 1 : -1));
+    const float trans_y = static_cast<float>(flh.Y * (This()->BurstIndex % 2 == 0 ? 1 : -1));
     const float trans_z = static_cast<float>(flh.Z + weaponinfo->BarrelThickness);
     matrix.Translate(trans_x, trans_y, trans_z);
 

--- a/src/extensions/techno/technoext.h
+++ b/src/extensions/techno/technoext.h
@@ -106,4 +106,14 @@ class TechnoClassExtension : public RadioClassExtension
          *  When has this unit last received a target? (not comprehensive)
          */
         int LastTargetFrame;
+
+        /**
+         *  Should we reset burst once the countdown reaches 0?
+         */
+        bool IsToResetBurst;
+
+        /**
+         *  The countdown until burst gets reset if unit has lost the target.
+         */
+        CDTimerClass<FrameTimerClass> BurstResetTimer;
 };

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1410,22 +1410,22 @@ void TechnoClassExt::_Assign_Target(AbstractClass* target)
         */
         else {
 
-            /*
-            **  Set BurstIndex to a large value. This is a hack to make it so that Rearm_Delay returns the actual rearm time, not interburst time.
-            */
-            int old_burst = CurrentBurstIndex;
-            CurrentBurstIndex = INT_MAX;
-
             WeaponSlotType which = What_Weapon_Should_I_Use(old_target);
             const WeaponTypeClass* weapon = Get_Weapon(which)->Weapon;
             if (weapon != nullptr && weapon->Burst > 1) {
+
+                /*
+                **  Set BurstIndex to a large value. This is a hack to make it so that Rearm_Delay returns the actual rearm time, not interburst time.
+                */
+                int old_burst = CurrentBurstIndex;
+                CurrentBurstIndex = INT_MAX;
+
                 extension->IsToResetBurst = true;
                 extension->BurstResetTimer = Rearm_Delay(which);
-            }
 
-            CurrentBurstIndex = old_burst;
+                CurrentBurstIndex = old_burst;
+            }
         }
-        
     }
 }
 

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -623,7 +623,7 @@ void TechnoClassExt::_Mission_AI()
      */
     if (extension->IsToResetBurst && extension->BurstResetTimer == 0) {
         extension->IsToResetBurst = false;
-        CurrentBurstIndex = 0;
+        BurstIndex = 0;
     }
 
     MissionClass::AI();
@@ -776,7 +776,7 @@ FireErrorType TechnoClassExt::_Can_Fire(AbstractClass * target, WeaponSlotType w
     if (which != WEAPON_SLOT_SECONDARY && RTTI == RTTI_UNIT)
     {
         const auto unit = reinterpret_cast<UnitClass*>(this);
-        const int burst = CurrentBurstIndex % weapon->Burst;
+        const int burst = BurstIndex % weapon->Burst;
         if (burst < 2)
         {
             if (unit->Class->FiringSyncFrame[burst] != -1
@@ -1386,7 +1386,7 @@ void TechnoClassExt::_Assign_Target(AbstractClass* target)
         }
 
         /*
-        **  We have a target now, don't try to burst anymore.
+        **  We have a target now, don't try to reset burst anymore.
         */
         extension->IsToResetBurst = false;
     }
@@ -1402,7 +1402,7 @@ void TechnoClassExt::_Assign_Target(AbstractClass* target)
         **  If we've got no target and didn't have one to begin with, reset burst now.
         */
         if (old_target == nullptr && !extension->IsToResetBurst) {
-            CurrentBurstIndex = 0;
+            BurstIndex = 0;
         }
 
         /*
@@ -1417,13 +1417,13 @@ void TechnoClassExt::_Assign_Target(AbstractClass* target)
                 /*
                 **  Set BurstIndex to a large value. This is a hack to make it so that Rearm_Delay returns the actual rearm time, not interburst time.
                 */
-                int old_burst = CurrentBurstIndex;
-                CurrentBurstIndex = INT_MAX;
+                int old_burst = BurstIndex;
+                BurstIndex = INT_MAX;
 
                 extension->IsToResetBurst = true;
                 extension->BurstResetTimer = Rearm_Delay(which);
 
-                CurrentBurstIndex = old_burst;
+                BurstIndex = old_burst;
             }
         }
     }
@@ -2566,7 +2566,7 @@ DECLARE_PATCH(_TechnoClass_Assign_Target_Spawn_Manager_Patch)
         extension->SpawnManager->Queue_Target(nullptr);
 
     // Stolen instructions
-    this_ptr->CurrentBurstIndex = 0;
+    this_ptr->BurstIndex = 0;
 
     JMP(0x0062FDE8);
 }

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -134,7 +134,7 @@ void UnitClassExt::_Firing_AI()
 
             if (primary != WEAPON_SLOT_SECONDARY && weapon)
             {
-                const int firing_sync = CurrentBurstIndex % weapon->Burst;
+                const int firing_sync = BurstIndex % weapon->Burst;
                 if (firing_sync < 2 && Class->FiringSyncFrame[firing_sync] != -1)
                 {
                     if (FiringSyncDelay == -1)

--- a/src/new/spawnmanager/spawnmanager.cpp
+++ b/src/new/spawnmanager/spawnmanager.cpp
@@ -367,9 +367,9 @@ void SpawnManagerClass::AI()
                  */
                 const auto weapon = Owner->Get_Weapon(WEAPON_SLOT_PRIMARY)->Weapon;
                 if (control->IsSpawnedMissile && weapon->Burst > 1 && i < weapon->Burst)
-                    Owner->CurrentBurstIndex = i;
+                    Owner->BurstIndex = i;
                 else
-                    Owner->CurrentBurstIndex = 0;
+                    Owner->BurstIndex = 0;
 
                 /**
                  *  Update our status.
@@ -382,7 +382,7 @@ void SpawnManagerClass::AI()
                  *  Apply SecondSpawnOffset if this is the second missile in a burst.
                  */
                 Coordinate fire_coord;
-                if (Owner->CurrentBurstIndex % 2 == 0)
+                if (Owner->BurstIndex % 2 == 0)
                     fire_coord = owner_ext->Fire_Coord(weapon_slot);
                 else
                     fire_coord = owner_ext->Fire_Coord(weapon_slot, owner_type_ext->SecondSpawnOffset);
@@ -413,7 +413,7 @@ void SpawnManagerClass::AI()
                  *  Reset burst since if we're done with this volley.
                  */
                 if (i == SpawnControls.Count() - 1)
-                    Owner->CurrentBurstIndex = 0;
+                    Owner->BurstIndex = 0;
 
                 /**
                  *  Missiles only take a destination once, so they go straight to the target.


### PR DESCRIPTION
This PR should stop the player form being able to reset the burst of a unit by stopping the unit. The unit should instead wait until its ROF expires.

Resolves #185 