### PR TITLE
Tiberium spreader customization

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -283,3 +283,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where the "Building exists" event would fire when you queued a building on the sidebar.
   - Fix a bug where using the "Destroy Tag" trigger action could lead to trying to free invalid memory.
   - Implement `BarGate` for buildings.
+  - Add Tiberium spreader customization.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1206,12 +1206,16 @@ LightBlueTint=1       ; float, the blue tint of this terrain objects light.
 
 - Vinifera adds additional customization for Tiberium spreaders (`SpawnsTiberium=yes`).
 
+```{note}
+Spreaders don't spawn Tiberium out of thin air. A spreader first spreads Tiberium from itself, then from the radius-1 ring of Tiberium around it, then from the radius-2 ring, and so on. You can think of it as accelerating the natural spread process. If a cell doesn't border the spreader of a piece of Tiberium, it won't be spread to.
+```
+
 In `RULES.INI`:
 ```ini
 [SOMETERRAIN]             ; TerrainType
 SpawnsTiberiumRange=1     ; integer, the maximum range in which Tiberium will be spawned.
 SpawnsTiberiumGrowth=5,5  ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
-SpawnsTiberiumCount=1,1   ; two integers, the minimum and maximum number of Tiberium overlays that will be spawned (maximum can be omitted).
+SpawnsTiberiumCount=1,1   ; two integers, the minimum and maximum number of spreads that will occur (maximum can be omitted).
 ```
 
 ## Theaters

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1215,7 +1215,7 @@ In `RULES.INI`:
 [SOMETERRAIN]                 ; TerrainType
 SpawnsTiberiumRange=1         ; integer, the maximum range in which Tiberium will be spawned.
 SpawnsTiberiumStage=5,5       ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
-SpawnsTiberiumStageFalloff=0  ; float, the amount by which the growth stage will decrease for ever ring after the first one.
+SpawnsTiberiumStageFalloff=0  ; float, the amount by which the growth stage will decrease for every ring after the first one.
 SpawnsTiberiumCount=1,1       ; two integers, the minimum and maximum number of spreads that will occur (maximum can be omitted).
 ```
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1210,8 +1210,8 @@ In `RULES.INI`:
 ```ini
 [SOMETERRAIN]             ; TerrainType
 SpawnsTiberiumRange=1     ; integer, the maximum range in which Tiberium will be spawned.
-SpawnsTiberiumGrowth=1,1  ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
-SpawnsTiberiumCount=5,5   ; two integers, the minimum and maximum number of Tiberium overlays that will be spawned (maximum can be omitted).
+SpawnsTiberiumGrowth=5,5  ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
+SpawnsTiberiumCount=1,1   ; two integers, the minimum and maximum number of Tiberium overlays that will be spawned (maximum can be omitted).
 ```
 
 ## Theaters

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1211,7 +1211,7 @@ In `RULES.INI`:
 [SOMETERRAIN]             ; TerrainType
 SpawnsTiberiumRange=1     ; integer, the maximum range in which Tiberium will be spawned.
 SpawnsTiberiumGrowth=1,1  ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
-SpawnsTiberiumCount=5,5   ; two integers, the minimum and maximum number of Tiberium overlaysthat will be spawned (maximum can be omitted).
+SpawnsTiberiumCount=5,5   ; two integers, the minimum and maximum number of Tiberium overlays that will be spawned (maximum can be omitted).
 ```
 
 ## Theaters

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1212,10 +1212,11 @@ Spreaders don't spawn Tiberium out of thin air. A spreader first spreads Tiberiu
 
 In `RULES.INI`:
 ```ini
-[SOMETERRAIN]             ; TerrainType
-SpawnsTiberiumRange=1     ; integer, the maximum range in which Tiberium will be spawned.
-SpawnsTiberiumGrowth=5,5  ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
-SpawnsTiberiumCount=1,1   ; two integers, the minimum and maximum number of spreads that will occur (maximum can be omitted).
+[SOMETERRAIN]                 ; TerrainType
+SpawnsTiberiumRange=1         ; integer, the maximum range in which Tiberium will be spawned.
+SpawnsTiberiumStage=5,5       ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
+SpawnsTiberiumStageFalloff=0  ; float, the amount by which the growth stage will decrease for ever ring after the first one.
+SpawnsTiberiumCount=1,1       ; two integers, the minimum and maximum number of spreads that will occur (maximum can be omitted).
 ```
 
 ## Theaters

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1202,6 +1202,18 @@ LightGreenTint=1      ; float, the green tint of this terrain objects light.
 LightBlueTint=1       ; float, the blue tint of this terrain objects light.
 ```
 
+### Tiberium Speaders
+
+- Vinifera adds additional customization for Tiberium spreaders (`SpawnsTiberium=yes`).
+
+In `RULES.INI`:
+```ini
+[SOMETERRAIN]             ; TerrainType
+SpawnsTiberiumRange=1     ; integer, the maximum range in which Tiberium will be spawned.
+SpawnsTiberiumGrowth=1,1  ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
+SpawnsTiberiumCount=5,5   ; two integers, the minimum and maximum number of Tiberium overlaysthat will be spawned (maximum can be omitted).
+```
+
 ## Theaters
 
 - Vinifera allow the creation of new custom theater types. A new INI has been added to define these TheaterTypes, if the INI is not present, the game will default to the normal `TEMPERATE` and `SNOW` TheaterTypes.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -66,6 +66,7 @@ New:
 - Implement integer varialbes, and trigger actiosn and events to operate on them (by ZivDero)
 - Veterancy and Health Filter kotkeys (by hacklex)
 - Add unit promotion sounds, EVA and flashing (by ZivDero)
+- Add Tiberium spreader customization (by ZivDero)
 
 
 Vinifera fixes:

--- a/src/extensions/anim/animext_hooks.cpp
+++ b/src/extensions/anim/animext_hooks.cpp
@@ -227,7 +227,7 @@ void AnimClassExt::_AI()
                                 if (tibcell->Can_Tiberium_Germinate(nullptr) && Class->TiberiumSpawnType != nullptr) {
                                     new OverlayClass(OverlayTypes[Class->TiberiumSpawnType->HeapID + Random_Pick(0, 3)], tibcell->Cell_Number());
                                     tibcell->OverlayData = Random_Pick(0, 2);
-                                    Rect overlayrect = tibcell->Get_Overlay_Rect();
+                                    Rect overlayrect = tibcell->Overlay_Render_Rect();
                                     overlayrect.Y -= TacticalRect.Y;
                                     updaterect = Union(updaterect, overlayrect);
                                 }

--- a/src/extensions/cell/cellext.cpp
+++ b/src/extensions/cell/cellext.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CELLEXT.CPP
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Extended CellClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "cellext.h"
+#include "cell.h"
+#include "wwcrc.h"
+#include "tibsun_inline.h"
+#include "extension.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+
+/**
+ *  Replacement for CellClass::Spread_Tiberium that supports a custom Tiberium richness.
+ *
+ *  @author: CCHyper
+ */
+bool CellClassExtension::Spread_Tiberium(CellClass* this_ptr, bool forced, int richness)
+{
+    if (!forced) {
+        if (!this_ptr->Can_Tiberium_Spread()) return (false);
+    }
+
+    TiberiumType tibtype = this_ptr->Tiberium_Type_Here();
+    tibtype = forced && tibtype == TIBERIUM_NONE ? TIBERIUM_FIRST : tibtype;
+
+    if (tibtype != TIBERIUM_NONE) {
+        TiberiumClass* tiberium = Tiberiums[tibtype];
+        FacingType offset = Random_Pick(FACING_N, FACING_NW);
+        for (FacingType index = FACING_N; index < FACING_COUNT; index++) {
+            CellClass* newcell = &this_ptr->Adjacent_Cell(FacingType((index + offset) & 7));
+
+            if (newcell != NULL && newcell->Can_Tiberium_Germinate(tiberium)) {
+                return (newcell->Place_Tiberium(tibtype, richness));
+            }
+        }
+    }
+    return (false);
+}

--- a/src/extensions/cell/cellext.h
+++ b/src/extensions/cell/cellext.h
@@ -1,0 +1,42 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          CELLEXT.H
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Extended CellClass class.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include "abstracttypeext.h"
+#include "cell.h"
+
+
+/**
+ *  Extending CellClass comes with a number of complications, so
+ *  until it is truly necessary, we're avoiding it.
+ */
+static class CellClassExtension
+{
+public:
+    static bool Spread_Tiberium(CellClass* this_ptr, bool forced, int richness = 5);
+};

--- a/src/extensions/cell/cellext_hooks.cpp
+++ b/src/extensions/cell/cellext_hooks.cpp
@@ -39,7 +39,7 @@
 #include "fatal.h"
 #include "debughandler.h"
 #include "asserthandler.h"
-#include "building.h"
+#include "cellext.h"
 #include "extension.h"
 
 #include "hooker.h"
@@ -63,6 +63,7 @@ static DECLARE_EXTENDING_CLASS_AND_PAIR(CellClass)
 public:
     bool _Can_Tiberium_Germinate(TiberiumClass const* tiberium) const;
     bool _Can_Place_Veins() const;
+    bool _Spread_Tiberium(bool forced);
 };
 
 
@@ -143,6 +144,17 @@ bool CellClassExt::_Can_Place_Veins() const
         }
     }
     return false;
+}
+
+
+/**
+ *  Proxy for CellClassExt::Spread_Tiberium.
+ *
+ *  @author: ZivDero
+ */
+bool CellClassExt::_Spread_Tiberium(bool forced)
+{
+    return CellClassExtension::Spread_Tiberium(this, forced);
 }
 
 
@@ -366,5 +378,6 @@ void CellClassExtension_Hooks()
     Patch_Jump(0x00455130, &_CellClass_Draw_Fog_Patch);
     Patch_Jump(0x004596C0, &CellClassExt::_Can_Tiberium_Germinate);
     Patch_Jump(0x0045B0D0, &CellClassExt::_Can_Place_Veins);
+    Patch_Jump(0x004594D0, &CellClassExt::_Spread_Tiberium);
     Patch_Jump(0x004531E4, &_CellClass_Update_Wall_Owner_Skip_Buildings_That_Cannot_Own_Walls_Patch);
 }

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -197,10 +197,16 @@ void TerrainClassExtension::Spread_Tiberium() const
 
     /**
      *  First try spreading from under the tree, like in vanilla.
+     *  Try up to 8 times, since there are 8 cells bordering the center.
      */
-    if (Map[This()->PositionCoord].Spread_Tiberium(true)) {
-        spreads++;
+    for (int i = 0; i < FACING_COUNT; i++) {
+        if (Map[This()->PositionCoord].Spread_Tiberium(true)) {
+            spreads++;
+            if (spreads >= count) break;
+        }
     }
+
+    if (spreads >= count) return;
 
     /**
      *  Then we start spreading in concentric rings.

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -30,6 +30,7 @@
 #include "lightsource.h"
 #include "wwcrc.h"
 #include "extension.h"
+#include "tiberium.h"
 #include "mouse.h"
 #include "cellext.h"
 #include "terraintypeext.h"
@@ -193,6 +194,8 @@ void TerrainClassExtension::Spread_Tiberium() const
     Cell origin = This()->PositionCell;
     int count = Scen->RandomNumber(ttype_ext->TiberiumSpawnCount.X, ttype_ext->TiberiumSpawnCount.Y);
 
+    TiberiumClass* tiberium = Tiberiums[ttype->TiberiumToSpawn];
+
     int spreads = 0;
 
     /**
@@ -200,7 +203,9 @@ void TerrainClassExtension::Spread_Tiberium() const
      *  Try up to 8 times, since there are 8 cells bordering the center.
      */
     for (int i = 0; i < FACING_COUNT; i++) {
-        if (CellClassExtension::Spread_Tiberium(&Map[This()->PositionCoord], true, Scen->RandomNumber(ttype_ext->TiberiumSpawnGrowth.X, ttype_ext->TiberiumSpawnGrowth.Y))) {
+        int stage = Scen->RandomNumber(ttype_ext->TiberiumSpawnStage.X, ttype_ext->TiberiumSpawnStage.Y);
+        stage = std::clamp(stage, 0, tiberium->FrameCount - 1);
+        if (CellClassExtension::Spread_Tiberium(&Map[This()->PositionCoord], true, stage)) {
             spreads++;
             if (spreads >= count) break;
         }
@@ -248,10 +253,16 @@ void TerrainClassExtension::Spread_Tiberium() const
              *  Try to spread from cells in this ring until we've spread enough.
              */
             for (auto& cell : ring) {
-                if (Map[cell].Tiberium_Type_Here() == ttype->TiberiumToSpawn && CellClassExtension::Spread_Tiberium(&Map[cell], true, Scen->RandomNumber(ttype_ext->TiberiumSpawnGrowth.X, ttype_ext->TiberiumSpawnGrowth.Y))) {
-                    spreads++;
-                    has_spread = true;
-                    if (spreads >= count) break;
+                if (Map[cell].Tiberium_Type_Here() == ttype->TiberiumToSpawn) {
+                    int stage = Scen->RandomNumber(ttype_ext->TiberiumSpawnStage.X, ttype_ext->TiberiumSpawnStage.Y);
+                    stage -= ttype_ext->TiberiumSpawnStageFalloff * r;
+                    stage = std::clamp(stage, 0, tiberium->FrameCount - 1);
+
+                    if (CellClassExtension::Spread_Tiberium(&Map[cell], true, stage)) {
+                        spreads++;
+                        has_spread = true;
+                        if (spreads >= count) break;
+                    }
                 }
             }
 

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -200,7 +200,7 @@ void TerrainClassExtension::Spread_Tiberium() const
      *  Try up to 8 times, since there are 8 cells bordering the center.
      */
     for (int i = 0; i < FACING_COUNT; i++) {
-        if (Map[This()->PositionCoord].Spread_Tiberium(true)) {
+        if (CellClassExtension::Spread_Tiberium(&Map[This()->PositionCoord], true, Scen->RandomNumber(ttype_ext->TiberiumSpawnGrowth.X, ttype_ext->TiberiumSpawnGrowth.Y))) {
             spreads++;
             if (spreads >= count) break;
         }

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -234,19 +234,30 @@ void TerrainClassExtension::Spread_Tiberium() const
         /**
          *  Shuffle them so that spread isn't orderly.
          */
-        static std::minstd_rand rng(Scen->RandomNumber);
+        static std::minstd_rand rng(Scen->RandomNumber());
         std::shuffle(ring.begin(), ring.end(), rng);
 
-        /**
-         *  Try to spread from cells in this ring until we've spread enough.
-         */
-        for (auto& cell : ring) {
-            if (Map[cell].Tiberium_Type_Here() == ttype->TiberiumToSpawn && CellClassExtension::Spread_Tiberium(&Map[cell], true, Scen->RandomNumber(ttype_ext->TiberiumSpawnGrowth.X, ttype_ext->TiberiumSpawnGrowth.Y))) {
-                spreads++;
-                if (spreads >= count) break;
+        while (spreads < count) {
+
+            /**
+             *  Track if we've spread at all in this cycle. If not, then bail.
+             */
+            bool has_spread = false;
+
+            /**
+             *  Try to spread from cells in this ring until we've spread enough.
+             */
+            for (auto& cell : ring) {
+                if (Map[cell].Tiberium_Type_Here() == ttype->TiberiumToSpawn && CellClassExtension::Spread_Tiberium(&Map[cell], true, Scen->RandomNumber(ttype_ext->TiberiumSpawnGrowth.X, ttype_ext->TiberiumSpawnGrowth.Y))) {
+                    spreads++;
+                    has_spread = true;
+                    if (spreads >= count) break;
+                }
             }
+
+            if (!has_spread) break;
         }
 
-        if (spreads >= count) return;
+        if (spreads >= count) break;
     }
 }

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -228,7 +228,7 @@ void TerrainClassExtension::Spread_Tiberium() const
         /**
          *  Shuffle them so that spread isn't orderly.
          */
-        static std::mt19937 rng(Scen->RandomNumber);
+        static std::minstd_rand rng(Scen->RandomNumber);
         std::shuffle(ring.begin(), ring.end(), rng);
 
         /**

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -30,8 +30,12 @@
 #include "lightsource.h"
 #include "wwcrc.h"
 #include "extension.h"
+#include "mouse.h"
+#include "cellext.h"
+#include "terraintypeext.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include <random>
 
 
 /**
@@ -173,4 +177,70 @@ void TerrainClassExtension::Detach(AbstractClass * target, bool all)
 void TerrainClassExtension::Object_CRC(CRCEngine &crc) const
 {
     //EXT_DEBUG_TRACE("TerrainClassExtension::Object_CRC - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+}
+
+
+/**
+ *  Spreads Tiberium from this Terrain.
+ *
+ *  @author: ZivDero
+ */
+void TerrainClassExtension::Spread_Tiberium() const
+{
+    TerrainTypeClass* ttype = This()->Class;
+    TerrainTypeClassExtension* ttype_ext = Extension::Fetch(ttype);
+
+    Cell origin = This()->PositionCell;
+    int count = Scen->RandomNumber(ttype_ext->TiberiumSpawnCount.X, ttype_ext->TiberiumSpawnCount.Y);
+
+    int spreads = 0;
+
+    /**
+     *  First try spreading from under the tree, like in vanilla.
+     */
+    if (Map[This()->PositionCoord].Spread_Tiberium(true)) {
+        spreads++;
+    }
+
+    /**
+     *  Then we start spreading in concentic rings.
+     */
+    for (int r = 1; r <= ttype_ext->TiberiumSpawnRange - 1; ++r) {
+        static std::vector<Cell> ring(128);
+        ring.clear();
+
+        /**
+         *  Collect all cells of the current ring.
+         */
+        for (int x = origin.X - r; x <= origin.X + r; ++x) {
+            for (int y = origin.Y - r; y <= origin.Y + r; ++y) {
+                int dx = x - origin.X;
+                int dy = y - origin.Y;
+                int dist2 = dx * dx + dy * dy;
+                int r_min2 = (r - 0.5) * (r - 0.5);
+                int r_max2 = (r + 0.5) * (r + 0.5);
+                if (dist2 >= r_min2 && dist2 < r_max2) {
+                    ring.emplace_back(x, y);
+                }
+            }
+        }
+
+        /**
+         *  Shuffle them so that spread isn't orderly.
+         */
+        static std::mt19937 rng(Scen->RandomNumber);
+        std::shuffle(ring.begin(), ring.end(), rng);
+
+        /**
+         *  Try to spread from cells in this ring until we've spread enough.
+         */
+        for (auto& cell : ring) {
+            if (Map[cell].Tiberium_Type_Here() == ttype->TiberiumToSpawn && CellClassExtension::Spread_Tiberium(&Map[cell], true, Scen->RandomNumber(ttype_ext->TiberiumSpawnGrowth.X, ttype_ext->TiberiumSpawnGrowth.Y))) {
+                spreads++;
+                if (spreads >= count) break;
+            }
+        }
+
+        if (spreads >= count) return;
+    }
 }

--- a/src/extensions/terrain/terrainext.cpp
+++ b/src/extensions/terrain/terrainext.cpp
@@ -203,7 +203,7 @@ void TerrainClassExtension::Spread_Tiberium() const
     }
 
     /**
-     *  Then we start spreading in concentic rings.
+     *  Then we start spreading in concentric rings.
      */
     for (int r = 1; r <= ttype_ext->TiberiumSpawnRange - 1; ++r) {
         static std::vector<Cell> ring(128);

--- a/src/extensions/terrain/terrainext.h
+++ b/src/extensions/terrain/terrainext.h
@@ -62,6 +62,8 @@ TerrainClassExtension final : public ObjectClassExtension
         virtual const TerrainClass *This_Const() const override { return reinterpret_cast<const TerrainClass *>(ObjectClassExtension::This_Const()); }
         virtual RTTIType Fetch_RTTI() const override { return RTTI_TERRAIN; }
 
+        void Spread_Tiberium() const;
+
     public:
         /**
          *  The light source instance for this terrain object.

--- a/src/extensions/terrain/terrainext_hooks.cpp
+++ b/src/extensions/terrain/terrainext_hooks.cpp
@@ -34,12 +34,79 @@
 #include "lightsource.h"
 #include "vinifera_util.h"
 #include "extension.h"
+#include "scenario.h"
+#include "mouse.h"
 #include "fatal.h"
+#include "rules.h"
 #include "asserthandler.h"
 #include "debughandler.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ *
+ *  @note: This must not contain a constructor or destructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+static DECLARE_EXTENDING_CLASS_AND_PAIR(TerrainClass)
+{
+public:
+    void _AI();
+};
+
+
+/**
+ *  Replacement for TerrainClass::AI.
+ *
+ *  @author: ZivDero
+ */
+void TerrainClassExt::_AI()
+{
+    ObjectClass::AI();
+
+    if (Class->IsAnimated) {
+        if (Fetch_Rate() == 0) {
+            if (Probability_Of(Class->AnimationProbability)) {
+                Set_Stage(0);
+                Set_Rate(Class->AnimationRate);
+            }
+        }
+    }
+
+    if (StageClass::Graphic_Logic()) {
+
+        /**
+         *  If the terrain object is in the process of crumbling, then when at the
+         *  last stage of the crumbling animation, delete the terrain object.
+         */
+        if (IsCrumbling && Fetch_Stage() == (((ShapeSet const*)Class->Get_Image_Data())->Get_Count()) - 1) {
+            Delete_Me();
+            return;
+        }
+
+        if (Class->IsTiberiumSpawn && Class->IsAnimated && Fetch_Stage() == (((ShapeSet const*)Class->Get_Image_Data())->Get_Count() / 2)) {
+            Set_Stage(0);
+            Set_Rate(0);
+            Extension::Fetch(this)->Spread_Tiberium();
+        }
+    }
+
+    if (IsOnFire) {
+        if (abs(Scen->RandomNumber()) % 100 == 0) {
+            CellClass& cellptr = Map[Get_Coord()];
+            for (FacingType facing = FACING_FIRST; facing < FACING_COUNT; facing++) {
+                TerrainClass* terrain = cellptr.Adjacent_Cell(facing).Cell_Terrain();
+                if (terrain && !terrain->IsOnFire && Probability_Of2(Rule->TreeFlammability)) {
+                    terrain->Catch_Fire();
+                }
+            }
+        }
+    }
+}
 
 
 /**
@@ -190,4 +257,5 @@ void TerrainClassExtension_Hooks()
 
     Patch_Jump(0x006409C3, &_TerrainClass_Unlimbo_LightSource_Patch);
     Patch_Jump(0x0063F4D9, &_TerrainClass_Take_Damage_LightSource_Patch);
+    Patch_Jump(0x0063FFB0, &TerrainClassExt::_AI);
 }

--- a/src/extensions/terraintype/terraintypeext.cpp
+++ b/src/extensions/terraintype/terraintypeext.cpp
@@ -39,14 +39,17 @@
  *  
  *  @author: CCHyper
  */
-TerrainTypeClassExtension::TerrainTypeClassExtension(const TerrainTypeClass *this_ptr) :
+TerrainTypeClassExtension::TerrainTypeClassExtension(const TerrainTypeClass* this_ptr) :
     ObjectTypeClassExtension(this_ptr),
     IsLightEnabled(false),
     LightVisibility(5000),
     LightIntensity(0),
     LightRedTint(1000000),
     LightGreenTint(1000000),
-    LightBlueTint(1000000)
+    LightBlueTint(1000000),
+    TiberiumSpawnRange(1),
+    TiberiumSpawnCount(1, 1),
+    TiberiumSpawnGrowth(5, 5)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TerrainTypeClassExtension::TerrainTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -196,6 +199,27 @@ bool TerrainTypeClassExtension::Read_INI(CCINIClass &ini)
     LightRedTint = ini.Get_Double(ini_name, "LightRedTint", (LightRedTint / 1000)) * 1000.0 + 0.1;
     LightGreenTint = ini.Get_Double(ini_name, "LightGreenTint", (LightGreenTint / 1000)) * 1000.0 + 0.1;
     LightBlueTint = ini.Get_Double(ini_name, "LightBlueTint", (LightBlueTint / 1000)) * 1000.0 + 0.1;
+
+    auto get_min_max = [](auto& ini, const char* section, const char* key, const Point2D& defval) {
+        char buffer[128];
+        int scan_min = 0, scan_max = 0;
+        if (ini.Get_String(section, key, buffer, sizeof(buffer)) > 0) {
+            int scanned = sscanf(buffer, "%d,%d", &scan_min, &scan_max);
+            if (scanned > 0) {
+                if (scanned == 1) {
+                    return Point2D(scan_min, scan_min);
+                } else if (scanned == 2) {
+                    if (scan_max < scan_min) std::swap(scan_min, scan_max);
+                    return Point2D(scan_min, scan_max);
+                }
+            }
+        }
+        return defval;
+    };
+
+    TiberiumSpawnRange = ini.Get_Int(ini_name, "SpawnsTiberiumRange", TiberiumSpawnRange);
+    TiberiumSpawnCount = get_min_max(ini, ini_name, "SpawnsTiberiumCount", TiberiumSpawnCount);
+    TiberiumSpawnGrowth = get_min_max(ini, ini_name, "SpawnsTiberiumGrowth", TiberiumSpawnGrowth);
 
     IsInitialized = true;
     

--- a/src/extensions/terraintype/terraintypeext.cpp
+++ b/src/extensions/terraintype/terraintypeext.cpp
@@ -48,8 +48,9 @@ TerrainTypeClassExtension::TerrainTypeClassExtension(const TerrainTypeClass* thi
     LightGreenTint(1000000),
     LightBlueTint(1000000),
     TiberiumSpawnRange(1),
-    TiberiumSpawnGrowth(5, 5),
-    TiberiumSpawnCount(1, 1)
+    TiberiumSpawnStage(5, 5),
+    TiberiumSpawnCount(1, 1),
+    TiberiumSpawnStageFalloff(0)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TerrainTypeClassExtension::TerrainTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -219,7 +220,8 @@ bool TerrainTypeClassExtension::Read_INI(CCINIClass &ini)
 
     TiberiumSpawnRange = ini.Get_Int(ini_name, "SpawnsTiberiumRange", TiberiumSpawnRange);
     TiberiumSpawnCount = get_min_max(ini, ini_name, "SpawnsTiberiumCount", TiberiumSpawnCount);
-    TiberiumSpawnGrowth = get_min_max(ini, ini_name, "SpawnsTiberiumGrowth", TiberiumSpawnGrowth);
+    TiberiumSpawnStage = get_min_max(ini, ini_name, "SpawnsTiberiumStage", TiberiumSpawnStage);
+    TiberiumSpawnStageFalloff = ini.Get_Float(ini_name, "SpawnsTiberiumStageFalloff", TiberiumSpawnStageFalloff);
 
     IsInitialized = true;
     

--- a/src/extensions/terraintype/terraintypeext.cpp
+++ b/src/extensions/terraintype/terraintypeext.cpp
@@ -48,8 +48,8 @@ TerrainTypeClassExtension::TerrainTypeClassExtension(const TerrainTypeClass* thi
     LightGreenTint(1000000),
     LightBlueTint(1000000),
     TiberiumSpawnRange(1),
-    TiberiumSpawnCount(1, 1),
-    TiberiumSpawnGrowth(5, 5)
+    TiberiumSpawnGrowth(5, 5),
+    TiberiumSpawnCount(1, 1)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TerrainTypeClassExtension::TerrainTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 

--- a/src/extensions/terraintype/terraintypeext.h
+++ b/src/extensions/terraintype/terraintypeext.h
@@ -93,17 +93,17 @@ TerrainTypeClassExtension final : public ObjectTypeClassExtension
         int LightBlueTint;
 
         /**
-         *  If SpreadsTiberium=yes, the max range in which Tiberium will be spread.
+         *  If SpawnsTiberium=yes, the max range in which Tiberium will be spawned.
          */
         int TiberiumSpawnRange;
 
         /**
-         *  If SpreadsTiberium=yes, the growth stage at which the Tiberium will be spawned (min, max).
+         *  If SpawnsTiberium=yes, the growth stage at which the Tiberium will be spawned (min, max).
          */
         Point2D TiberiumSpawnGrowth;
 
         /**
-         *  If SpreadsTiberium=yes, the number of Tiberium overlays that will be spawned (min, max).
+         *  If SpawnsTiberium=yes, the number of Tiberium overlays that will be spawned (min, max).
          */
         Point2D TiberiumSpawnCount;
 };

--- a/src/extensions/terraintype/terraintypeext.h
+++ b/src/extensions/terraintype/terraintypeext.h
@@ -100,7 +100,12 @@ TerrainTypeClassExtension final : public ObjectTypeClassExtension
         /**
          *  If SpawnsTiberium=yes, the growth stage at which the Tiberium will be spawned (min, max).
          */
-        Point2D TiberiumSpawnGrowth;
+        Point2D TiberiumSpawnStage;
+
+        /**
+         *  If SpawnsTiberium=yes, amount by which the growth stage will decrease for ever ring after 1.
+         */
+        float TiberiumSpawnStageFalloff;
 
         /**
          *  If SpawnsTiberium=yes, the number of Tiberium overlays that will be spawned (min, max).

--- a/src/extensions/terraintype/terraintypeext.h
+++ b/src/extensions/terraintype/terraintypeext.h
@@ -91,4 +91,19 @@ TerrainTypeClassExtension final : public ObjectTypeClassExtension
          *  The blue tint of this terrain objects light.
          */
         int LightBlueTint;
+
+        /**
+         *  If SpreadsTiberium=yes, the max range in which Tiberium will be spread.
+         */
+        int TiberiumSpawnRange;
+
+        /**
+         *  If SpreadsTiberium=yes, the growth stage at which the Tiberium will be spawned (min, max).
+         */
+        Point2D TiberiumSpawnGrowth;
+
+        /**
+         *  If SpreadsTiberium=yes, the number of Tiberium overlays that will be spawned (min, max).
+         */
+        Point2D TiberiumSpawnCount;
 };


### PR DESCRIPTION
This PR adds additional customization for Tiberium spreaders (`SpawnsTiberium=yes`).

```{note}
Spreaders don't spawn Tiberium out of thin air. A spreader first spreads Tiberium from itself, then from the radius-1 ring of Tiberium around it, then from the radius-2 ring, and so on. You can think of it as accelerating the natural spread process. If a cell doesn't border the spreader of a piece of Tiberium, it won't be spread to.
```

In `RULES.INI`:
```ini
[SOMETERRAIN]                 ; TerrainType
SpawnsTiberiumRange=1         ; integer, the maximum range in which Tiberium will be spawned.
SpawnsTiberiumStage=5,5       ; two integers, the minimum and maximum growth stage at which Tiberium will be spawned (maximum can be omitted).
SpawnsTiberiumStageFalloff=0  ; float, the amount by which the growth stage will decrease for ever ring after the first one.
SpawnsTiberiumCount=1,1       ; two integers, the minimum and maximum number of spreads that will occur (maximum can be omitted).
```

Resolves #628, resolves #556