### PR TITLE
Implement INI Inheritance

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -154,6 +154,7 @@ This page lists all the individual contributions to the project by their author.
   - Graphics for the new sidebar fitting vanilla sidebar.
 - **[Phobos Contributors](https://github.com/Phobos-developers/Phobos/blob/develop/CREDITS.md)**:
   - DirStruct implementation.
+  - Original INI inheritance implementation as reference.
 - **Rampastring**:
   - Add `IceStrength` to Rules, and `IceDestructionEnabled` scenario option.
   - Add `ImmuneToEMP` to TechnoTypes.
@@ -316,3 +317,6 @@ This page lists all the individual contributions to the project by their author.
   - Replace DirectDraw with SDL.
   - Fix a bug where you could tote a `Totable=no` unit by force-moving onto it.
   - Tutorial text INI keys are now interpreted as strings, not integers.
+  - Implement INI inheritance/includes.
+  - Fix a bug where the last line of an INI file would not be parsed.
+  - Fix incorrect merging of sections and keys in INI files.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -96,3 +96,5 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Teams attacking a BwP now take zones into account.
 - Fix a bug where placed buildings were not revealed to allies, only the player who placed down the building.
 - Fix a bug where the player's army wouldn't fire at armed civilians.
+- Fix a bug where the last line of an INI file would not be parsed.
+- Fix incorrect merging of sections and keys in INI files.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -48,7 +48,7 @@ In any `INI` file:
 ```
 
 ```{caution}
-Avoid recursive includes. Vinifera does not provide circular reference protection; self-referencing files will cause the game to stop responding.
+Avoid recursive includes. Vinifera does not provide circular reference protection; self-referencing files will cause the game to crash.
 ```
 
 ```{note}
@@ -83,7 +83,7 @@ Owner=GDI
 ```
 
 ```{caution}
-There are no internal guards against recursive inheritance. If Section A inherits from Section B, and Section B inherits from Section A, the game will hang in an infinite loop.
+There are no internal guards against recursive inheritance. If Section A inherits from Section B, and Section B inherits from Section A, the game will crash.
 ```
 
 ```{caution}

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -15,6 +15,77 @@ This page describes every change in Vinifera that wasn't categorized into a prop
 - Parachute animations with `AltPalette=yes` now remap to the parachuted unit owner's color.
 - Improve alternative factory selection when the primary factory is blocked.
 
+## INI
+
+### INI Inclusion and Inheritance
+
+INI files now support modularity through the `[$Include]` and `[$Inherit]` sections. These allow files to be merged or used as templates, each with distinct override behaviors.
+
+#### `[$Include]`
+* **Behavior:** The current file pulls in external data as if "pasting" it into the logic.
+* **Priority:** Included files override the current file. Values read later in the inclusion chain take precedence.
+* **Use Case:** Splitting a massive configuration into smaller, organized sub-modules.
+
+#### `[$Inherit]`
+* **Behavior:** The current file uses external files as a base template or background layer.
+* **Priority:** The current file overrides inherited files. This allows the host file to act as a "patch" layer.
+* **Use Case:** Creating map-specific overrides or mods that only define changes relative to a base file (e.g., `RULES.INI`).
+
+### Technical Rules
+* Supported in any INI file (`RULES.INI`, `ART.INI`, `SOUND.INI`, `AI.INI`, maps, etc.).
+* Files must be listed with unique keys (e.g., `0=FILE1.INI`, `1=FILE2.INI`).
+* Supported with files loaded from the game directory or from within any loaded `.MIX` archive.
+* Both features perform **depth-first recursion** (nested includes are resolved before moving to the next file in the list).
+* Entries are processed sequentially in the order in which they appear, regardless of their key (left of `=`).
+
+In any `INI` file:
+```ini
+[$Inherit]
+0=SOMEFILE1.INI  ; file name
+
+[$Include]
+0=SOMEFILE2.INI  ; file name
+```
+
+```{caution}
+Avoid recursive includes. Vinifera does not provide circular reference protection; self-referencing files will cause the game to stop responding.
+```
+
+### Section inheritance
+
+Sections can now inherit entries from one or more "parent" sections using the `$Inherits` key. This allows for shared configuration templates and reduced redundancy within INI files.
+
+### Technical Rules
+* **Fallback Logic:** If a key is missing or has no value in the current section, the game looks up the value in the specified parent sections. If the value is still not found, it falls back to the hardcoded engine default.
+* **Override Priority:** The current (child) section always takes precedence.
+* **Multiple Parents:** You can list multiple parents separated by commas. The lookup follows a **left-to-right** priority:
+  `$Inherits=ParentA, ParentB` (The engine checks ParentA first, then ParentB).
+* **Recursion:** Inheritance is **depth-first**. If ParentA inherits from ParentX, Vinifera will fully resolve ParentA's hierarchy before checking ParentB.
+
+In any `INI` file:
+```ini
+[TemplateA]
+Armor=heavy
+Speed=5
+
+[TemplateB]
+Speed=10
+Weapon=Vulcan
+
+[NewUnit]
+$Inherits=TemplateA,TemplateB
+Owner=GDI
+; Result: Armor=heavy (from A), Weapon=Vulcan (from B), Speed=5 (from A), Owner=GDI (Own value)
+```
+
+```{caution}
+There are no internal guards against recursive inheritance. If Section A inherits from Section B, and Section B inherits from Section A, the game will hang in an infinite loop.
+```
+
+```{caution}
+Section-level does not work in certain cases that *iterate* a section. Notably, it may not be used with type lists, `[Tutorial]`, map briefings, as well as with map object lists.
+```
+
 ## Quality of Life
 
 - Harvesters are now considered when executing the "Guard" command. They have a special case when assigned with the Guard mission that tells them to find the nearest Tiberium patch and begin harvesting.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -51,6 +51,10 @@ In any `INI` file:
 Avoid recursive includes. Vinifera does not provide circular reference protection; self-referencing files will cause the game to stop responding.
 ```
 
+```{note}
+Included/inherited files **MUST** be present. Failure to find such a file will cause the game to exit for security reasons.
+```
+
 ### Section inheritance
 
 Sections can now inherit entries from one or more "parent" sections using the `$Inherits` key. This allows for shared configuration templates and reduced redundancy within INI files.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -56,11 +56,11 @@ Avoid recursive includes. Vinifera does not provide circular reference protectio
 Sections can now inherit entries from one or more "parent" sections using the `$Inherits` key. This allows for shared configuration templates and reduced redundancy within INI files.
 
 ### Technical Rules
-* **Fallback Logic:** If a key is missing or has no value in the current section, the game looks up the value in the specified parent sections. If the value is still not found, it falls back to the hardcoded engine default.
-* **Override Priority:** The current (child) section always takes precedence.
-* **Multiple Parents:** You can list multiple parents separated by commas. The lookup follows a **left-to-right** priority:
+* If a key is missing or has no value in the current section, the game looks up the value in the specified parent sections. If the value is still not found, it falls back to the hardcoded engine default.
+* The current (child) section always takes precedence.
+* You can list multiple parents separated by commas. The lookup follows a **left-to-right** priority:
   `$Inherits=ParentA, ParentB` (The engine checks ParentA first, then ParentB).
-* **Recursion:** Inheritance is **depth-first**. If ParentA inherits from ParentX, Vinifera will fully resolve ParentA's hierarchy before checking ParentB.
+* Inheritance is **depth-first**. If ParentA inherits from ParentX, ParentA's hierarchy will be fully resolved before ParentB is checked.
 
 In any `INI` file:
 ```ini

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -80,6 +80,7 @@ New:
 - Add "Adjust House Modifier" trigger action (by Rampstring)
 - Add "Only Harvesters" quarry (by Rampastring)
 - Tutorial text INI keys are now interpreted as strings, not integers (by ZivDero)
+- Implement INI inheritance/includes (by ZivDero)
 
 
 Vinifera fixes:
@@ -128,6 +129,8 @@ Vanilla fixes:
 - Teams attacking a BwP now take zones into account (by Rampastring) 
 - Fix a bug where placed buildings were not revealed to allies, only the player who placed down the building (by Rampastring)
 - Fix a bug where the player's army wouldn't fire at armed civilians (by Rampastring)
+- Fix a bug where the last line of an INI file would not be parsed (by ZivDero)
+- Fix incorrect merging of sections and keys in INI files (by ZivDero)
 
 :::
 

--- a/src/extensions/extension_hooks.cpp
+++ b/src/extensions/extension_hooks.cpp
@@ -159,6 +159,7 @@
 #include "swizzle.h"
 
 #include "hooker.h"
+#include "iniext_hooks.h"
 #include "objectext_hooks.h"
 #include "prerequisitegroup_hooks.h"
 #include "sdl_hooks.h"
@@ -288,6 +289,7 @@ void Extension_Hooks()
     CDExtension_Hooks();
     PlayMovieExtension_Hooks();
     VQAExtension_Hooks();
+    INIClassExtension_Hooks();
     CCINIClassExtension_Hooks();
     RawFileClassExtension_Hooks();
     CCFileClassExtension_Hooks();

--- a/src/extensions/ini/iniext_hooks.cpp
+++ b/src/extensions/ini/iniext_hooks.cpp
@@ -1,0 +1,568 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          INIEXT_HOOKS.CPP
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Contains the hooks for the extended INIClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#include "tibsun_globals.h"
+#include "tibsun_functions.h"
+#include "ini.h"
+#include "fatal.h"
+#include "debughandler.h"
+#include "asserthandler.h"
+#include "b64pipe.h"
+#include "buffpipe.h"
+#include "cstraw.h"
+#include "filestraw.h"
+#include <unordered_map>
+
+#include "hooker.h"
+#include "miscutil.h"
+#include "strtrim.h"
+#include "syringe.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ * 
+ *  @note: This must not contain a constructor or destructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+class INIClassExt : public INIClass
+{
+public:
+    int _Load(Straw& ffile, bool);
+    int _Get_String(char const* section, char const* entry, char const* defvalue, char* buffer, int size) const;
+
+    int _Get_Int(char const* section, char const* entry, int defvalue) const;
+    bool _Get_Bool(char const* section, char const* entry, bool defvalue) const;
+    double _Get_Float(char const* section, char const* entry, double defvalue) const;
+    TPoint2D<int> _Get_Point(char const* section, char const* entry, TPoint2D<int> const& defvalue) const;
+    TPoint3D<int> _Get_Point(char const* section, char const* entry, TPoint3D<int> const& defvalue) const;
+    TPoint3D<float> _Get_Point(char const* section, char const* entry, TPoint3D<float> const& defvalue) const;
+    int _Get_UUBlock(char const* section, void* block, int len) const;
+    int _Get_TextBlock(char const* section, char* buffer, int len) const;
+    CLSID _Get_UUID(char const* section, char const* entry, CLSID defvalue) const;
+    Rect _Get_Rect(char const* section, char const* entry, Rect const& defvalue) const;
+
+    void Inherit_File(INIClass const& ini);
+    void Include_File(INIClass const& ini);
+};
+
+
+/**
+ *  Reads a line from the INI file.
+ *
+ *  @author: ZivDero
+ */
+bool Read_Line(Straw& file, std::string& line)
+{
+    line.clear();
+
+    while (true) {
+        char c;
+        if (file.Get(&c, sizeof(c)) != sizeof(c)) { // EOF
+            return !line.empty();
+        }
+
+        if (c == '\n') {
+            return true;
+        }
+
+        if (c != '\r') {
+            line.push_back(c);
+        }
+    }
+}
+
+
+/**
+ *  Extracts a section name from a line.
+ *
+ *  @author: ZivDero
+ */
+std::string Extract_Section_Name(std::string_view line)
+{
+    auto l = line.find('[');
+    if (l == std::string_view::npos) return {};
+
+    auto r = line.find(']', l + 1);
+    if (r == std::string_view::npos || r <= l + 1) return {};
+
+    std::string name(line.substr(l + 1, r - l - 1));
+    strtrim(name.data());
+
+    return name;
+}
+
+
+/**
+ *  Inherits the INI data from another INI file.
+ *
+ *  @author: ZivDero
+ */
+void INIClassExt::Inherit_File(INIClass const& ini)
+{
+    for (const INISection* section = ini.SectionList.First(); section; section = section->Next_Valid() ? section->Next() : nullptr) {
+        for (const INIEntry* entry = section->EntryList.First(); entry; entry = entry->Next_Valid() ? entry->Next() : nullptr) {
+            if (strcmp(entry->Entry, "$Inherit") == 0 || strcmp(entry->Entry, "$Include") == 0) {
+                continue;
+            }
+            if (Is_Present(section->Section, entry->Entry)) {
+                continue;
+            }
+            Put_String(section->Section, entry->Entry, entry->Value);
+        }
+    }
+}
+
+
+/**
+ *  Includes the INI data from another INI file.
+ *
+ *  @author: ZivDero
+ */
+void INIClassExt::Include_File(INIClass const& ini)
+{
+    for (const INISection* section = ini.SectionList.First(); section; section = section->Next_Valid() ? section->Next() : nullptr) {
+        for (const INIEntry* entry = section->EntryList.First(); entry; entry = entry->Next_Valid() ? entry->Next() : nullptr) {
+            if (strcmp(entry->Entry, "$Inherit") == 0 || strcmp(entry->Entry, "$Include") == 0) {
+                continue;
+            }
+            Put_String(section->Section, entry->Entry, entry->Value);
+        }
+    }
+}
+
+
+/**
+ *  Loads the INI data from the data stream (straw).
+ *
+ *  @author: ZivDero, tomsons26
+ */
+int INIClassExt::_Load(Straw& ffile, bool)
+{
+    std::string line;
+    line.reserve(1024);
+
+    CacheStraw file;
+    file.Get_From(ffile);
+
+    std::string section;
+
+    while (Read_Line(file, line)) {
+
+        /**
+         *  Determine if this line is a comment or blank line. Throw it out if it is.
+         */
+        Strip_Comments(line.data());
+        if (line.empty() || line[0] == ';' || line[0] == '=') {
+            continue;
+        }
+
+        /**
+         *  Process a section.
+         */
+        if (Line_Contains_Section(line.data())) {
+            section = Extract_Section_Name(line);
+            strtrim(section.data());
+            continue;
+        }
+
+        /**
+         *  We haven't found the first section yet, discard the line.
+         */
+        if (section.empty()) {
+            continue;
+        }
+
+        /**
+         *  The line isn't an obvious comment. Make sure that there is the "=" character
+         *  at an appropriate spot.
+         */
+        char* buffer = line.data();
+        char* divider = strchr(buffer, '=');
+        if (!divider) continue;
+
+        /**
+         *  Split the line into entry and value sections. Be sure to catch the
+         *  "=foobar" and "foobar=" cases. These lines are ignored.
+         */
+        *divider++ = '\0';
+        strtrim(buffer);
+        if (!strlen(buffer)) continue;
+
+        strtrim(divider);
+        if (!strlen(divider)) continue;
+
+        if (Put_String(section.c_str(), buffer, divider) == false) {
+            return false;
+        }
+    }
+
+    constexpr const char* inherit_section = "$Inherit";
+    constexpr const char* include_section = "$Include";
+
+    std::vector<std::string> inherits;
+    if (Section_Present(inherit_section)) {
+        int count = Entry_Count(inherit_section);
+        for (int i = 0; i < count; i++) {
+            std::string entry = Get_String(inherit_section, Get_Entry(inherit_section, i), {});
+            if (std::ranges::find(inherits, entry) == inherits.end()) {
+                inherits.emplace_back(entry);
+            }
+        }
+    }
+
+    std::vector<std::string> includes;
+    if (Section_Present(include_section)) {
+        int count = Entry_Count(include_section);
+        for (int i = 0; i < count; i++) {
+            std::string entry = Get_String(include_section, Get_Entry(include_section, i), {});
+            if (std::ranges::find(includes, entry) == includes.end()) {
+                includes.emplace_back(entry);
+            }
+        }
+    }
+
+    for (auto& filename : inherits) {
+        CCFileClass ifile(filename.c_str());
+        if (ifile.Is_Available()) {
+            INIClass iini;
+            iini.Load(ifile);
+            Inherit_File(iini);
+        } else {
+            DEBUG_FATAL("INIClassExt::_Load - Inherit file not found: %s\n", filename.c_str());
+            char error[512];
+            std::snprintf(error, sizeof(error), "INIClassExt::_Load - Inherit file not found: %s\nThe game will now exit.", filename.c_str());
+            MessageBox(MainWindow, error, "Vinifera", MB_OK | MB_ICONERROR);
+            Emergency_Exit(EXIT_FAILURE);
+        }
+    }
+
+    for (auto& filename : includes) {
+        CCFileClass ifile(filename.c_str());
+        if (ifile.Is_Available()) {
+            INIClass iini;
+            iini.Load(ifile);
+            Include_File(iini);
+        } else {
+            DEBUG_FATAL("INIClassExt::_Load - Include file not found: %s\n", filename.c_str());
+            char error[512];
+            std::snprintf(error, sizeof(error), "INIClassExt::_Load - Include file not found: %s\nThe game will now exit.", filename.c_str());
+            MessageBox(MainWindow, error, "Vinifera", MB_OK | MB_ICONERROR);
+            Emergency_Exit(EXIT_FAILURE);
+        }
+    }
+
+    return true;
+}
+
+
+/**
+ *  Cached inherited sections.
+ */
+static std::unordered_map<void*, std::vector<std::string>> InheritedSections;
+
+
+/**
+ *  Get_String replacement that checks inherited sections if the entry is not found in the main section.
+ *
+ *  @author: ZivDero, tomsons26
+ */
+int INIClassExt::_Get_String(char const* section, char const* entry, char const* defvalue, char* buffer, int size) const
+{
+    /**
+     *  Verify that the parameters are nominally legal.
+     */
+    if (buffer == nullptr || size < 2 || section == nullptr || entry == nullptr) return 0;
+
+    if (std::string_view(section) == "E1") {
+        DEBUG_INFO("E1: Fetching [%s]->%s\n", section, entry);
+    }
+
+    /**
+     *  Fetch the entry string if it is present.
+     */
+    bool has_value = false;
+    INIEntry* entryptr = Find_Entry(section, entry);
+    if (entryptr != nullptr && entryptr->Value != nullptr) {
+        defvalue = entryptr->Value;
+        has_value = true;
+    }
+
+    /**
+     *  Attempt to find the entry string among inherited sections. If not,
+     *  then the normal default value will be used as the entry value.
+     */
+    if (!has_value) {
+        INISection* sectionptr = Find_Section(section);
+        if (InheritedSections.contains(sectionptr)) {
+            for (const std::string& inherited_section : InheritedSections[sectionptr]) {
+                int count = Get_String(inherited_section.c_str(), entry, "", buffer, size);
+                if (count > 0) {
+                    DEBUG_INFO("Fetched [%s]->%s from %s\n", section, entry, inherited_section.c_str());
+                    return count;
+                }
+            }
+        }
+    }
+
+    /**
+     *  Fill in the buffer with the entry value and return with the length of the string.
+     */
+    if (defvalue == nullptr) {
+        buffer[0] = '\0';
+        return 0;
+    } else {
+        strncpy(buffer, defvalue, size);
+        buffer[size - 1] = '\0';
+        strtrim(buffer);
+        return strlen(buffer);
+    }
+}
+
+
+/**
+ *  Caches the inherited sections upon putting the $Inherits entry.
+ *
+ *  @author: ZivDero
+ */
+DEFINE_HOOK(0x004DDD3A, _INIClass_Put_String_Cache_Inherits, 5)
+{
+    GET_STACK(INIClass::INISection*, secptr, 0x14);
+    GET_STACK(char const*, entry, 0x50);
+    GET_STACK(char const*, string, 0x54);
+
+    if (strcmp(entry, "$Inherits") == 0) {
+        InheritedSections[secptr].clear();
+        for (std::string_view part : SplitView(string, ',', StringSplitOptions::RemoveEmpty | StringSplitOptions::Trim)) {
+            InheritedSections[secptr].emplace_back(part);
+        }
+    }
+
+    return 0;
+}
+
+DEFINE_HOOK(0x004DED22, _INIClass_INISection_DTOR_Clear_Inherits, 5)
+{
+    GET(INIClass::INISection*, secptr, ECX);
+
+    InheritedSections.erase(secptr);
+
+    return 0;
+}
+
+
+/**
+ *  Various INI getter replacements.
+ *
+ *  @author: tomsons26, ZivDero
+ */
+int INIClassExt::_Get_Int(char const* section, char const* entry, int defvalue) const
+{
+    if (section == nullptr || entry == nullptr) return defvalue;
+
+    std::string value = Get_String(section, entry, {});
+    if (!value.empty()) {
+        if (value[0] == '$') {
+            sscanf(value.c_str(), "$%x", &defvalue);
+        } else {
+            if (tolower(value.back()) == 'h') {
+                sscanf(value.c_str(), "%xh", &defvalue);
+            } else {
+                defvalue = atoi(value.c_str());
+            }
+        }
+    }
+    return defvalue;
+}
+
+bool INIClassExt::_Get_Bool(char const* section, char const* entry, bool defvalue) const
+{
+    if (section == nullptr || entry == nullptr) return defvalue;
+
+    std::string value = Get_String(section, entry, {});
+    if (!value.empty()) {
+        switch (toupper(value[0])) {
+        case 'Y':
+        case 'T':
+        case '1':
+            return true;
+
+        case 'N':
+        case 'F':
+        case '0':
+            return false;
+        }
+    }
+    return defvalue;
+}
+
+double INIClassExt::_Get_Float(char const* section, char const* entry, double defvalue) const
+{
+    if (section == nullptr || entry == nullptr) return defvalue;
+
+    std::string value = Get_String(section, entry, {});
+    if (!value.empty()) {
+        float val;
+        sscanf(value.c_str(), "%f", &val);
+        defvalue = val;
+        if (value.find('%') != std::string::npos) {
+            defvalue /= 100.0;
+        }
+    }
+    return defvalue;
+}
+
+TPoint2D<int> INIClassExt::_Get_Point(char const* section, char const* entry, TPoint2D<int> const& defvalue) const
+{
+    char buffer[64];
+    if (Get_String(section, entry, "", buffer, sizeof(buffer))) {
+        int x, y;
+        std::sscanf(buffer, "%d,%d", &x, &y);
+        return {x, y};
+    }
+    return defvalue;
+}
+
+TPoint3D<int> INIClassExt::_Get_Point(char const* section, char const* entry, TPoint3D<int> const& defvalue) const
+{
+    char buffer[64];
+    if (Get_String(section, entry, "", buffer, sizeof(buffer))) {
+        int x, y, z;
+        std::sscanf(buffer, "%d,%d,%d", &x, &y, &z);
+        return {x, y, z};
+    }
+    return defvalue;
+}
+
+TPoint3D<float> INIClassExt::_Get_Point(char const* section, char const* entry, TPoint3D<float> const& defvalue) const
+{
+    char buffer[64];
+    if (Get_String(section, entry, "", buffer, sizeof(buffer))) {
+        float x, y, z;
+        std::sscanf(buffer, "%f,%f,%f", &x, &y, &z);
+        return {x, y, z};
+    }
+    return defvalue;
+}
+
+int INIClassExt::_Get_UUBlock(char const* section, void* block, int len) const
+{
+    if (section == nullptr) return 0;
+
+    Base64Pipe b64pipe(Base64Pipe::DECODE);
+    BufferPipe bpipe(block, len);
+
+    b64pipe.Put_To(&bpipe);
+
+    int total = 0;
+    int counter = Entry_Count(section);
+    for (int index = 0; index < counter; index++) {
+        char buffer[128];
+
+        int length = Get_String(section, Get_Entry(section, index), "=", buffer, sizeof(buffer));
+        int outcount = b64pipe.Put(buffer, length);
+        total += outcount;
+    }
+    total += b64pipe.End();
+    return total;
+}
+
+int INIClassExt::_Get_TextBlock(char const* section, char* buffer, int len) const
+{
+    if (len <= 0) return 0;
+
+    buffer[0] = '\0';
+    if (len <= 1) return 0;
+
+    int elen = Entry_Count(section);
+    int total = 0;
+    for (int index = 0; index < elen; index++) {
+        if (index > 0) {
+            *buffer++ = ' ';
+            len--;
+            total++;
+        }
+
+        Get_String(section, Get_Entry(section, index), "", buffer, len);
+
+        int partial = std::strlen(buffer);
+        total += partial;
+        buffer += partial;
+        len -= partial;
+        if (len <= 1) break;
+    }
+    return total;
+}
+
+CLSID INIClassExt::_Get_UUID(char const* section, char const* entry, CLSID defvalue) const
+{
+    char buffer[128];
+
+    if (Get_String(section, entry, "", buffer, sizeof(buffer))) {
+        wchar_t wBuffer[128];
+        MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, buffer, -1, wBuffer, std::size(wBuffer));
+        CLSID uuid;
+        if (SUCCEEDED(CLSIDFromString(wBuffer, &uuid))) {
+            return uuid;
+        }
+    }
+    return defvalue;
+}
+
+Rect INIClassExt::_Get_Rect(char const* section, char const* entry, Rect const& defvalue) const
+{
+    char buffer[64];
+
+    if (Get_String(section, entry, "", buffer, sizeof(buffer))) {
+        Rect retval = defvalue;
+        sscanf(buffer, "%d,%d,%d,%d", &retval.X, &retval.Y, &retval.Width, &retval.Height);
+        return retval;
+    }
+    return defvalue;
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void INIClassExtension_Hooks()
+{
+    Patch_Jump(0x004DB7D0, &INIClassExt::_Load);
+    Patch_Jump(0x004DDF60, &INIClassExt::_Get_String);
+
+    Patch_Jump(0x004DD140, &INIClassExt::_Get_Int);
+    Patch_Jump(0x004DE140, &INIClassExt::_Get_Bool);
+    Patch_Jump(0x004DD9F0, &INIClassExt::_Get_Float);
+    Patch_Jump(0x004DE340, static_cast<TPoint2D<int> (INIClassExt::*)(char const*, char const*, TPoint2D<int> const&) const>(&INIClassExt::_Get_Point));
+    Patch_Jump(0x004DE520, static_cast<TPoint3D<int> (INIClassExt::*)(char const*, char const*, TPoint3D<int> const&) const>(&INIClassExt::_Get_Point));
+    Patch_Jump(0x004DE730, static_cast<TPoint3D<float> (INIClassExt::*)(char const*, char const*, TPoint3D<float> const&) const>(&INIClassExt::_Get_Point));
+    Patch_Jump(0x004DCAD0, &INIClassExt::_Get_UUBlock);
+    Patch_Jump(0x004DCDE0, &INIClassExt::_Get_TextBlock);
+    Patch_Jump(0x004DD320, &INIClassExt::_Get_UUID);
+    Patch_Jump(0x004DD610, &INIClassExt::_Get_Rect);
+}

--- a/src/extensions/ini/iniext_hooks.cpp
+++ b/src/extensions/ini/iniext_hooks.cpp
@@ -323,7 +323,7 @@ int INIClassExt::_Get_String(char const* section, char const* entry, char const*
             for (const std::string& inherited_section : InheritedSections[sectionptr]) {
                 int count = Get_String(inherited_section.c_str(), entry, "", buffer, size);
                 if (count > 0) {
-                    DEBUG_INFO("Fetched [%s]->%s from %s\n", section, entry, inherited_section.c_str());
+                    //DEBUG_INFO("Fetched [%s]->%s from %s\n", section, entry, inherited_section.c_str());
                     return count;
                 }
             }

--- a/src/extensions/ini/iniext_hooks.cpp
+++ b/src/extensions/ini/iniext_hooks.cpp
@@ -299,10 +299,6 @@ int INIClassExt::_Get_String(char const* section, char const* entry, char const*
      */
     if (buffer == nullptr || size < 2 || section == nullptr || entry == nullptr) return 0;
 
-    if (std::string_view(section) == "E1") {
-        DEBUG_INFO("E1: Fetching [%s]->%s\n", section, entry);
-    }
-
     /**
      *  Fetch the entry string if it is present.
      */

--- a/src/extensions/ini/iniext_hooks.cpp
+++ b/src/extensions/ini/iniext_hooks.cpp
@@ -126,10 +126,10 @@ std::string Extract_Section_Name(std::string_view line)
 void INIClassExt::Inherit_File(INIClass const& ini)
 {
     for (const INISection* section = ini.SectionList.First(); section; section = section->Next_Valid() ? section->Next() : nullptr) {
+        if (strcmp(section->Section, "$Inherit") == 0 || strcmp(section->Section, "$Include") == 0) {
+            continue;
+        }
         for (const INIEntry* entry = section->EntryList.First(); entry; entry = entry->Next_Valid() ? entry->Next() : nullptr) {
-            if (strcmp(entry->Entry, "$Inherit") == 0 || strcmp(entry->Entry, "$Include") == 0) {
-                continue;
-            }
             if (Is_Present(section->Section, entry->Entry)) {
                 continue;
             }
@@ -147,10 +147,10 @@ void INIClassExt::Inherit_File(INIClass const& ini)
 void INIClassExt::Include_File(INIClass const& ini)
 {
     for (const INISection* section = ini.SectionList.First(); section; section = section->Next_Valid() ? section->Next() : nullptr) {
+        if (strcmp(section->Section, "$Inherit") == 0 || strcmp(section->Section, "$Include") == 0) {
+            continue;
+        }
         for (const INIEntry* entry = section->EntryList.First(); entry; entry = entry->Next_Valid() ? entry->Next() : nullptr) {
-            if (strcmp(entry->Entry, "$Inherit") == 0 || strcmp(entry->Entry, "$Include") == 0) {
-                continue;
-            }
             Put_String(section->Section, entry->Entry, entry->Value);
         }
     }

--- a/src/extensions/ini/iniext_hooks.h
+++ b/src/extensions/ini/iniext_hooks.h
@@ -1,0 +1,31 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *
+ *  @project       Vinifera
+ *
+ *  @file          INIEXT_HOOKS.H
+ *
+ *  @author        ZivDero
+ *
+ *  @brief         Contains the hooks for the extended INIClass.
+ *
+ *  @license       Vinifera is free software: you can redistribute it and/or
+ *                 modify it under the terms of the GNU General Public License
+ *                 as published by the Free Software Foundation, either version
+ *                 3 of the License, or (at your option) any later version.
+ *
+ *                 Vinifera is distributed in the hope that it will be
+ *                 useful, but WITHOUT ANY WARRANTY; without even the implied
+ *                 warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *                 PURPOSE. See the GNU General Public License for more details.
+ *
+ *                 You should have received a copy of the GNU General Public
+ *                 License along with this program.
+ *                 If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+
+void INIClassExtension_Hooks();

--- a/src/util/miscutil.h
+++ b/src/util/miscutil.h
@@ -29,9 +29,11 @@
 
 #include "always.h"
 #include "tibsun_defines.h"
+
+#include <string_view>
 #include <windows.h>
 #include <time.h>
-
+#include <vector>
 
 
 struct VoxelObject;
@@ -79,3 +81,114 @@ const char *Filename_From_Path(const char *filename);
 bool Parse_Boolean(const char* value, bool defval);
 
 bool Key_Down(int key);
+
+
+/**
+ *  Convenient generator-like class for splitting and trimming strings.
+ */
+enum class StringSplitOptions : unsigned {
+    None = 0,
+    RemoveEmpty = 1 << 0,
+    Trim = 1 << 1,
+};
+
+inline StringSplitOptions operator|(StringSplitOptions a, StringSplitOptions b)
+{
+    return static_cast<StringSplitOptions>(static_cast<unsigned>(a) | static_cast<unsigned>(b));
+}
+
+inline bool HasFlag(StringSplitOptions v, StringSplitOptions f)
+{
+    return (static_cast<unsigned>(v) & static_cast<unsigned>(f)) != 0;
+}
+
+class SplitView
+{
+    std::string_view s_;
+    char delim_;
+    StringSplitOptions opts_;
+
+public:
+    SplitView(std::string_view s, char delim, StringSplitOptions opts = StringSplitOptions::None) : s_(s), delim_(delim), opts_(opts) {}
+
+    class iterator
+    {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = std::string_view;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const std::string_view*;
+        using reference = const std::string_view&;
+
+        iterator() : done_(true) {} // End iterator constructor
+
+        iterator(std::string_view s, char delim, StringSplitOptions opts, bool done) : s_(s), delim_(delim), opts_(opts), pos_(0), done_(done)
+        {
+            if (!done_) advance();
+        }
+
+        reference operator*() const { return current_; }
+        pointer operator->() const { return &current_; }
+
+        iterator& operator++()
+        {
+            advance();
+            return *this;
+        }
+
+        iterator operator++(int)
+        {
+            iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        bool operator==(const iterator& other) const
+        {
+            if (done_ && other.done_) return true;
+            return done_ == other.done_ && pos_ == other.pos_;
+        }
+        bool operator!=(const iterator& other) const { return !(*this == other); }
+
+    private:
+        void advance()
+        {
+            while (pos_ <= s_.size()) {
+                size_t next_delim = s_.find(delim_, pos_);
+                size_t end = (next_delim == std::string_view::npos) ? s_.size() : next_delim;
+
+                std::string_view token = s_.substr(pos_, end - pos_);
+
+                pos_ = (next_delim == std::string_view::npos) ? s_.size() + 1 : next_delim + 1;
+
+                if (HasFlag(opts_, StringSplitOptions::Trim)) {
+                    auto b = token.find_first_not_of(" \t");
+                    if (b == std::string_view::npos)
+                        token = {};
+                    else {
+                        auto e = token.find_last_not_of(" \t");
+                        token = token.substr(b, e - b + 1);
+                    }
+                }
+
+                if (token.empty() && HasFlag(opts_, StringSplitOptions::RemoveEmpty)) {
+                    continue;
+                }
+
+                current_ = token;
+                return;
+            }
+            done_ = true;
+        }
+
+        std::string_view s_;
+        char delim_ = 0;
+        StringSplitOptions opts_ = StringSplitOptions::None;
+        size_t pos_ = 0;
+        bool done_ = false;
+        std::string_view current_;
+    };
+
+    iterator begin() const { return iterator {s_, delim_, opts_, false}; }
+    iterator end() const { return iterator {}; }
+};


### PR DESCRIPTION
### INI Inclusion and Inheritance

INI files now support modularity through the `[$Include]` and `[$Inherit]` sections. These allow files to be merged or used as templates, each with distinct override behaviors.

#### `[$Include]`
* **Behavior:** The current file pulls in external data as if "pasting" it into the logic.
* **Priority:** Included files override the current file. Values read later in the inclusion chain take precedence.
* **Use Case:** Splitting a massive configuration into smaller, organized sub-modules.

#### `[$Inherit]`
* **Behavior:** The current file uses external files as a base template or background layer.
* **Priority:** The current file overrides inherited files. This allows the host file to act as a "patch" layer.
* **Use Case:** Creating map-specific overrides or mods that only define changes relative to a base file (e.g., `RULES.INI`).

### Technical Rules
* Supported in any INI file (`RULES.INI`, `ART.INI`, `SOUND.INI`, `AI.INI`, maps, etc.).
* Files must be listed with unique keys (e.g., `0=FILE1.INI`, `1=FILE2.INI`).
* Supported with files loaded from the game directory or from within any loaded `.MIX` archive.
* Both features perform **depth-first recursion** (nested includes are resolved before moving to the next file in the list).
* Entries are processed sequentially in the order in which they appear, regardless of their key (left of `=`).

In any `INI` file:
```ini
[$Inherit]
0=SOMEFILE1.INI  ; file name

[$Include]
0=SOMEFILE2.INI  ; file name
```

```{caution}
Avoid recursive includes. Vinifera does not provide circular reference protection; self-referencing files will cause the game to stop responding.
```

```{note}
Included/inherited files **MUST** be present. Failure to find such a file will cause the game to exit for security reasons.
```

### Section inheritance

Sections can now inherit entries from one or more "parent" sections using the `$Inherits` key. This allows for shared configuration templates and reduced redundancy within INI files.

### Technical Rules
* If a key is missing or has no value in the current section, the game looks up the value in the specified parent sections. If the value is still not found, it falls back to the hardcoded engine default.
* The current (child) section always takes precedence.
* You can list multiple parents separated by commas. The lookup follows a **left-to-right** priority:
  `$Inherits=ParentA, ParentB` (The engine checks ParentA first, then ParentB).
* Inheritance is **depth-first**. If ParentA inherits from ParentX, ParentA's hierarchy will be fully resolved before ParentB is checked.

In any `INI` file:
```ini
[TemplateA]
Armor=heavy
Speed=5

[TemplateB]
Speed=10
Weapon=Vulcan

[NewUnit]
$Inherits=TemplateA,TemplateB
Owner=GDI
; Result: Armor=heavy (from A), Weapon=Vulcan (from B), Speed=5 (from A), Owner=GDI (Own value)
```

```{caution}
There are no internal guards against recursive inheritance. If Section A inherits from Section B, and Section B inherits from Section A, the game will hang in an infinite loop.
```

```{caution}
Section-level does not work in certain cases that *iterate* a section. Notably, it may not be used with type lists, `[Tutorial]`, map briefings, as well as with map object lists.
```