### PR TITLE
Implement BarGate

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -282,4 +282,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where `Totable=no` did not work.
   - Fix a bug where the "Building exists" event would fire when you queued a building on the sidebar.
   - Fix a bug where using the "Destroy Tag" trigger action could lead to trying to free invalid memory.
-  - Implement `VerticalGate` for buildings.
+  - Implement `BarGate` for buildings.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -282,3 +282,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where `Totable=no` did not work.
   - Fix a bug where the "Building exists" event would fire when you queued a building on the sidebar.
   - Fix a bug where using the "Destroy Tag" trigger action could lead to trying to free invalid memory.
+  - Implement `VerticalGate` for buildings.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -128,6 +128,16 @@ GateUpSound=    ; VocType, sound effect to play when the gate is rising. Default
 GateDownSound=  ; VocType, sound effect to play when the gate is lowering. Defaults to [AudioVisual]->GateDown.
 ```
 
+### Vertical Gate
+
+- Normally, the game drawn gates flat on the ground when they are open. You can optionally turn this off to have a gate that is drawn above units when open instead.
+
+In `RULES.INI`:
+```ini
+[SOMEBUILDING]   ; BuildingType
+VerticalGate=no  ; boolean, should the gate be drawn normally, as opposed to flat when it's open.
+```
+
 ### ProduceCash
 
 - Vinifera implements the Produce Cash logic from Red Alert 2. The system works exactly as it does in Red Alert 2, but with the following differences:

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -134,8 +134,8 @@ GateDownSound=  ; VocType, sound effect to play when the gate is lowering. Defau
 
 In `RULES.INI`:
 ```ini
-[SOMEBUILDING]   ; BuildingType
-VerticalGate=no  ; boolean, should the gate be drawn normally, as opposed to flat when it's open.
+[SOMEBUILDING]  ; BuildingType
+BarGate=no      ; boolean, should the gate be drawn normally, as opposed to flat when it's open.
 ```
 
 ### ProduceCash

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -93,7 +93,7 @@ Vanilla fixes:
 - Fix a bug where the game could freeze in the score screen in `Clip_Line` when running on Windows 11 24H2 (by tomsons26, Rampastring)
 
 New:
-- Implement `VerticalGate` for buildings (by ZivDero)
+- Implement `BarGate` for buildings (by ZivDero)
 
 :::
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -92,6 +92,9 @@ Vanilla fixes:
 - Fix a bug where using the "Destroy Tag" trigger action could lead to trying to free invalid memory (by ZivDero)
 - Fix a bug where the game could freeze in the score screen in `Clip_Line` when running on Windows 11 24H2 (by tomsons26, Rampastring)
 
+New:
+- Implement `VerticalGate` for buildings (by ZivDero)
+
 :::
 
 ### 0.1.0.0

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -406,7 +406,7 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
         shapefile = Get_Image_Data();
 
         ZGradientType zgrad = ZGRAD_GROUND;
-        if (shapenum < Class->GateStages / 2) {
+        if (shapenum < Class->GateStages / 2 || type_ext->IsVerticalGate) {
             zgrad = ZGRAD_90DEG;
         }
 

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -406,7 +406,7 @@ void BuildingClassExt::_Draw_It(Point2D const& xdrawpoint, Rect const& xcliprect
         shapefile = Get_Image_Data();
 
         ZGradientType zgrad = ZGRAD_GROUND;
-        if (shapenum < Class->GateStages / 2 || type_ext->IsVerticalGate) {
+        if (shapenum < Class->GateStages / 2 || type_ext->IsBarGate) {
             zgrad = ZGRAD_90DEG;
         }
 

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -58,7 +58,8 @@ BuildingTypeClassExtension::BuildingTypeClassExtension(const BuildingTypeClass *
     RoofDoorAnim(nullptr),
     UnderRoofDoorAnim(nullptr),
     IsExclusiveFactory(false),
-    IsWallOwner(true)
+    IsWallOwner(true),
+    IsVerticalGate(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("BuildingTypeClassExtension::BuildingTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -223,8 +223,8 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
     IsHideDuringSpecialAnim = ArtINI.Get_Bool(ini_name, "HideDuringSpecialAnim", IsHideDuringSpecialAnim);
 
     IsExclusiveFactory = ini.Get_Bool(ini_name, "ExclusiveFactory", IsExclusiveFactory);
-
     IsWallOwner = ini.Get_Bool(ini_name, "WallOwner", IsWallOwner);
+    IsVerticalGate = ini.Get_Bool(ini_name, "VerticalGate", IsVerticalGate);
 
     Fetch_Building_Normal_Image(Scen->Theater);
 

--- a/src/extensions/buildingtype/buildingtypeext.cpp
+++ b/src/extensions/buildingtype/buildingtypeext.cpp
@@ -59,7 +59,7 @@ BuildingTypeClassExtension::BuildingTypeClassExtension(const BuildingTypeClass *
     UnderRoofDoorAnim(nullptr),
     IsExclusiveFactory(false),
     IsWallOwner(true),
-    IsVerticalGate(false)
+    IsBarGate(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("BuildingTypeClassExtension::BuildingTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -224,7 +224,7 @@ bool BuildingTypeClassExtension::Read_INI(CCINIClass &ini)
 
     IsExclusiveFactory = ini.Get_Bool(ini_name, "ExclusiveFactory", IsExclusiveFactory);
     IsWallOwner = ini.Get_Bool(ini_name, "WallOwner", IsWallOwner);
-    IsVerticalGate = ini.Get_Bool(ini_name, "VerticalGate", IsVerticalGate);
+    IsBarGate = ini.Get_Bool(ini_name, "BarGate", IsBarGate);
 
     Fetch_Building_Normal_Image(Scen->Theater);
 

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -137,4 +137,9 @@ public:
      *  Determines whether this building is able to claim nearby walls pre-placed on maps as belonging to the owner's house.
      */
     bool IsWallOwner;
+
+    /**
+     *  If this is a gate, should it always be drawn normally, as opposed to being drawn on the ground when open?
+     */
+    bool IsVerticalGate;
 };

--- a/src/extensions/buildingtype/buildingtypeext.h
+++ b/src/extensions/buildingtype/buildingtypeext.h
@@ -141,5 +141,5 @@ public:
     /**
      *  If this is a gate, should it always be drawn normally, as opposed to being drawn on the ground when open?
      */
-    bool IsVerticalGate;
+    bool IsBarGate;
 };


### PR DESCRIPTION
- Normally, the game drawn gates flat on the ground when they are open. You can optionally turn this off to have a gate that is drawn above units when open instead.

In `RULES.INI`:
```ini
[SOMEBUILDING]  ; BuildingType
VerticalGate=no   ; boolean, should the gate be drawn normally, as opposed to flat when it's open.
```