### PR TITLE
Implement voxel light customization

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -259,3 +259,4 @@ This page lists all the individual contributions to the project by their author.
   - Factories now hold their object if there is no war factory available for the unit to exit from instead of refuding construction.
   - Fix building light sources no longer being attached to the building after loading the game.
   - Fix shroud looking bugged if you attempt to reveal too many cells at once.
+  - Implement voxel light customization.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -132,6 +132,20 @@ SavedGamesDirectory=Saved Games  ; string, the name of the directory in which to
 Subdirectories are also supported, e. g. `Tiberian Sun\Saved Games`.
 ```
 
+## Voxel Light Customization
+
+- In vanilla, voxels are lit directly from the South at a 45 degree angle. With Vinifera, this can be customized.
+
+In `RULES.INI`:
+```ini
+[AudioVisual]
+VoxelLightAzimuth=0     ; float, the horizontal direction of the light source,
+                        ; rotating from the South (bottom-left) counter-clockwise, in degrees.
+VoxelLightElevation=45  ; float, the vertical angle of the light source (how high up is the Sun),
+                        ; rotating from the South (bottom-left) counter-clockwise (towards North, passing above the unit), in degrees.
+VoxelShadowOffset=6     ; float, how much the shadow is offset from the unit.
+```
+
 ## File System
 
 - `GENERIC.MIX` and `ISOGEN.MIX` mixfiles can now be used to place common assets between theaters.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -53,6 +53,9 @@ This page lists the history of changes across stable Vinifera releases and also 
 
 :::{dropdown} Click to show
 
+New:
+- Implement voxel light customization (by ZivDero)
+
 Vinifera fixes:
 - Fix unit placement in non-TS Client builds of Vinifera (by ZivDero)
 

--- a/src/extensions/mainloop/mainloopext_hooks.cpp
+++ b/src/extensions/mainloop/mainloopext_hooks.cpp
@@ -44,6 +44,8 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "rulesext.h"
+#include "voxelinit.h"
 
 
 /**
@@ -277,6 +279,17 @@ static bool Main_Loop_Intercept()
         }
 
     }
+
+#if false // demo day-night light cycle loop
+    static float light_angle = 0;
+    static CDTimerClass<SystemTimerClass> light_timer = 5;
+    if (light_timer == 0) {
+        light_timer = 5;
+        light_angle += DEG_TO_RADF(3);
+        if (light_angle >= DEG_TO_RADF(360)) light_angle -= DEG_TO_RADF(360);
+        RulesClassExtension::Set_Voxel_Light_Angle(RuleExtension->VoxelLightAzimuth, light_angle, 6);
+    }
+#endif
 
     return ret;
 }

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -71,6 +71,8 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
         bool Tiberiums(CCINIClass &ini);
         bool PrerequisiteGroups(CCINIClass &ini);
 
+        static bool Set_Voxel_Light_Angle(float azimuth, float elevation, float offset);
+
     private:
         void Check();
         void Fixups(CCINIClass &ini);
@@ -146,4 +148,19 @@ class RulesClassExtension final : public GlobalExtensionClass<RulesClass>
          *  the multiple factory bonus on an object's build time.
          */
         int MultipleFactoryCap;
+
+        /**
+         *  Horizontal direction of the light source.
+         */
+        float VoxelLightAzimuth;
+
+        /**
+         *  Vertical angle of the light source.
+         */
+        float VoxelLightElevation;
+
+        /**
+         *  How much the shadow is offset from the unit.
+         */
+        float VoxelShadowOffset;
 };


### PR DESCRIPTION
- In vanilla, voxels are lit directly from the South at a 45 degree angle. With Vinifera, this can be customized.

In `RULES.INI`:
```ini
[AudioVisual]
VoxelLightAzimuth=0     ; float, the horizontal direction of the light source,
                        ; rotating from the South (bottom-left) counter-clockwise, in degrees.
VoxelLightElevation=45  ; float, the vertical angle of the light source (how high up is the Sun),
                        ; rotating from the South (bottom-left) counter-clockwise (towards North, passing above the unit), in degrees.
VoxelShadowOffset=6     ; float, how much the shadow is offset from the unit.
```