### PR TITLE
Interpret tutorial text INI keys as strings

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -315,3 +315,4 @@ This page lists all the individual contributions to the project by their author.
   - Add customizable wake animations.
   - Replace DirectDraw with SDL.
   - Fix a bug where you could tote a `Totable=no` unit by force-moving onto it.
+  - Tutorial text INI keys are now interpreted as strings, not integers.

--- a/docs/Mapping.md
+++ b/docs/Mapping.md
@@ -143,7 +143,7 @@ Trigger action 11 `Text Trigger` now takes a string key for the tutorial text en
 |  **ID**  | **Action**               | **NeedCode** | **PARAM1**       | **PARAM2** | **PARAM3** | **PARAM4** | **PARAM5** | **PARAM6** |
 |----------|--------------------------|--------------|------------------|------------|------------|------------|------------|------------|
 | 11       | Text Trigger (Enhanced)     |
-|          | Displays a text message with optional color and duration. Supports templated text substitution: placeholders like `{{g_variableName}}` or `{{l_variableName}}` are replaced with the corresponding global or local variable values. Duration is in real time seconds (0 means like in vanilla). | Other (0) | Text Index (string)     | Color (#) | Duration  | *unused*   | *unused*   | *unused*   |
+|          | Displays a text message with optional color and duration. Supports templated text substitution: placeholders like `{{g_variableName}}` or `{{l_variableName}}` are replaced with the corresponding global or local variable values. Duration is in real time seconds (0 means like in vanilla). | Other (0) | Text ID (string)     | Color (#) | Duration  | *unused*   | *unused*   | *unused*   |
 | 106      | Give Credits             |
 |          | Gives or removes credits from the specified house. A positive amount gives money, a negative amount subtracts it. | Other (0)   | House (#)        | Credits    | *unused*   | *unused*   | *unused*   | *unused*   |
 | 107      | Enable Short Game        |

--- a/docs/Mapping.md
+++ b/docs/Mapping.md
@@ -136,10 +136,14 @@ NAME = [Action Count], [TActionType], [NeedCode], [PARAM1], [PARAM2], [PARAM3], 
 
 ### New Trigger Actions
 
+```{warning}
+Trigger action 11 `Text Trigger` now takes a string key for the tutorial text entry, not an interer!
+```
+
 |  **ID**  | **Action**               | **NeedCode** | **PARAM1**       | **PARAM2** | **PARAM3** | **PARAM4** | **PARAM5** | **PARAM6** |
 |----------|--------------------------|--------------|------------------|------------|------------|------------|------------|------------|
 | 11       | Text Trigger (Enhanced)     |
-|          | Displays a text message with optional color and duration. Supports templated text substitution: placeholders like `{{g_variableName}}` or `{{l_variableName}}` are replaced with the corresponding global or local variable values. Duration is in real time seconds (0 means like in vanilla). | Other (0) | Text Index (#)     | Color (#) | Duration  | *unused*   | *unused*   | *unused*   |
+|          | Displays a text message with optional color and duration. Supports templated text substitution: placeholders like `{{g_variableName}}` or `{{l_variableName}}` are replaced with the corresponding global or local variable values. Duration is in real time seconds (0 means like in vanilla). | Other (0) | Text Index (string)     | Color (#) | Duration  | *unused*   | *unused*   | *unused*   |
 | 106      | Give Credits             |
 |          | Gives or removes credits from the specified house. A positive amount gives money, a negative amount subtracts it. | Other (0)   | House (#)        | Credits    | *unused*   | *unused*   | *unused*   | *unused*   |
 | 107      | Enable Short Game        |

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -79,6 +79,7 @@ New:
 - Improve alternative factory selection when the primary factory is blocked (by Rampstring)
 - Add "Adjust House Modifier" trigger action (by Rampstring)
 - Add "Only Harvesters" quarry (by Rampastring)
+- Tutorial text INI keys are now interpreted as strings, not integers (by ZivDero)
 
 
 Vinifera fixes:

--- a/src/extensions/extension.cpp
+++ b/src/extensions/extension.cpp
@@ -514,7 +514,7 @@ AbstractClassExtension *Extension::Private::Make_Internal(const AbstractClass *a
         case RTTI_SMUDGETYPE: { extptr = Extension_Make<SmudgeTypeClass, SmudgeTypeClassExtension>(reinterpret_cast<const SmudgeTypeClass *>(abstract)); break; }
         case RTTI_SUPERWEAPONTYPE: { extptr = Extension_Make<SuperWeaponTypeClass, SuperWeaponTypeClassExtension>(reinterpret_cast<const SuperWeaponTypeClass *>(abstract)); break; }
         //case RTTI_TASKFORCE: { extptr = Extension_Make<TaskForceClass, TaskForceClassExtension>(reinterpret_cast<const TaskForceClass *>(abstract)); break; } // Not yet implemented
-        case RTTI_TEAM: { extptr = Extension_Make<TeamClass, TeamClassExtension>(reinterpret_cast<const TeamClass *>(abstract)); break; } // Not yet implemented
+        case RTTI_TEAM: { extptr = Extension_Make<TeamClass, TeamClassExtension>(reinterpret_cast<const TeamClass *>(abstract)); break; }
         case RTTI_TEAMTYPE: { extptr = Extension_Make<TeamTypeClass, TeamTypeClassExtension>(reinterpret_cast<const TeamTypeClass *>(abstract)); break; }
         case RTTI_TERRAIN: { extptr = Extension_Make<TerrainClass, TerrainClassExtension>(reinterpret_cast<const TerrainClass *>(abstract)); break; }
         case RTTI_TERRAINTYPE: { extptr = Extension_Make<TerrainTypeClass, TerrainTypeClassExtension>(reinterpret_cast<const TerrainTypeClass *>(abstract)); break; }
@@ -527,7 +527,7 @@ AbstractClassExtension *Extension::Private::Make_Internal(const AbstractClass *a
         //case RTTI_TAG: { extptr = Extension_Make<TagClass, TagClassExtension>(reinterpret_cast<const TagClass *>(abstract)); break; } // Not yet implemented
         //case RTTI_TAGTYPE: { extptr = Extension_Make<TagTypeClass, Extension>(reinterpret_cast<const TagTypeClass *>(abstract)); break; } // Not yet implemented
         case RTTI_TIBERIUM: { extptr = Extension_Make<TiberiumClass, TiberiumClassExtension>(reinterpret_cast<const TiberiumClass *>(abstract)); break; }
-        case RTTI_ACTION: { extptr = Extension_Make<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; } // Not yet implemented
+        case RTTI_ACTION: { extptr = Extension_Make<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; }
         case RTTI_EVENT: { extptr = Extension_Make<TEventClass, TEventClassExtension>(reinterpret_cast<const TEventClass *>(abstract)); break; }
         case RTTI_WEAPONTYPE: { extptr = Extension_Make<WeaponTypeClass, WeaponTypeClassExtension>(reinterpret_cast<const WeaponTypeClass *>(abstract)); break; }
         case RTTI_WARHEADTYPE: { extptr = Extension_Make<WarheadTypeClass, WarheadTypeClassExtension>(reinterpret_cast<const WarheadTypeClass *>(abstract)); break; }
@@ -594,7 +594,7 @@ bool Extension::Private::Destroy_Internal(const AbstractClass *abstract)
         case RTTI_SMUDGETYPE: { removed = Extension_Destroy<SmudgeTypeClass, SmudgeTypeClassExtension>(reinterpret_cast<const SmudgeTypeClass *>(abstract)); break; }
         case RTTI_SUPERWEAPONTYPE: { removed = Extension_Destroy<SuperWeaponTypeClass, SuperWeaponTypeClassExtension>(reinterpret_cast<const SuperWeaponTypeClass *>(abstract)); break; }
         //case RTTI_TASKFORCE: { removed = Extension_Destroy<TaskForceClass, TaskForceClassExtension>(reinterpret_cast<const TaskForceClass *>(abstract)); break; } // Not yet implemented
-        case RTTI_TEAM: { removed = Extension_Destroy<TeamClass, TeamClassExtension>(reinterpret_cast<const TeamClass *>(abstract)); break; } // Not yet implemented
+        case RTTI_TEAM: { removed = Extension_Destroy<TeamClass, TeamClassExtension>(reinterpret_cast<const TeamClass *>(abstract)); break; }
         case RTTI_TEAMTYPE: { removed = Extension_Destroy<TeamTypeClass, TeamTypeClassExtension>(reinterpret_cast<const TeamTypeClass *>(abstract)); break; }
         case RTTI_TERRAIN: { removed = Extension_Destroy<TerrainClass, TerrainClassExtension>(reinterpret_cast<const TerrainClass *>(abstract)); break; }
         case RTTI_TERRAINTYPE: { removed = Extension_Destroy<TerrainTypeClass, TerrainTypeClassExtension>(reinterpret_cast<const TerrainTypeClass *>(abstract)); break; }
@@ -607,8 +607,8 @@ bool Extension::Private::Destroy_Internal(const AbstractClass *abstract)
         //case RTTI_TAG: { removed = Extension_Destroy<TagClass, TagClassExtension>(reinterpret_cast<const TagClass *>(abstract)); break; } // Not yet implemented
         //case RTTI_TAGTYPE: { removed = Extension_Destroy<TagTypeClass, Extension>(reinterpret_cast<const TagTypeClass *>(abstract)); break; } // Not yet implemented
         case RTTI_TIBERIUM: { removed = Extension_Destroy<TiberiumClass, TiberiumClassExtension>(reinterpret_cast<const TiberiumClass *>(abstract)); break; }
-        case RTTI_ACTION: { removed = Extension_Destroy<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; } // Not yet implemented
-        case RTTI_EVENT: { removed = Extension_Destroy<TEventClass, TEventClassExtension>(reinterpret_cast<const TEventClass *>(abstract)); break; } // Not yet implemented
+        case RTTI_ACTION: { removed = Extension_Destroy<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; }
+        case RTTI_EVENT: { removed = Extension_Destroy<TEventClass, TEventClassExtension>(reinterpret_cast<const TEventClass *>(abstract)); break; }
         case RTTI_WEAPONTYPE: { removed = Extension_Destroy<WeaponTypeClass, WeaponTypeClassExtension>(reinterpret_cast<const WeaponTypeClass *>(abstract)); break; }
         case RTTI_WARHEADTYPE: { removed = Extension_Destroy<WarheadTypeClass, WarheadTypeClassExtension>(reinterpret_cast<const WarheadTypeClass *>(abstract)); break; }
         //case RTTI_WAYPOINT: { removed = Extension_Destroy<WaypointClass, WaypointClassExtension>(reinterpret_cast<const WaypointClass *>(abstract)); break; } // Not yet implemented
@@ -688,7 +688,7 @@ bool Extension::Save(IStream *pStm)
     if (!Extension_Save<BuildingTypeClass, BuildingTypeClassExtension>(pStm, BuildingTypeExtensions)) { return false; }
     //if (!Extension_Save<BulletClass, BulletClassExtension>(pStm, BulletExtensions)) { return false; }                 // Not yet implemented
     if (!Extension_Save<BulletTypeClass, BulletTypeClassExtension>(pStm, BulletTypeExtensions)) { return false; }
-    //if (!Extension_Save<CampaignClass, CampaignClassExtension>(pStm, CampaignExtensions)) { return false; }           // Supported, but Campaign's are not saved to file.
+    //if (!Extension_Save<CampaignClass, CampaignClassExtension>(pStm, CampaignExtensions)) { return false; }           // Supported, but Campaigns are not saved to file.
     //if (!Extension_Save<CellClass, CellClassExtension>(pStm, CellExtensions)) { return false; }                       // Not yet implemented
     if (!Extension_Save<FactoryClass, FactoryClassExtension>(pStm, FactoryExtensions)) { return false; }
     if (!Extension_Save<HouseClass, HouseClassExtension>(pStm, HouseExtensions)) { return false; }
@@ -696,7 +696,7 @@ bool Extension::Save(IStream *pStm)
     if (!Extension_Save<InfantryClass, InfantryClassExtension>(pStm, InfantryExtensions)) { return false; }
     if (!Extension_Save<InfantryTypeClass, InfantryTypeClassExtension>(pStm, InfantryTypeExtensions)) { return false; }
     //if (!Extension_Save<IsometricTileClass, IsometricTileClassExtension>(pStm, IsometricTileExtensions)) { return false; } // Not yet implemented
-    //if (!Extension_Save<IsometricTileTypeClass, IsometricTileTypeClassExtension>(pStm, IsometricTileTypeExtensions)) { return false; } // Supported, but IsoTileTypes's are not saved to file.
+    //if (!Extension_Save<IsometricTileTypeClass, IsometricTileTypeClassExtension>(pStm, IsometricTileTypeExtensions)) { return false; } // Supported, but IsoTileTypess are not saved to file.
     //if (!Extension_Save<BuildingLightClass, BuildingLightClassExtension>(pStm, BuildingLightExtensions)) { return false; } // Not yet implemented
     if (!Extension_Save<OverlayClass, OverlayClassExtension>(pStm, OverlayExtensions)) { return false; }
     if (!Extension_Save<OverlayTypeClass, OverlayTypeClassExtension>(pStm, OverlayTypeExtensions)) { return false; }
@@ -929,7 +929,7 @@ bool Extension::Request_Pointer_Remap()
     //if (!Extension_Request_Pointer_Remap<TagClass, TagClassExtension>(Tags)) { return false; }                        // Not yet implemented
     //if (!Extension_Request_Pointer_Remap<TagTypeClass, TagTypeClassExtension>(TagTypes)) { return false; }            // Not yet implemented
     if (!Extension_Request_Pointer_Remap<TiberiumClass, TiberiumClassExtension>(Tiberiums)) { return false; }
-    if (!Extension_Request_Pointer_Remap<TActionClass, TActionClassExtension>(TActions)) { return false; }            // Not yet implemented
+    if (!Extension_Request_Pointer_Remap<TActionClass, TActionClassExtension>(TActions)) { return false; }
     if (!Extension_Request_Pointer_Remap<TEventClass, TEventClassExtension>(TEvents)) { return false; }
     if (!Extension_Request_Pointer_Remap<WeaponTypeClass, WeaponTypeClassExtension>(Weapons)) { return false; }
     if (!Extension_Request_Pointer_Remap<WarheadTypeClass, WarheadTypeClassExtension>(Warheads)) { return false; }

--- a/src/extensions/extension.cpp
+++ b/src/extensions/extension.cpp
@@ -141,6 +141,7 @@
 #include "waveext.h"
 #include "weapontypeext.h"
 #include "teventext.h"
+#include "tactionext.h"
 
 #include "rulesext.h"
 #include "scenarioext.h"
@@ -526,7 +527,7 @@ AbstractClassExtension *Extension::Private::Make_Internal(const AbstractClass *a
         //case RTTI_TAG: { extptr = Extension_Make<TagClass, TagClassExtension>(reinterpret_cast<const TagClass *>(abstract)); break; } // Not yet implemented
         //case RTTI_TAGTYPE: { extptr = Extension_Make<TagTypeClass, Extension>(reinterpret_cast<const TagTypeClass *>(abstract)); break; } // Not yet implemented
         case RTTI_TIBERIUM: { extptr = Extension_Make<TiberiumClass, TiberiumClassExtension>(reinterpret_cast<const TiberiumClass *>(abstract)); break; }
-        //case RTTI_ACTION: { extptr = Extension_Make<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; } // Not yet implemented
+        case RTTI_ACTION: { extptr = Extension_Make<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; } // Not yet implemented
         case RTTI_EVENT: { extptr = Extension_Make<TEventClass, TEventClassExtension>(reinterpret_cast<const TEventClass *>(abstract)); break; }
         case RTTI_WEAPONTYPE: { extptr = Extension_Make<WeaponTypeClass, WeaponTypeClassExtension>(reinterpret_cast<const WeaponTypeClass *>(abstract)); break; }
         case RTTI_WARHEADTYPE: { extptr = Extension_Make<WarheadTypeClass, WarheadTypeClassExtension>(reinterpret_cast<const WarheadTypeClass *>(abstract)); break; }
@@ -606,7 +607,7 @@ bool Extension::Private::Destroy_Internal(const AbstractClass *abstract)
         //case RTTI_TAG: { removed = Extension_Destroy<TagClass, TagClassExtension>(reinterpret_cast<const TagClass *>(abstract)); break; } // Not yet implemented
         //case RTTI_TAGTYPE: { removed = Extension_Destroy<TagTypeClass, Extension>(reinterpret_cast<const TagTypeClass *>(abstract)); break; } // Not yet implemented
         case RTTI_TIBERIUM: { removed = Extension_Destroy<TiberiumClass, TiberiumClassExtension>(reinterpret_cast<const TiberiumClass *>(abstract)); break; }
-        //case RTTI_ACTION: { removed = Extension_Destroy<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; } // Not yet implemented
+        case RTTI_ACTION: { removed = Extension_Destroy<TActionClass, TActionClassExtension>(reinterpret_cast<const TActionClass *>(abstract)); break; } // Not yet implemented
         case RTTI_EVENT: { removed = Extension_Destroy<TEventClass, TEventClassExtension>(reinterpret_cast<const TEventClass *>(abstract)); break; } // Not yet implemented
         case RTTI_WEAPONTYPE: { removed = Extension_Destroy<WeaponTypeClass, WeaponTypeClassExtension>(reinterpret_cast<const WeaponTypeClass *>(abstract)); break; }
         case RTTI_WARHEADTYPE: { removed = Extension_Destroy<WarheadTypeClass, WarheadTypeClassExtension>(reinterpret_cast<const WarheadTypeClass *>(abstract)); break; }
@@ -723,7 +724,7 @@ bool Extension::Save(IStream *pStm)
     //if (!Extension_Save<TagClass, TagClassExtension>(pStm, TagExtensions)) { return false; }                          // Not yet implemented
     //if (!Extension_Save<TagTypeClass, TagTypeClassExtension>(pStm, TagTypeExtensions)) { return false; }              // Not yet implemented
     if (!Extension_Save<TiberiumClass, TiberiumClassExtension>(pStm, TiberiumExtensions)) { return false; }
-    //if (!Extension_Save<TActionClass, TActionClassExtension>(pStm, TActionExtensions)) { return false; }              // Not yet implemented
+    if (!Extension_Save<TActionClass, TActionClassExtension>(pStm, TActionExtensions)) { return false; }
     if (!Extension_Save<TEventClass, TEventClassExtension>(pStm, TEventExtensions)) { return false; }
     if (!Extension_Save<WeaponTypeClass, WeaponTypeClassExtension>(pStm, WeaponTypeExtensions)) { return false; }
     if (!Extension_Save<WarheadTypeClass, WarheadTypeClassExtension>(pStm, WarheadTypeExtensions)) { return false; }
@@ -823,7 +824,7 @@ bool Extension::Load(IStream *pStm)
     //if (!Extension_Load<TagClass, TagClassExtension>(pStm, TagExtensions)) { return false; }                          // Not yet implemented
     //if (!Extension_Load<TagTypeClass, TagTypeClassExtension>(pStm, TagTypeExtensions)) { return false; }              // Not yet implemented
     if (!Extension_Load<TiberiumClass, TiberiumClassExtension>(pStm, TiberiumExtensions)) { return false; }
-    //if (!Extension_Load<TActionClass, TActionClassExtension>(pStm, TActionExtensions)) { return false; }              // Not yet implemented
+    if (!Extension_Load<TActionClass, TActionClassExtension>(pStm, TActionExtensions)) { return false; }
     if (!Extension_Load<TEventClass, TEventClassExtension>(pStm, TEventExtensions)) { return false; }
     if (!Extension_Load<WeaponTypeClass, WeaponTypeClassExtension>(pStm, WeaponTypeExtensions)) { return false; }
     if (!Extension_Load<WarheadTypeClass, WarheadTypeClassExtension>(pStm, WarheadTypeExtensions)) { return false; }
@@ -928,7 +929,7 @@ bool Extension::Request_Pointer_Remap()
     //if (!Extension_Request_Pointer_Remap<TagClass, TagClassExtension>(Tags)) { return false; }                        // Not yet implemented
     //if (!Extension_Request_Pointer_Remap<TagTypeClass, TagTypeClassExtension>(TagTypes)) { return false; }            // Not yet implemented
     if (!Extension_Request_Pointer_Remap<TiberiumClass, TiberiumClassExtension>(Tiberiums)) { return false; }
-    //if (!Extension_Request_Pointer_Remap<TActionClass, TActionClassExtension>(TActions)) { return false; }            // Not yet implemented
+    if (!Extension_Request_Pointer_Remap<TActionClass, TActionClassExtension>(TActions)) { return false; }            // Not yet implemented
     if (!Extension_Request_Pointer_Remap<TEventClass, TEventClassExtension>(TEvents)) { return false; }
     if (!Extension_Request_Pointer_Remap<WeaponTypeClass, WeaponTypeClassExtension>(Weapons)) { return false; }
     if (!Extension_Request_Pointer_Remap<WarheadTypeClass, WarheadTypeClassExtension>(Warheads)) { return false; }
@@ -1007,7 +1008,7 @@ bool Extension::Register_Class_Factories()
     //REGISTER_CLASS(TagClassExtension);                                        // Not yet implemented
     //REGISTER_CLASS(TagTypeClassExtension);                                    // Not yet implemented
     REGISTER_CLASS(TiberiumClassExtension);
-    //REGISTER_CLASS(TActionClassExtension);                                    // Not yet implemented
+    REGISTER_CLASS(TActionClassExtension);
     REGISTER_CLASS(TEventClassExtension);
     REGISTER_CLASS(WeaponTypeClassExtension);
     REGISTER_CLASS(WarheadTypeClassExtension);
@@ -1089,9 +1090,9 @@ void Extension::Free_Heaps()
     //TagExtensions.Clear();                                                    // Not yet implemented
     //TagTypeExtensions.Clear();                                                // Not yet implemented
     TiberiumExtensions.Clear();
-    //TActionExtensions.Clear();                                                // Not yet implemented
+    TActionExtensions.Clear();
     TEventExtensions.Clear();
-     WeaponTypeExtensions.Clear();
+    WeaponTypeExtensions.Clear();
     WarheadTypeExtensions.Clear();
     //WaypointExtensions.Clear();                                               // Not yet implemented
     //TubeExtensions.Clear();                                                   // Not yet implemented
@@ -1418,7 +1419,7 @@ void Extension::Print_CRCs(FILE *fp, EventClass *ev)
     //std::fprintf(fp, "TagExtensions.Count = %d\n", TagExtensions.Count());                                            // Not yet implemented
     //std::fprintf(fp, "TagTypeExtensions.Count = %d\n", TagTypeExtensions.Count());                                    // Not yet implemented
     std::fprintf(fp, "TiberiumExtensions.Count = %d\n", TiberiumExtensions.Count());
-    //std::fprintf(fp, "TActionExtensions.Count = %d\n", TActionExtensions.Count());                                    // Not yet implemented
+    std::fprintf(fp, "TActionExtensions.Count = %d\n", TActionExtensions.Count());
     std::fprintf(fp, "TEventExtensions.Count = %d\n", TEventExtensions.Count());
     std::fprintf(fp, "WeaponTypeExtensions.Count = %d\n", WeaponTypeExtensions.Count());
     std::fprintf(fp, "WarheadTypeExtensions.Count = %d\n", WarheadTypeExtensions.Count());
@@ -1936,7 +1937,7 @@ void Extension::Print_CRCs(FILE *fp, EventClass *ev)
     //Print_Heap_CRC_Lists(fp, TagExtensions);                                  // Not yet implemented
     //Print_Heap_CRC_Lists(fp, TagTypeExtensions);                              // Not yet implemented
     Print_Heap_CRC_Lists(fp, TiberiumExtensions);
-    //Print_Heap_CRC_Lists(fp, TActionExtensions);                              // Not yet implemented
+    Print_Heap_CRC_Lists(fp, TActionExtensions);
     Print_Heap_CRC_Lists(fp, TEventExtensions);
     Print_Heap_CRC_Lists(fp, WeaponTypeExtensions);
     Print_Heap_CRC_Lists(fp, WarheadTypeExtensions);
@@ -2017,7 +2018,7 @@ void Extension::Detach_This_From_All(AbstractClass * target, bool all)
     //Extension_Detach_This_From_All(TagExtensions, target, all);               // Not yet implemented
     //Extension_Detach_This_From_All(TagTypeExtensions, target, all);           // Not yet implemented
     Extension_Detach_This_From_All(TiberiumExtensions, target, all);
-    //Extension_Detach_This_From_All(TActionExtensions, target, all);           // Not yet implemented
+    Extension_Detach_This_From_All(TActionExtensions, target, all);
     Extension_Detach_This_From_All(TEventExtensions, target, all);
     Extension_Detach_This_From_All(WeaponTypeExtensions, target, all);
     Extension_Detach_This_From_All(WarheadTypeExtensions, target, all);
@@ -2106,7 +2107,7 @@ unsigned Extension::Get_Save_Version_Number()
     //version += sizeof(TagClassExtension);                                     // Not yet implemented
     //version += sizeof(TagTypeClassExtension);                                 // Not yet implemented
     version += sizeof(TiberiumClassExtension);
-    //version += sizeof(TActionClassExtension);                                 // Not yet implemented
+    version += sizeof(TActionClassExtension);                                 // Not yet implemented
     version += sizeof(TEventClassExtension);
     version += sizeof(WeaponTypeClassExtension);
     version += sizeof(WarheadTypeClassExtension);

--- a/src/extensions/extension.h
+++ b/src/extensions/extension.h
@@ -175,7 +175,7 @@ class WaveClassExtension;
 // class TagClassExtension;
 // class TagTypeClassExtension;
 class TiberiumClassExtension;
-// class TActionClassExtension;
+class TActionClassExtension;
 // class TEventClassExtension;
 class WeaponTypeClassExtension;
 class WarheadTypeClassExtension;
@@ -430,7 +430,7 @@ MAKE_EXTENSION_PAIR(WaveClass);
 //MAKE_EXTENSION_PAIR(TagClass);                                        // Not yet implemented
 //MAKE_EXTENSION_PAIR(TagTypeClass);                                    // Not yet implemented
 MAKE_EXTENSION_PAIR(TiberiumClass);
-//MAKE_EXTENSION_PAIR(TActionClass);                                    // Not yet implemented
+MAKE_EXTENSION_PAIR(TActionClass);
 //MAKE_EXTENSION_PAIR(TEventClass);                                     // Not yet implemented
 MAKE_EXTENSION_PAIR(WeaponTypeClass);
 MAKE_EXTENSION_PAIR(WarheadTypeClass);

--- a/src/extensions/extension_globals.cpp
+++ b/src/extensions/extension_globals.cpp
@@ -63,6 +63,7 @@ DynamicVectorClass<WarheadTypeClassExtension *> WarheadTypeExtensions;
 DynamicVectorClass<WaveClassExtension *> WaveExtensions;
 DynamicVectorClass<WeaponTypeClassExtension *> WeaponTypeExtensions;
 DynamicVectorClass<TEventClassExtension*> TEventExtensions;
+DynamicVectorClass<TActionClassExtension*> TActionExtensions;
 
 TacticalExtension *TacticalMapExtension = nullptr;
 

--- a/src/extensions/extension_globals.h
+++ b/src/extensions/extension_globals.h
@@ -71,6 +71,7 @@ class WarheadTypeClassExtension;
 class WaveClassExtension;
 class WeaponTypeClassExtension;
 class TEventClassExtension;
+class TActionClassExtension;
 
 class TacticalExtension;
 
@@ -141,6 +142,7 @@ extern DynamicVectorClass<WarheadTypeClassExtension *> WarheadTypeExtensions;
 extern DynamicVectorClass<WaveClassExtension *> WaveExtensions;
 extern DynamicVectorClass<WeaponTypeClassExtension *> WeaponTypeExtensions;
 extern DynamicVectorClass<TEventClassExtension*> TEventExtensions;
+extern DynamicVectorClass<TActionClassExtension*> TActionExtensions;
 
 /**
  *  Abstract derived classes, but only a single instance is required.

--- a/src/extensions/init/initext_hooks.cpp
+++ b/src/extensions/init/initext_hooks.cpp
@@ -41,6 +41,7 @@
 #include "iomap.h"
 #include "dsaudio.h"
 #include "asserthandler.h"
+#include "ccini.h"
 #include "debughandler.h"
 #include "optionsext.h"
 #include "sdl_functions.h"
@@ -50,6 +51,7 @@
 #include <bcrypt.h>
 
 #include "hooker.h"
+#include "scenarioext.h"
 #include "syringe.h"
 
 
@@ -845,6 +847,31 @@ DEFINE_HOOK(0x006B7E22, WinMainCRTStartup_Syringe_Patch, 9)
         }
     }
 
+    return 0;
+}
+
+
+/**
+ *  Load tutorial.ini into our new map in Init_Bulk_Data.
+ *
+ *  @author: ZivDero
+ */
+DEFINE_HOOK(0x004E46BB, _Init_Bulk_Data_Tutorial_Text_Patch, 0)
+{
+    REF_STACK(CCINIClass, tutorial_ini, 0x18);
+    ScenarioClassExtension::Read_Tutorial_INI(tutorial_ini);
+    return 0x004E482E;
+}
+
+
+/**
+ *  Clear our new tutorial text map in Prog_End.
+ *
+ *  @author: ZivDero
+ */
+DEFINE_HOOK(0x00601B15, _Prog_End_Tutorial_Text_Patch, 5)
+{
+    Vinifera_TutorialText.clear();
     return 0;
 }
 

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -277,7 +277,7 @@ bool ScenarioClassExtension::Read_Tutorial_INI(CCINIClass const& ini)
             /**
              *  Get a tutorial message entry.
              */
-            if (ini.Get_String(TUTORIAL, entry, buffer, sizeof(buffer))) {
+            if (ini.Get_String(TUTORIAL, entry, "", buffer, sizeof(buffer))) {
                 Vinifera_TutorialText[entry] = buffer;
             }
         }

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -199,19 +199,14 @@ void ScenarioClassExtension::Init_Clear()
          *  Clear the any previously loaded tutorial messages in preperation for
          *  reloading the TUTORIAL.INI as they might contain scenario overrides.
          */
-        for (int i = 0; i < TutorialText.Count(); i++) {
-            const char* txt = TutorialText.Fetch_By_Position(i);
-            if (txt != nullptr) {
-                free(const_cast<char*>(txt));
-            }
-        }
-        TutorialText.Clear();
+        Vinifera_TutorialText.clear();
 
         /**
          *  Reload the main tutorial message data.
          */
         CCINIClass ini;
-        ini.Load(CCFileClass("TUTORIAL.INI"), false);
+        CCFileClass tutorial_file("TUTORIAL.INI");
+        ini.Load(tutorial_file, false);
         Read_Tutorial_INI(ini);
     }
 
@@ -252,7 +247,7 @@ bool ScenarioClassExtension::Read_INI(CCINIClass &ini)
      * 
      *  Fetch additional tutorial message data (if present) from the scenario.
      */
-    Read_Tutorial_INI(ini, true);
+    Read_Tutorial_INI(ini);
 
     BeaconManager.Load_Art();
 
@@ -265,20 +260,16 @@ bool ScenarioClassExtension::Read_INI(CCINIClass &ini)
  *
  *  @author: CCHyper
  */
-bool ScenarioClassExtension::Read_Tutorial_INI(CCINIClass &ini, bool log)
+bool ScenarioClassExtension::Read_Tutorial_INI(CCINIClass const& ini)
 {
+    char buffer[512];
     static char const * const TUTORIAL = "Tutorial";
 
     /**
      *  Fetch the additional tutorial message data (if present).
      */
     if (ini.Is_Present(TUTORIAL)) {
-
-        char buf[300];
-
         int counter = ini.Entry_Count(TUTORIAL);
-
-        if (counter > 0 && log) DEBUG_INFO("Tutorial section found and has %d entries.\n", counter);
 
         for (int index = 0; index < counter; ++index) {
             const char *entry = ini.Get_Entry(TUTORIAL, index);
@@ -286,36 +277,10 @@ bool ScenarioClassExtension::Read_Tutorial_INI(CCINIClass &ini, bool log)
             /**
              *  Get a tutorial message entry.
              */
-            if (ini.Get_String(TUTORIAL, entry, "", buf, sizeof(buf))) {
-
-                /**
-                 *  Convert the entry name (which in this context is an index) to an "id" value.
-                 */
-                int id = std::strtol(entry, nullptr, 10);
-                const char *string = strdup(buf);
-
-                /**
-                 *  Check to see if this id already exists before adding it, otherwise
-                 *  the replacement message will not get used.
-                 */
-                if (TutorialText.Is_Present(id)) {
-                    TutorialText.Remove_Index(id);
-                    if (log) DEV_DEBUG_INFO("  Removed ID '%d' from TutorialText index.\n", id);
-#ifndef NDEBUG
-                    if (log) { DEV_DEBUG_INFO("  %d = \"%s\".\n", id, TutorialText[id]); }
-#endif
-                }
-
-                if (log) DEV_DEBUG_INFO("  Adding ID '%d' from TutorialText index.\n", id);
-#ifndef NDEBUG
-                if (log) DEV_DEBUG_INFO("  %d = \"%s\".\n", id, string);
-#endif
-
-                TutorialText.Add_Index(id, string);
+            if (ini.Get_String(TUTORIAL, entry, buffer, sizeof(buffer))) {
+                Vinifera_TutorialText[entry] = buffer;
             }
-
         }
-
     }
 
     return true;

--- a/src/extensions/scenario/scenarioext.h
+++ b/src/extensions/scenario/scenarioext.h
@@ -53,7 +53,7 @@ class ScenarioClassExtension final : public GlobalExtensionClass<ScenarioClass>
         void Init_Clear();
         bool Read_INI(CCINIClass &ini);
 
-        bool Read_Tutorial_INI(CCINIClass &ini, bool log = false);
+        static bool Read_Tutorial_INI(CCINIClass const& ini);
 
         Cell Waypoint_Cell(WAYPOINT wp) const;
         CellClass * Waypoint_CellClass(WAYPOINT wp) const;

--- a/src/extensions/taction/tactionext.cpp
+++ b/src/extensions/taction/tactionext.cpp
@@ -1501,11 +1501,11 @@ bool TActionClassExtension::Do_DISABLE_TEMPLATED_TEXT(HouseClass* house, ObjectC
  *
  *  @author: Rampastring
  */
-bool TActionClassExtension::Do_ADJUST_HOUSE_MODIFIER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_ADJUST_HOUSE_MODIFIER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    int amount = taction.TriggerRect.X;
+    int amount = This()->TriggerRect.X;
 
-    switch (taction.Data.Value)
+    switch (This()->Data.Value)
     {
     case 0:
         house->FirepowerBias += (double)amount / 100.0;

--- a/src/extensions/taction/tactionext.cpp
+++ b/src/extensions/taction/tactionext.cpp
@@ -41,10 +41,13 @@
 #include "session.h"
 #include "tacticalext.h"
 #include "tag.h"
+#include "tagtype.h"
+#include "teamtype.h"
 #include "techno.h"
 #include "tibsun_inline.h"
 #include "trigger.h"
 #include "triggertype.h"
+#include "vinifera_globals.h"
 #include "voc.h"
 
 
@@ -80,6 +83,139 @@ TActionClass::ActionDescriptionStruct TActionClassExtension::ExtActionDescriptio
     { "Disable templated text", "Removes the currently active templated text from the screen." },
     { "Adjust House Modifier", "Adjusts a house modifier by given percentage points." },
 };
+
+
+/**
+ *  Class constructor.
+ *
+ *  @author: ZivDero
+ */
+TActionClassExtension::TActionClassExtension(const TActionClass* this_ptr) :
+    AbstractClassExtension(this_ptr),
+    Text {""}
+{
+    // if (this_ptr) EXT_DEBUG_TRACE("TActionClassExtension::TActionClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    TActionExtensions.Add(this);
+}
+
+
+/**
+ *  Class no-init constructor.
+ *
+ *  @author: ZivDero
+ */
+TActionClassExtension::TActionClassExtension(const NoInitClass& noinit) :
+    AbstractClassExtension(noinit),
+    Text(noinit)
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::TActionClassExtension(NoInitClass) - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+}
+
+
+/**
+ *  Class destructor.
+ *
+ *  @author: ZivDero
+ */
+TActionClassExtension::~TActionClassExtension()
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::~TActionClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    TActionExtensions.Delete(this);
+}
+
+
+/**
+ *  Retrieves the class identifier (CLSID) of the object.
+ *
+ *  @author: ZivDero
+ */
+HRESULT TActionClassExtension::GetClassID(CLSID* lpClassID)
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::GetClassID - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    if (lpClassID == nullptr) {
+        return E_POINTER;
+    }
+
+    *lpClassID = __uuidof(this);
+
+    return S_OK;
+}
+
+
+/**
+ *  Initializes an object from the stream where it was saved previously.
+ *
+ *  @author: ZivDero
+ */
+HRESULT TActionClassExtension::Load(IStream* pStm)
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::Load - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    HRESULT hr = AbstractClassExtension::Internal_Load(pStm);
+    if (FAILED(hr)) {
+        return E_FAIL;
+    }
+
+    new (this) TActionClassExtension(NoInitClass());
+
+    return hr;
+}
+
+
+/**
+ *  Saves an object to the specified stream.
+ *
+ *  @author: ZivDero
+ */
+HRESULT TActionClassExtension::Save(IStream* pStm, BOOL fClearDirty)
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::Save - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    HRESULT hr = AbstractClassExtension::Internal_Save(pStm, fClearDirty);
+    if (FAILED(hr)) {
+        return hr;
+    }
+
+    return hr;
+}
+
+
+/**
+ *  Return the raw size of class data for save/load purposes.
+ *
+ *  @author: ZivDero
+ */
+int TActionClassExtension::Get_Object_Size() const
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::Get_Object_Size - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+
+    return sizeof(*this);
+}
+
+
+/**
+ *  Removes the specified target from any targeting and reference trackers.
+ *
+ *  @author: ZivDero
+ */
+void TActionClassExtension::Detach(AbstractClass* target, bool all)
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::Detach - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+}
+
+
+/**
+ *  Compute a unique crc value for this instance.
+ *
+ *  @author: ZivDero
+ */
+void TActionClassExtension::Object_CRC(CRCEngine& crc) const
+{
+    // EXT_DEBUG_TRACE("TActionClassExtension::Object_CRC - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
+}
 
 
 /**
@@ -125,7 +261,7 @@ const char* TActionClassExtension::Action_Description(int action)
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Execute(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Execute(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     bool success = false;
 
@@ -138,14 +274,14 @@ bool TActionClassExtension::Execute(TActionClass& taction, HouseClass* house, Ob
         object = nullptr;
     }
 
-    #define DISPATCH(a) case TACTION_ ## a: success = Do_ ## a (taction, house, object, trig, cell); break;
-    #define EXT_DISPATCH(a) case EXT_TACTION_ ## a: success = Do_ ## a (taction, house, object, trig, cell); break;
+    #define DISPATCH(a) case TACTION_ ## a: success = Do_ ## a (house, object, trig, cell); break;
+    #define EXT_DISPATCH(a) case EXT_TACTION_ ## a: success = Do_ ## a (house, object, trig, cell); break;
 
     // warning C4063: case '#' is not a valid value for switch of enum 'TActionType'
     #pragma warning(push)
     #pragma warning(disable : 4063)
 
-    switch (taction.Action) {
+    switch (This()->Action) {
 
         /**
          *  Intercepted vanilla TActions.
@@ -202,7 +338,7 @@ bool TActionClassExtension::Execute(TActionClass& taction, HouseClass* house, Ob
          *  Unexpected TActionType.
          */
     default:
-        DEV_DEBUG_WARNING("Invalid action type (%d)!\n", taction.Action);
+        DEV_DEBUG_WARNING("Invalid action type (%d)!\n", This()->Action);
         break;
     }
 
@@ -297,12 +433,12 @@ bool TActionClassExtension::Is_Vinifera_TAction(TActionType type)
  *
  *  @author: Rampastring
  */
-bool TActionClassExtension::Do_WIN(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_WIN(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Flag the player as won or lost, like in the original code.
      */
-    if (taction.Data.House == PlayerPtr->Class->House) {
+    if (This()->Data.House == PlayerPtr->Class->House) {
         PlayerPtr->Flag_To_Win();
     } else {
         PlayerPtr->Flag_To_Lose();
@@ -316,7 +452,7 @@ bool TActionClassExtension::Do_WIN(TActionClass& taction, HouseClass* house, Obj
         for (int i = 0; i < Houses.Count(); i++) {
             HouseClass* hptr = Houses[i];
 
-            if (hptr->Class->House != taction.Data.House) {
+            if (hptr->Class->House != This()->Data.House) {
                 hptr->IsDefeated = true;
             }
         }
@@ -334,12 +470,12 @@ bool TActionClassExtension::Do_WIN(TActionClass& taction, HouseClass* house, Obj
  *
  *  @author: Rampastring
  */
-bool TActionClassExtension::Do_LOSE(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_LOSE(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Flag the player as won or lost, like in the original code.
      */
-    if (taction.Data.House != PlayerPtr->Class->House) {
+    if (This()->Data.House != PlayerPtr->Class->House) {
         PlayerPtr->Flag_To_Win();
     } else {
         PlayerPtr->Flag_To_Lose();
@@ -353,7 +489,7 @@ bool TActionClassExtension::Do_LOSE(TActionClass& taction, HouseClass* house, Ob
         for (int i = 0; i < Houses.Count(); i++) {
             HouseClass* hptr = Houses[i];
 
-            if (hptr->Class->House == taction.Data.House) {
+            if (hptr->Class->House == This()->Data.House) {
                 hptr->IsDefeated = true;
             }
         }
@@ -368,22 +504,21 @@ bool TActionClassExtension::Do_LOSE(TActionClass& taction, HouseClass* house, Ob
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_TEXT_TRIGGER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_TEXT_TRIGGER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    int text_index = taction.Data.Value;
-    if (!TutorialText.Is_Present(text_index)) {
+    if (!Vinifera_TutorialText.contains(Text.c_str())) {
         return false;
     }
 
     /**
      *  Substitute the placeholders in the tutorial string.
      */
-    std::string text = ScenarioClassExtension::Substitute_Variable_Placeholders(TutorialText[text_index]);
+    std::string text = ScenarioClassExtension::Substitute_Variable_Placeholders(Vinifera_TutorialText[Text.c_str()]);
 
     /**
      *  Fetch the requested duration. If it's <= 0, fall back to vanilla.
      */
-    int duration = taction.TriggerRect.Y;
+    int duration = This()->TriggerRect.Y;
     duration = std::max(0, duration);
     if (duration == 0) {
         duration = Rule->MessageDelay * TICKS_PER_MINUTE;
@@ -391,7 +526,7 @@ bool TActionClassExtension::Do_TEXT_TRIGGER(TActionClass& taction, HouseClass* h
         duration *= TIMER_SECOND;
     }
 
-    ColorSchemeType color = static_cast<ColorSchemeType>(taction.TriggerRect.X) * 2;
+    ColorSchemeType color = static_cast<ColorSchemeType>(This()->TriggerRect.X) * 2;
     if (color < COLORSCHEME_FIRST || color >= ColorSchemes.Count()) {
         color = PlayerPtr->Scheme;
     }
@@ -412,13 +547,13 @@ bool TActionClassExtension::Do_TEXT_TRIGGER(TActionClass& taction, HouseClass* h
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_DESTROY_TRIGGER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DESTROY_TRIGGER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    if (taction.Trigger != nullptr) {
+    if (This()->Trigger != nullptr) {
         int count = Triggers.Count();
 
         for (int index = count - 1; index >= 0; index--) {
-            if (Triggers[index]->Class == taction.Trigger) {
+            if (Triggers[index]->Class == This()->Trigger) {
                 Triggers[index]->Mark_To_Die();
             }
         }
@@ -435,14 +570,14 @@ bool TActionClassExtension::Do_DESTROY_TRIGGER(TActionClass& taction, HouseClass
  *
  *  @author: CCHyper
  */
-bool TActionClassExtension::Do_ENABLE_TRIGGER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_ENABLE_TRIGGER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  This is direct port of the code from Red Alert 2, which looks to fix this issue.
      */
-    if (taction.Trigger != nullptr) {
+    if (This()->Trigger != nullptr) {
         for (int index = 0; index < Triggers.Count(); index++) {
-            if (Triggers[index]->Class == taction.Trigger) {
+            if (Triggers[index]->Class == This()->Trigger) {
                 bool really_enable = true;
 
                 /**
@@ -475,11 +610,11 @@ bool TActionClassExtension::Do_ENABLE_TRIGGER(TActionClass& taction, HouseClass*
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_DESTROY_TAG(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DESTROY_TAG(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    if (taction.Tag != nullptr) {
+    if (This()->Tag != nullptr) {
         for (int index = 0; index < Tags.Count(); index++) {
-            if (Tags[index]->Class == taction.Tag) {
+            if (Tags[index]->Class == This()->Tag) {
                 delete Tags[index];
                 index--;
             }
@@ -496,7 +631,7 @@ bool TActionClassExtension::Do_DESTROY_TAG(TActionClass& taction, HouseClass* ho
  *
  *  @author: CCHyper
  */
-bool TActionClassExtension::Do_PLAY_SOUND_RANDOM(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_PLAY_SOUND_RANDOM(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     Cell list[NEW_WAYPOINT_COUNT];
     int count = 0;
@@ -514,7 +649,7 @@ bool TActionClassExtension::Do_PLAY_SOUND_RANDOM(TActionClass& taction, HouseCla
     /**
      *  Pick a random cell from the valid waypoint list and play the desired sound.
      */
-    Static_Sound(taction.Data.Sound, list[Random_Pick(0u, std::size(list) - 1)].As_Coord());
+    Static_Sound(This()->Data.Sound, list[Random_Pick(0u, std::size(list) - 1)].As_Coord());
     return true;
 }
 
@@ -524,16 +659,16 @@ bool TActionClassExtension::Do_PLAY_SOUND_RANDOM(TActionClass& taction, HouseCla
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_GIVE_CREDITS(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_GIVE_CREDITS(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    HouseClass* hptr = HouseClassExtension::House_From_HousesType(taction.Data.House);
+    HouseClass* hptr = HouseClassExtension::House_From_HousesType(This()->Data.House);
 
     /**
      *  Give credits to the house.
      */
     if (hptr != nullptr) {
 
-        const int amount = taction.TriggerRect.X;
+        const int amount = This()->TriggerRect.X;
         if (amount >= 0) {
             hptr->Refund_Money(amount);
         } else {
@@ -550,7 +685,7 @@ bool TActionClassExtension::Do_GIVE_CREDITS(TActionClass& taction, HouseClass* h
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_ENABLE_SHORT_GAME(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_ENABLE_SHORT_GAME(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     Session.Options.ShortGame = true;
 
@@ -563,7 +698,7 @@ bool TActionClassExtension::Do_ENABLE_SHORT_GAME(TActionClass& taction, HouseCla
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_DISABLE_SHORT_GAME(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DISABLE_SHORT_GAME(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     Session.Options.ShortGame = false;
 
@@ -576,9 +711,9 @@ bool TActionClassExtension::Do_DISABLE_SHORT_GAME(TActionClass& taction, HouseCl
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_HOUSE_DESTROY_ALL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_HOUSE_DESTROY_ALL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    HouseClass* hptr = HouseClassExtension::House_From_HousesType(taction.Data.House);
+    HouseClass* hptr = HouseClassExtension::House_From_HousesType(This()->Data.House);
 
     /**
      *  Blow the house up and mark the player as defeated.
@@ -597,7 +732,7 @@ bool TActionClassExtension::Do_HOUSE_DESTROY_ALL(TActionClass& taction, HouseCla
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_MAKE_ELITE(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MAKE_ELITE(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Iterate all technos, and if their tag is attached to this trigger, make them elite.
@@ -621,7 +756,7 @@ bool TActionClassExtension::Do_MAKE_ELITE(TActionClass& taction, HouseClass* hou
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_ENABLE_ALLYREVEAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_ENABLE_ALLYREVEAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     Rule->IsAllyReveal = true;
 
@@ -634,7 +769,7 @@ bool TActionClassExtension::Do_ENABLE_ALLYREVEAL(TActionClass& taction, HouseCla
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_DISABLE_ALLYREVEAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DISABLE_ALLYREVEAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     Rule->IsAllyReveal = false;
 
@@ -647,7 +782,7 @@ bool TActionClassExtension::Do_DISABLE_ALLYREVEAL(TActionClass& taction, HouseCl
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_CREATE_AUTOSAVE(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_CREATE_AUTOSAVE(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     DEBUG_ERROR("EXT_TACTION_CREATE_AUTOSAVE is not yet implemented, but has been executed!");
     return false;
@@ -659,7 +794,7 @@ bool TActionClassExtension::Do_CREATE_AUTOSAVE(TActionClass& taction, HouseClass
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_DELETE_OBJECT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DELETE_OBJECT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Iterate all technos, and if their tag is attached to this trigger, flag them for deletion.
@@ -683,7 +818,7 @@ bool TActionClassExtension::Do_DELETE_OBJECT(TActionClass& taction, HouseClass* 
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_ALL_ASSIGN_MISSION(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_ALL_ASSIGN_MISSION(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Iterate all units, and if they are owned by the trigger owner, assign the mission.
@@ -693,7 +828,7 @@ bool TActionClassExtension::Do_ALL_ASSIGN_MISSION(TActionClass& taction, HouseCl
 
         if (techno->IsActive && techno->IsDown && !techno->IsInLimbo) {
             if (techno->House == house) {
-                techno->Assign_Mission(static_cast<MissionType>(taction.Data.Value));
+                techno->Assign_Mission(static_cast<MissionType>(This()->Data.Value));
             }
         }
     }
@@ -707,10 +842,10 @@ bool TActionClassExtension::Do_ALL_ASSIGN_MISSION(TActionClass& taction, HouseCl
  *
  *  @author: ZivDero, based on ts-patches implementation by Rampastring
  */
-bool TActionClassExtension::Do_MAKE_ALLY_ONE_WAY(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MAKE_ALLY_ONE_WAY(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    if (taction.Data.House != HOUSE_NONE) {
-        HouseClass* house2 = HouseClassExtension::House_From_HousesType(taction.Data.House);
+    if (This()->Data.House != HOUSE_NONE) {
+        HouseClass* house2 = HouseClassExtension::House_From_HousesType(This()->Data.House);
 
         /**
          *  We need to increment ScenarioInit to allow houses to ally even if
@@ -729,10 +864,10 @@ bool TActionClassExtension::Do_MAKE_ALLY_ONE_WAY(TActionClass& taction, HouseCla
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_MAKE_ENEMY_ONE_WAY(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MAKE_ENEMY_ONE_WAY(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    if (taction.Data.House != HOUSE_NONE) {
-        HouseClass* house2 = HouseClassExtension::House_From_HousesType(taction.Data.House);
+    if (This()->Data.House != HOUSE_NONE) {
+        HouseClass* house2 = HouseClassExtension::House_From_HousesType(This()->Data.House);
 
         /**
          *  We need to increment ScenarioInit to allow houses to ally even if
@@ -830,14 +965,14 @@ static int Operate(int lhs, int rhs, VariableOperation operation)
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_MODIFY_GLOBAL_CONSTANT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MODIFY_GLOBAL_CONSTANT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int left_index = taction.Data.Value;
-    VariableOperation operation = static_cast<VariableOperation>(taction.TriggerRect.X);
-    int right = taction.TriggerRect.Y;
+    int left_index = This()->Data.Value;
+    VariableOperation operation = static_cast<VariableOperation>(This()->TriggerRect.X);
+    int right = This()->TriggerRect.Y;
 
     /**
      *  Fetch the current value of the variable.
@@ -866,14 +1001,14 @@ bool TActionClassExtension::Do_MODIFY_GLOBAL_CONSTANT(TActionClass& taction, Hou
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_MODIFY_GLOBAL_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MODIFY_GLOBAL_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int left_index = taction.Data.Value;
-    VariableOperation operation = static_cast<VariableOperation>(taction.TriggerRect.X);
-    int right_index = taction.TriggerRect.Y;
+    int left_index = This()->Data.Value;
+    VariableOperation operation = static_cast<VariableOperation>(This()->TriggerRect.X);
+    int right_index = This()->TriggerRect.Y;
 
     /**
      *  Fetch the current value of the variable.
@@ -910,14 +1045,14 @@ bool TActionClassExtension::Do_MODIFY_GLOBAL_GLOBAL(TActionClass& taction, House
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_MODIFY_GLOBAL_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MODIFY_GLOBAL_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int left_index = taction.Data.Value;
-    VariableOperation operation = static_cast<VariableOperation>(taction.TriggerRect.X);
-    int right_index = taction.TriggerRect.Y;
+    int left_index = This()->Data.Value;
+    VariableOperation operation = static_cast<VariableOperation>(This()->TriggerRect.X);
+    int right_index = This()->TriggerRect.Y;
 
     /**
      *  Fetch the current value of the variable.
@@ -954,12 +1089,12 @@ bool TActionClassExtension::Do_MODIFY_GLOBAL_LOCAL(TActionClass& taction, HouseC
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_INCREMENT_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_INCREMENT_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
+    int index = This()->Data.Value;
 
     /**
      *  Fetch the current value of the variable.
@@ -988,12 +1123,12 @@ bool TActionClassExtension::Do_INCREMENT_GLOBAL(TActionClass& taction, HouseClas
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_DECREMENT_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DECREMENT_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
+    int index = This()->Data.Value;
 
     /**
      *  Fetch the current value of the variable.
@@ -1022,14 +1157,14 @@ bool TActionClassExtension::Do_DECREMENT_GLOBAL(TActionClass& taction, HouseClas
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_MODIFY_LOCAL_CONSTANT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MODIFY_LOCAL_CONSTANT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int left_index = taction.Data.Value;
-    VariableOperation operation = static_cast<VariableOperation>(taction.TriggerRect.X);
-    int right = taction.TriggerRect.Y;
+    int left_index = This()->Data.Value;
+    VariableOperation operation = static_cast<VariableOperation>(This()->TriggerRect.X);
+    int right = This()->TriggerRect.Y;
 
     /**
      *  Fetch the current value of the variable.
@@ -1058,14 +1193,14 @@ bool TActionClassExtension::Do_MODIFY_LOCAL_CONSTANT(TActionClass& taction, Hous
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_MODIFY_LOCAL_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MODIFY_LOCAL_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int left_index = taction.Data.Value;
-    VariableOperation operation = static_cast<VariableOperation>(taction.TriggerRect.X);
-    int right_index = taction.TriggerRect.Y;
+    int left_index = This()->Data.Value;
+    VariableOperation operation = static_cast<VariableOperation>(This()->TriggerRect.X);
+    int right_index = This()->TriggerRect.Y;
 
     /**
      *  Fetch the current value of the variable.
@@ -1102,14 +1237,14 @@ bool TActionClassExtension::Do_MODIFY_LOCAL_GLOBAL(TActionClass& taction, HouseC
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_MODIFY_LOCAL_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_MODIFY_LOCAL_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int left_index = taction.Data.Value;
-    VariableOperation operation = static_cast<VariableOperation>(taction.TriggerRect.X);
-    int right_index = taction.TriggerRect.Y;
+    int left_index = This()->Data.Value;
+    VariableOperation operation = static_cast<VariableOperation>(This()->TriggerRect.X);
+    int right_index = This()->TriggerRect.Y;
 
     /**
      *  Fetch the current value of the variable.
@@ -1146,12 +1281,12 @@ bool TActionClassExtension::Do_MODIFY_LOCAL_LOCAL(TActionClass& taction, HouseCl
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_INCREMENT_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_INCREMENT_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
+    int index = This()->Data.Value;
 
     /**
      *  Fetch the current value of the variable.
@@ -1180,12 +1315,12 @@ bool TActionClassExtension::Do_INCREMENT_LOCAL(TActionClass& taction, HouseClass
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_DECREMENT_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DECREMENT_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
+    int index = This()->Data.Value;
 
     /**
      *  Fetch the current value of the variable.
@@ -1214,14 +1349,14 @@ bool TActionClassExtension::Do_DECREMENT_LOCAL(TActionClass& taction, HouseClass
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_RANDOM_NUMBER_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_RANDOM_NUMBER_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
-    int min = taction.TriggerRect.X;
-    int max = taction.TriggerRect.Y;
+    int index = This()->Data.Value;
+    int min = This()->TriggerRect.X;
+    int max = This()->TriggerRect.Y;
 
     /**
      *  Generate the number.
@@ -1244,14 +1379,14 @@ bool TActionClassExtension::Do_RANDOM_NUMBER_GLOBAL(TActionClass& taction, House
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_RANDOM_NUMBER_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_RANDOM_NUMBER_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
-    int min = taction.TriggerRect.X;
-    int max = taction.TriggerRect.Y;
+    int index = This()->Data.Value;
+    int min = This()->TriggerRect.X;
+    int max = This()->TriggerRect.Y;
 
     /**
      *  Generate the number.
@@ -1274,12 +1409,12 @@ bool TActionClassExtension::Do_RANDOM_NUMBER_LOCAL(TActionClass& taction, HouseC
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_PRINT_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_PRINT_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
+    int index = This()->Data.Value;
 
     /**
      *  Fetch the current value of the variable.
@@ -1308,12 +1443,12 @@ bool TActionClassExtension::Do_PRINT_GLOBAL(TActionClass& taction, HouseClass* h
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_PRINT_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_PRINT_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     /**
      *  Save the parameters for convenience.
      */
-    int index = taction.Data.Value;
+    int index = This()->Data.Value;
 
     /**
      *  Fetch the current value of the variable.
@@ -1342,9 +1477,9 @@ bool TActionClassExtension::Do_PRINT_LOCAL(TActionClass& taction, HouseClass* ho
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_ENABLE_TEMPLATED_TEXT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_ENABLE_TEMPLATED_TEXT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
-    TacticalMapExtension->Enable_Templated_Text(taction.Data.Value, static_cast<ColorSchemeType>(taction.TriggerRect.X * 2));
+    TacticalMapExtension->Enable_Templated_Text(This()->Data.Value, static_cast<ColorSchemeType>(This()->TriggerRect.X * 2));
     return true;
 }
 
@@ -1354,7 +1489,7 @@ bool TActionClassExtension::Do_ENABLE_TEMPLATED_TEXT(TActionClass& taction, Hous
  *
  *  @author: ZivDero
  */
-bool TActionClassExtension::Do_DISABLE_TEMPLATED_TEXT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
+bool TActionClassExtension::Do_DISABLE_TEMPLATED_TEXT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell)
 {
     TacticalMapExtension->Disable_Templated_Text();
     return true;

--- a/src/extensions/taction/tactionext.h
+++ b/src/extensions/taction/tactionext.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "extension.h"
+#include "stringid.h"
 #include "taction.h"
 #include "tibsun_defines.h"
 
@@ -38,60 +39,97 @@ class ObjectClass;
 class TriggerClass;
 
 
-class TActionClassExtension
+class DECLSPEC_UUID(UUID_ACTION_EXTENSION)
+TActionClassExtension final : public AbstractClassExtension
 {
 public:
-    static bool Execute(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    /**
+     *  IPersist
+     */
+    IFACEMETHOD(GetClassID)(CLSID* pClassID);
+
+    /**
+     *  IPersistStream
+     */
+    IFACEMETHOD(Load)(IStream* pStm);
+    IFACEMETHOD(Save)(IStream* pStm, BOOL fClearDirty);
+
+public:
+    TActionClassExtension(const TActionClass* this_ptr = nullptr);
+    TActionClassExtension(const NoInitClass& noinit);
+    virtual ~TActionClassExtension();
+
+    virtual int Get_Object_Size() const override;
+    virtual void Detach(AbstractClass* target, bool all = true) override;
+    virtual void Object_CRC(CRCEngine& crc) const override;
+
+    virtual TActionClass* This() const override { return reinterpret_cast<TActionClass*>(AbstractClassExtension::This()); }
+    virtual const TActionClass* This_Const() const override { return reinterpret_cast<const TActionClass*>(AbstractClassExtension::This_Const()); }
+    virtual RTTIType Fetch_RTTI() const override { return RTTI_ACTION; }
+
+    /**
+     *  Trigger actions don't have names.
+     */
+    virtual const char* Name() const { return ""; }
+    virtual const char* Full_Name() const { return ""; }
+
+public:
+    bool Execute(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
     static bool Is_Vinifera_TAction(TActionType type);
 
     static const char* Action_Name(int action);
     static const char* Action_Description(int action);
 
 private:
-
     /**
      *  Vanilla TActions that we re-implement.
      */
-    static bool Do_WIN(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_LOSE(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_TEXT_TRIGGER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DESTROY_TRIGGER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_ENABLE_TRIGGER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DESTROY_TAG(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_PLAY_SOUND_RANDOM(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_WIN(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_LOSE(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_TEXT_TRIGGER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DESTROY_TRIGGER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_ENABLE_TRIGGER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DESTROY_TAG(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_PLAY_SOUND_RANDOM(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
 
     /**
      *  New TActions.
      */
-    static bool Do_GIVE_CREDITS(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_ENABLE_SHORT_GAME(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DISABLE_SHORT_GAME(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_HOUSE_DESTROY_ALL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MAKE_ELITE(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_ENABLE_ALLYREVEAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DISABLE_ALLYREVEAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_CREATE_AUTOSAVE(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DELETE_OBJECT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_ALL_ASSIGN_MISSION(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MAKE_ALLY_ONE_WAY(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MAKE_ENEMY_ONE_WAY(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MODIFY_GLOBAL_CONSTANT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MODIFY_GLOBAL_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MODIFY_GLOBAL_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_INCREMENT_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DECREMENT_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MODIFY_LOCAL_CONSTANT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MODIFY_LOCAL_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_MODIFY_LOCAL_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_INCREMENT_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DECREMENT_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_RANDOM_NUMBER_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_RANDOM_NUMBER_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_PRINT_GLOBAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_PRINT_LOCAL(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_ENABLE_TEMPLATED_TEXT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_DISABLE_TEMPLATED_TEXT(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_GIVE_CREDITS(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_ENABLE_SHORT_GAME(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DISABLE_SHORT_GAME(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_HOUSE_DESTROY_ALL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MAKE_ELITE(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_ENABLE_ALLYREVEAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DISABLE_ALLYREVEAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_CREATE_AUTOSAVE(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DELETE_OBJECT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_ALL_ASSIGN_MISSION(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MAKE_ALLY_ONE_WAY(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MAKE_ENEMY_ONE_WAY(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MODIFY_GLOBAL_CONSTANT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MODIFY_GLOBAL_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MODIFY_GLOBAL_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_INCREMENT_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DECREMENT_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MODIFY_LOCAL_CONSTANT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MODIFY_LOCAL_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_MODIFY_LOCAL_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_INCREMENT_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DECREMENT_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_RANDOM_NUMBER_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_RANDOM_NUMBER_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_PRINT_GLOBAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_PRINT_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_ENABLE_TEMPLATED_TEXT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_DISABLE_TEMPLATED_TEXT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
     static bool Do_ADJUST_HOUSE_MODIFIER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+
+public:
+    /**
+     *  Buffer for any text parameter the action may use.
+     */
+    FixedString<128> Text;
 
 private:
     static TActionClass::ActionDescriptionStruct ExtActionDescriptions[EXT_TACTION_COUNT - EXT_TACTION_FIRST];

--- a/src/extensions/taction/tactionext.h
+++ b/src/extensions/taction/tactionext.h
@@ -123,7 +123,7 @@ private:
     bool Do_PRINT_LOCAL(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
     bool Do_ENABLE_TEMPLATED_TEXT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
     bool Do_DISABLE_TEMPLATED_TEXT(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
-    static bool Do_ADJUST_HOUSE_MODIFIER(TActionClass& taction, HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
+    bool Do_ADJUST_HOUSE_MODIFIER(HouseClass* house, ObjectClass* object, TriggerClass* trig, const Cell& cell);
 
 public:
     /**

--- a/src/extensions/taction/tactionext_hooks.cpp
+++ b/src/extensions/taction/tactionext_hooks.cpp
@@ -54,6 +54,9 @@
 #include "hooker.h"
 #include "mouse.h"
 #include "rules.h"
+#include "tagtype.h"
+#include "teamtype.h"
+#include "waypoint.h"
 
 
 /**
@@ -67,6 +70,7 @@ DECLARE_EXTENDING_CLASS_AND_PAIR(TActionClass)
 {
 public:
     bool _Operator_Parens_Intercept(HouseClass* house, ObjectClass* object, TriggerClass* trigger, Cell const& cell);
+    void _Read_INI();
 };
 
 
@@ -84,7 +88,7 @@ bool TActionClassExt::_Operator_Parens_Intercept(HouseClass* house, ObjectClass*
      *  If this is a Vinifera TAction, execute it.
      */
     if (TActionClassExtension::Is_Vinifera_TAction(Action)) {
-        success = TActionClassExtension::Execute(*this, house, object, trigger, cell);
+        success = Extension::Fetch(this)->Execute(house, object, trigger, cell);
     }
 
     /**
@@ -95,6 +99,96 @@ bool TActionClassExt::_Operator_Parens_Intercept(HouseClass* house, ObjectClass*
     }
 
     return success;
+}
+
+
+enum NeedCode {
+    NeedOther = 0,
+    NeedTeam = 1,
+    NeedTrigger = 2,
+    NeedTag = 3,
+    NeedTeamAndTime = 4
+};
+
+
+/**
+ *  Parses the INI text for this action's data.
+ *
+ *  @author: ZivDero, tomsons26
+ */
+void TActionClassExt::_Read_INI()
+{
+    auto& extension = *Extension::Fetch(this);
+
+    Data.Value = 0;
+    Action = static_cast<TActionType>(atoi(strtok(nullptr, ",")));
+    NeedCode code = static_cast<NeedCode>(atoi(strtok(nullptr, ",")));
+    char* text = strtok(nullptr, ",");
+    int val = atoi(text);
+
+    switch (code) {
+    case NeedOther:
+
+        /**
+         *  Hack: for text triggers, we want text now, but we won't change the need code
+         *  to preserve compatibility.
+         */
+        if (Action == TACTION_TEXT_TRIGGER) {
+            extension.Text = text;
+        } else {
+            Data.Value = val;
+        }
+        break;
+
+    case NeedTeam:
+    case NeedTeamAndTime:
+        if (val == -1) {
+            Team = nullptr;
+        } else {
+            if (strlen(text) < 3) {
+                Team = TeamTypes[val];
+            } else {
+                Team = TeamTypeClass::Find_Or_Make(text);
+            }
+        }
+        break;
+
+    case NeedTrigger:
+        if (val == -1) {
+            Trigger = nullptr;
+        } else {
+            if (strlen(text) < 3) {
+                Trigger = TriggerTypes[val];
+            } else {
+                Trigger = TriggerTypeClass::Find_Or_Make(text);
+            }
+        }
+        break;
+    case NeedTag:
+        if (val == -1) {
+            Tag = nullptr;
+        } else {
+            if (strlen(text) < 3) {
+                Tag = TagTypes[val];
+            } else {
+                Tag = TagTypeClass::Find_Or_Make(text);
+            }
+        }
+        break;
+    }
+
+    TriggerRect.X = atoi(strtok(nullptr, ","));
+    TriggerRect.Y = atoi(strtok(nullptr, ","));
+    TriggerRect.Width = atoi(strtok(nullptr, ","));
+    TriggerRect.Height = atoi(strtok(nullptr, ","));
+    char* temp = strtok(nullptr, ",");
+    if (temp != nullptr) {
+        if (code == NeedTeamAndTime) {
+            Data.Value = atoi(temp);
+        } else {
+            EffectLocation = Waypoint_From_String(temp);
+        }
+    }
 }
 
 
@@ -131,6 +225,7 @@ AttachType _Attaches_To(TActionType event)
 void TActionClassExtension_Hooks()
 {
     Patch_Call(0x0064961C, &TActionClassExt::_Operator_Parens_Intercept);
+    Patch_Jump(0x00618F70, &TActionClassExt::_Read_INI);
     Patch_Jump(0x0061D9C0, &_Attaches_To);
 
     /**

--- a/src/extensions/taction/tactionext_init.cpp
+++ b/src/extensions/taction/tactionext_init.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TACTIONEXT_INIT.CPP
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Contains the hooks for initialising the extended TActionClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "tactionext.h"
+#include "taction.h"
+#include "tibsun_globals.h"
+#include "vinifera_util.h"
+#include "vinifera_globals.h"
+#include "extension.h"
+#include "fatal.h"
+#include "asserthandler.h"
+#include "debughandler.h"
+
+#include "hooker.h"
+#include "syringe.h"
+
+
+/**
+ *  Patch for including the extended class members in the creation process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: ZivDero
+ */
+DEFINE_HOOK(0x00618CDC, _TActionClass_Constructor_Patch, 5)
+{
+    GET(TActionClass *, this_ptr, ESI); // Current "this" pointer.
+
+    /**
+     *  If we are performing a load operation, the Windows API will invoke the
+     *  constructors for us as part of the operation, so we can skip our hook here.
+     */
+    if (Vinifera_PerformingLoad) {
+        goto original_code;
+    }
+
+    /**
+     *  Create an extended class instance.
+     */
+    Extension::Make<TActionClassExtension>(this_ptr);
+
+original_code:
+    return 0;
+}
+
+
+/**
+ *  Patch for including the extended class members in the destruction process.
+ * 
+ *  @warning: Do not touch this unless you know what you are doing!
+ * 
+ *  @author: ZivDero
+ */
+DEFINE_HOOK(0x0061DB21, _TActionClass_Scalar_Destructor_Patch, 6)
+{
+    GET(TActionClass *, this_ptr, ESI);
+
+    /**
+     *  Remove the extended class from the global index.
+     */
+    Extension::Destroy<TActionClassExtension>(this_ptr);
+
+original_code:
+    return 0;
+}

--- a/src/extensions/taction/tactionext_init.h
+++ b/src/extensions/taction/tactionext_init.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          TACTIONEXT_INIT.H
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Contains the hooks for initialising the extended TActionClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void TActionClassExtension_Init();

--- a/src/extensions/tevent/teventext.h
+++ b/src/extensions/tevent/teventext.h
@@ -58,7 +58,7 @@ public:
 
     virtual TEventClass *This() const override { return reinterpret_cast<TEventClass *>(AbstractClassExtension::This()); }
     virtual const TEventClass *This_Const() const override { return reinterpret_cast<const TEventClass *>(AbstractClassExtension::This_Const()); }
-    virtual RTTIType Fetch_RTTI() const override { return RTTI_UNIT; }
+    virtual RTTIType Fetch_RTTI() const override { return RTTI_EVENT; }
 
     /**
      *  Trigger events don't have names.

--- a/src/vinifera/vinifera_globals.cpp
+++ b/src/vinifera/vinifera_globals.cpp
@@ -98,6 +98,8 @@ AircraftTrackerClass* AircraftTracker = nullptr;
 
 int EnvironmentGlobals[/*std::size(ScenExtension->GlobalFlags)*/500];
 
+std::unordered_map<std::string, std::string> Vinifera_TutorialText;
+
 MFCD *GenericMix = nullptr;
 MFCD *IsoGenericMix = nullptr;
 MFCD *SideCTMix = nullptr;

--- a/src/vinifera/vinifera_globals.h
+++ b/src/vinifera/vinifera_globals.h
@@ -31,6 +31,7 @@
 #include "vector.h"
 #include "ccfile.h"
 #include "extension_globals.h"
+#include <unordered_map>
 
 
 class PrerequisiteGroupClass;
@@ -122,6 +123,8 @@ extern KamikazeTrackerClass *KamikazeTracker;
 extern AircraftTrackerClass *AircraftTracker;
 
 extern int EnvironmentGlobals[/*std::size(ScenExtension->GlobalFlags)*/500];
+
+extern std::unordered_map<std::string, std::string> Vinifera_TutorialText;
 
 
 /**

--- a/src/vinifera/vinifera_saveload.cpp
+++ b/src/vinifera/vinifera_saveload.cpp
@@ -455,7 +455,7 @@ bool Vinifera_Get_All(IStream *pStm, bool load_net)
 
         scen_ini.Load(scen_file, false);
 
-        if (!ScenExtension->Read_Tutorial_INI(scen_ini, true)) {
+        if (!ScenExtension->Read_Tutorial_INI(scen_ini)) {
             DEBUG_ERROR("Failed to read tutorial strings from scenario file!\n");
             return false;
         }


### PR DESCRIPTION
This PR changes tutorial text keys to be interpreted as strings, not integers. As a result, this is now valid:

```
[Tutorial]
GDI_MIS_1A:Hint=Harvest the Tiberium to the north.
```

The string key can be specified in the trigger action as usual.