### PR TITLE
Add a Water MZone override

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -294,3 +294,4 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where vehicles paradropped from a carryall would be drawn with an offset.
   - Parachute animations with `AltPalette=yes` now remap to the parachuted unit owner's color.
   - Fix a bug where paradrops didn't take cell passability and bridges into account.
+  - Add Water movement zone override.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -158,6 +158,25 @@ In `RULES.INI`:
 TiberiumStorage=yes  ; boolean, does the player need storage (silos) to collect Tiberium?
 ```
 
+## Water Movement Zone
+
+- Red Alert 2 adds a few new movement zones, among them is the `Water` movement zone, used for ships.
+
+- Unfortunately, it is not trivial to add new movement zones to Tiberian Sun. However, Vinifera allows overriding any of the existing movement zones with a copy of the RA2 `Water` movement zone.
+
+```ini
+[General]
+WaterMovementZoneOverride=  ; MZoneType, the name of the movement zone which will be replaced with Water.
+```
+
+```{note}
+Movement zone `Normal` cannot be overridden this way.
+```
+
+```{note}
+Once a movement zone is replaced with water, it cannot be reverted.
+```
+
 ## File System
 
 - `GENERIC.MIX` and `ISOGEN.MIX` mixfiles can now be used to place common assets between theaters.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -279,7 +279,18 @@ AllowedSmudges=   ; list of SmudgeTypes, which Smudges can appear on this tile. 
 In `TEMPERAT.INI` (or other theater file):
 ```ini
 [SOMEISOTILESET]  ; IsometricTileType
-AllowVeins=yes    ; boolean, can Veins can grow on this tile.
+AllowVeins=yes    ; boolean, can Veins can grow on this tile?
+```
+
+
+### WaterTunnel
+
+- The `WaterTunnel` key turns this tile's `Tunnel` LandType tiles water-passable.
+
+In `TEMPERAT.INI` (or other theater file):
+```ini
+[SOMEISOTILESET]   ; IsometricTileType
+WaterTunnel=yes    ; boolean, is this tile's tunnel on water?
 ```
 
 ## Infantry

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -289,8 +289,8 @@ AllowVeins=yes    ; boolean, can Veins can grow on this tile?
 
 In `TEMPERAT.INI` (or other theater file):
 ```ini
-[SOMEISOTILESET]   ; IsometricTileType
-WaterTunnel=yes    ; boolean, is this tile's tunnel on water?
+[SOMEISOTILESET]  ; IsometricTileType
+WaterTunnel=no    ; boolean, is this tile's tunnel on water?
 ```
 
 ## Infantry
@@ -312,6 +312,18 @@ OmniHealer=no   ; boolean, should this infantry consider other infantry, unit, a
 
 ```{note}
 When an infantry with `Mechanic=yes` and `OmniHealer=yes` is selected and the mouse is over a transport unit or aircraft, holding down the `ALT` key (Force Move) will allow you to enter the transport instead of healing it.
+```
+
+## Overlays
+
+### WaterTunnel
+
+- If the cell the overlay is on has the `Tunnel` LandType, the `WaterTunnel` key turns this tile water-passable.
+
+In `RULES.INI`:
+```ini
+[SOMEOVERLAY]   ; OverlayType
+WaterTunnel=no  ; boolean, is this tile's tunnel on water?
 ```
 
 ## Projectiles

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -69,6 +69,7 @@ New:
 - Add Tiberium spreader customization (by ZivDero)
 - Implement `BarGate` for buildings (by ZivDero)
 - Parachute animations with `AltPalette=yes` now remap to the parachuted unit owner's color (by ZivDero)
+- Add Water movement zone override (by ZivDero)
 
 
 Vinifera fixes:

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -706,7 +706,7 @@ ActionType BuildingClassExt::_What_Action(ObjectClass const* object, bool disall
                          *
                          *  @author: Rampastring
                          */
-                        if (Map[cell].Passability != PASSABLE_OK && !(Extension::Fetch(Class)->IsNaval && Map[cell].Passability == PASSABLE_WATER)) {
+                        if (Map[cell].Passability != PASSABLE_LAND && !(Extension::Fetch(Class)->IsNaval && Map[cell].Passability == PASSABLE_WATER)) {
                             action = ACTION_NOMOVE;
                         }
                     }
@@ -752,7 +752,7 @@ ActionType BuildingClassExt::_What_Action(const Cell& cell, bool check_fog, bool
                  *
                  *  @author: Rampastring
                  */
-                if (Map[cell].Passability != PASSABLE_OK && !(Extension::Fetch(Class)->IsNaval && Map[cell].Passability == PASSABLE_WATER)) {
+                if (Map[cell].Passability != PASSABLE_LAND && !(Extension::Fetch(Class)->IsNaval && Map[cell].Passability == PASSABLE_WATER)) {
                     action = ACTION_NOMOVE;
                 }
                 

--- a/src/extensions/cell/cellext_hooks.cpp
+++ b/src/extensions/cell/cellext_hooks.cpp
@@ -44,6 +44,7 @@
 
 #include "hooker.h"
 #include "hooker_macros.h"
+#include "house.h"
 #include "isotiletype.h"
 #include "isotiletypeext.h"
 #include "overlaytype.h"
@@ -64,6 +65,7 @@ public:
     bool _Can_Tiberium_Germinate(TiberiumClass const* tiberium) const;
     bool _Can_Place_Veins() const;
     bool _Spread_Tiberium(bool forced);
+    void _Recalc_Passability();
 };
 
 
@@ -155,6 +157,76 @@ bool CellClassExt::_Can_Place_Veins() const
 bool CellClassExt::_Spread_Tiberium(bool forced)
 {
     return CellClassExtension::Spread_Tiberium(this, forced);
+}
+
+
+/**
+ *  Re-implementation of CellClass::Recalc_Passability.
+ *
+ *  @author: ZivDero, tomsons26
+ */
+void CellClassExt::_Recalc_Passability()
+{
+    if (!Map.In_Local_Radar(CellID)) {
+        Passability = PASSABLE_OUTSIDE;
+        return;
+    }
+
+    if (Overlay != OVERLAY_NONE) {
+        OverlayTypeClass const* overlay = OverlayTypes[Overlay];
+        if (overlay->IsCrushable) {
+            Passability = PASSABLE_CRUSH;
+            return;
+        }
+        if (overlay->IsWall) {
+            Passability = PASSABLE_BLOCKED;
+            return;
+        }
+        if (Ground[overlay->Land].Cost[SPEED_WHEEL] == 0) {
+            Passability = PASSABLE_NO;
+            return;
+        }
+    }
+
+    if (Land == LAND_WATER || Land == LAND_BEACH || (Land == LAND_TUNNEL && ITType != ISOTILE_NONE && Extension::Fetch(IsoTileTypes[ITType])->IsWaterTunnel)) {
+        Passability = PASSABLE_WATER;
+        return;
+    }
+
+    if (Ground[Land].Cost[SPEED_WHEEL] <= 0.01) {
+        Passability = PASSABLE_NO;
+        return;
+    }
+
+    ObjectClass* occupier = OccupierPtr;
+    while (occupier != nullptr) {
+        switch (occupier->RTTI) {
+        case RTTI_BUILDING:
+            if (static_cast<BuildingClass*>(occupier)->Class->IsFirestormWall) {
+                if (static_cast<BuildingClass*>(occupier)->House->IsFirestormActive) {
+                    Passability = PASSABLE_NO;
+                    return;
+                }
+            } else if (static_cast<BuildingClass*>(occupier)->Class->IsLaserFence) {
+                if (static_cast<BuildingClass*>(occupier)->LaserFenceFrame != 12 && static_cast<BuildingClass*>(occupier)->LaserFenceFrame != 8) {
+                    Passability = PASSABLE_NO;
+                }
+            }
+            break;
+
+        case RTTI_TERRAIN:
+            if ((Scen->Theater == THEATER_TEMPERATE && static_cast<TerrainClass*>(occupier)->Class->TemperateOccupationBits != 7) || (Scen->Theater == THEATER_SNOW && static_cast<TerrainClass*>(occupier)->Class->SnowOccupationBits != 7)) {
+                Passability = PASSABLE_PARTIALLY_BLOCKED;
+                return;
+            }
+
+            Passability = PASSABLE_BLOCKED;
+            return;
+        }
+        occupier = occupier->Next;
+    }
+
+    Passability = PASSABLE_LAND;
 }
 
 
@@ -379,5 +451,6 @@ void CellClassExtension_Hooks()
     Patch_Jump(0x004596C0, &CellClassExt::_Can_Tiberium_Germinate);
     Patch_Jump(0x0045B0D0, &CellClassExt::_Can_Place_Veins);
     Patch_Jump(0x004594D0, &CellClassExt::_Spread_Tiberium);
+    Patch_Jump(0x00459A00, &CellClassExt::_Recalc_Passability);
     Patch_Jump(0x004531E4, &_CellClass_Update_Wall_Owner_Skip_Buildings_That_Cannot_Own_Walls_Patch);
 }

--- a/src/extensions/cell/cellext_hooks.cpp
+++ b/src/extensions/cell/cellext_hooks.cpp
@@ -48,6 +48,7 @@
 #include "isotiletype.h"
 #include "isotiletypeext.h"
 #include "overlaytype.h"
+#include "overlaytypeext.h"
 #include "terrain.h"
 #include "terraintype.h"
 #include "tiberium.h"
@@ -174,6 +175,10 @@ void CellClassExt::_Recalc_Passability()
 
     if (Overlay != OVERLAY_NONE) {
         OverlayTypeClass const* overlay = OverlayTypes[Overlay];
+        if (Land == LAND_TUNNEL && Extension::Fetch(overlay)->IsWaterTunnel) {
+            Passability = PASSABLE_WATER;
+            return;
+        }
         if (overlay->IsCrushable) {
             Passability = PASSABLE_CRUSH;
             return;

--- a/src/extensions/isotiletype/isotiletypeext.cpp
+++ b/src/extensions/isotiletype/isotiletypeext.cpp
@@ -50,7 +50,8 @@ IsometricTileTypeClassExtension::IsometricTileTypeClassExtension(const Isometric
     TileSetName(""),
     AllowedTiberiums(),
     AllowedSmudges(),
-    IsAllowVeins(true)
+    IsAllowVeins(true),
+    IsWaterTunnel(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("IsometricTileTypeClassExtension::~IsometricTileTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -230,6 +231,7 @@ bool IsometricTileTypeClassExtension::Read_INI(CCINIClass &ini)
     }
 
     IsAllowVeins = ini.Get_Bool(ini_name, "AllowVeins", IsAllowVeins);
+    IsWaterTunnel = ini.Get_Bool(ini_name, "WaterTunnel", IsWaterTunnel);
 
     IsInitialized = true;
     

--- a/src/extensions/isotiletype/isotiletypeext.h
+++ b/src/extensions/isotiletype/isotiletypeext.h
@@ -87,4 +87,9 @@ IsometricTileTypeClassExtension final : public ObjectTypeClassExtension
          *  Can veins grow on this tile type?
          */
         bool IsAllowVeins;
+
+        /**
+         *  Is this a water tunnel entrance?
+         */
+        bool IsWaterTunnel;
 };

--- a/src/extensions/overlaytype/overlaytypeext.cpp
+++ b/src/extensions/overlaytype/overlaytypeext.cpp
@@ -39,7 +39,8 @@
  *  @author: CCHyper
  */
 OverlayTypeClassExtension::OverlayTypeClassExtension(const OverlayTypeClass *this_ptr) :
-    ObjectTypeClassExtension(this_ptr)
+    ObjectTypeClassExtension(this_ptr),
+    IsWaterTunnel(false)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("OverlayTypeClassExtension::OverlayTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 
@@ -184,6 +185,8 @@ bool OverlayTypeClassExtension::Read_INI(CCINIClass &ini)
     if (!ini.Is_Present(ini_name)) {
         return false;
     }
+
+    IsWaterTunnel = ini.Get_Bool(ini_name, "WaterTunnel", IsWaterTunnel);
 
     IsInitialized = true;
     

--- a/src/extensions/overlaytype/overlaytypeext.h
+++ b/src/extensions/overlaytype/overlaytypeext.h
@@ -62,4 +62,8 @@ OverlayTypeClassExtension final : public ObjectTypeClassExtension
         virtual RTTIType Fetch_RTTI() const override { return RTTI_INFANTRYTYPE; }
 
     public:
+        /**
+         *  Is this a water tunnel entrance?
+         */
+        bool IsWaterTunnel;
 };

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -662,6 +662,15 @@ bool RulesClassExtension::General(CCINIClass &ini)
     MultipleFactoryCap = ini.Get_Int(GENERAL, "MultipleFactoryCap", MultipleFactoryCap);
     IsTiberiumStorage = ini.Get_Bool(GENERAL, "TiberiumStorage", IsTiberiumStorage);
 
+    /**
+     *  Allow replacing any signle movement zone with a copy of RA2's water MZone.
+     */
+    MZoneType mzone_water = ini.Get_MZoneType(GENERAL, "WaterMovementZoneOverride", MZONE_NORMAL);
+    if (mzone_water != MZONE_NORMAL) {
+        int water[7] = {2, 2, 2, 1, 2, 2, 3}; // LAND = NO, CRUSH = NO, BLOCKED = NO, WATER = YES, PARTIALLY_BLOCKED = NO, NO = NO, OUTSIDE = ILLEGAL
+        std::copy(std::begin(water), std::end(water), MovementZonePassability[mzone_water]);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
## Water Movement Zone

- Red Alert 2 adds a few new movement zones, among them is the `Water` movement zone, used for ships.

- Unfortunately, it is not trivial to add new movement zones to Tiberian Sun. However, Vinifera allows overriding any of the existing movement zones with a copy of the RA2 `Water` movement zone.

```ini
[General]
WaterMovementZoneOverride=  ; MZoneType, the name of the movement zone which will be replaced with Water.
```

```{note}
Movement zone `Normal` cannot be overridden this way.
```

```{note}
Once a movement zone is replaced with water, it cannot be reverted.
```

### WaterTunnel

- The `WaterTunnel` key turns this tile's `Tunnel` LandType tiles water-passable.

In `TEMPERAT.INI` (or other theater file):
```ini
[SOMEISOTILESET]   ; IsometricTileType
WaterTunnel=no; boolean, is this tile's tunnel on water?
```

### WaterTunnel

- If the cell the overlay is on has the `Tunnel` LandType, the `WaterTunnel` key turns this tile's `Tunnel` LandType tiles water-passable.

In `RULES.INI`:
```ini
[SOMEOVERLAY]   ; OverlayType
WaterTunnel=no  ; boolean, is this tile's tunnel on water?
```