### PR TITLE
Add support for customizable self-heal cap and rate

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -146,6 +146,8 @@ This page lists all the individual contributions to the project by their author.
   - Replace DirectDraw with SDL.
 - **hacklex**:
   - Add Veterancy and Health Filter hotkeys.
+- **JoyfulShush**:
+  - Allow customizing self healing cap and rate game-wide and per-unit.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1236,7 +1236,9 @@ Vanilla prerequisite groups always exist by default. If you re-define them in `[
 
 ### Self Healing
 - Vinifera adds the ability to control the Self Healing mechanism for all technos, allowing to control both the maximum healing capacity and healing rate, both game-wide and per techno.
-- Techno-specific values apply first. If not specified, then game-wide values apply. If both are not specified, then Vinifera falls back to the original values used by the game, which depends on the attribute:
+- Techno-specific values apply first.
+- If not specified, then game-wide values apply.
+- If both are not specified, then Vinifera falls back to the original values used by the game, which depends on the attribute:
   - Self Healing Cap: based on `ConditionYellow`.
   - Self Healing Rate: based on `RepairRate`.
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1234,6 +1234,28 @@ Prerequisite=GROUPNAME
 Vanilla prerequisite groups always exist by default. If you re-define them in `[PrerequisiteGroups]`, values from `[PrerequisiteGroups]` will overwrite the values from `[General]`.
 ```
 
+### Self Healing
+- Vinifera adds the ability to control the Self Healing mechanism for all technos, allowing to control both the maximum healing capacity and healing rate, both game-wide and per techno.
+- Techno-specific values apply first. If not specified, then game-wide values apply. If both are not specified, then Vinifera falls back to the original values used by the game, which depends on the attribute:
+  - Self Healing Cap: based on `ConditionYellow`.
+  - Self Healing Rate: based on `RepairRate`.
+
+#### Game-wide definition
+In `RULES.INI`:
+```ini
+[General]
+SelfHealingCap=50% ; percentage, Determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
+SelfHealingRate=.016 ; float, minutes between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
+```
+
+#### Techno-specific definition
+In `RULES.INI`:
+```ini
+[SOMETECHNO]
+SelfHealingCap=50% ; percentage, Determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
+SelfHealingRate=.016 ; float, minutes between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
+```
+
 ## Terrain
 
 ### Light Sources

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1242,20 +1242,20 @@ Vanilla prerequisite groups always exist by default. If you re-define them in `[
   - Self Healing Cap: based on `ConditionYellow`.
   - Self Healing Rate: based on `RepairRate`.
 
-#### Game-wide definition
+Game-wide definition:
 In `RULES.INI`:
 ```ini
 [General]
-SelfHealingCap=50% ; percentage, Determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
-SelfHealingRate=.016 ; float, minutes between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
+SelfHealingCap=50% ; % or float, determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
+SelfHealingRate=.016 ; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
 ```
 
-#### Techno-specific definition
+Techno-specific definition:
 In `RULES.INI`:
 ```ini
 [SOMETECHNO]
-SelfHealingCap=50% ; percentage, Determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
-SelfHealingRate=.016 ; float, minutes between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
+SelfHealingCap=50% ; % or float, determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
+SelfHealingRate=.016 ; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
 ```
 
 ## Terrain

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -280,7 +280,7 @@ New:
 - Allow customizing which Tiberiums can grow on a tile (by ZivDero)
 - Allow customizing which Smudges can appear on a tile (by ZivDero)
 - Allow customizing if Veins can grow on a tile (by ZivDero)
-
+- Allow customizing Self Healing cap and rate globally and per-unit (by JoyfulShush)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)
@@ -361,4 +361,3 @@ Vanilla fixes:
 - Fix shroud looking bugged if you attempt to reveal too many cells at once (by ZivDero)
 
 :::
-

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -103,6 +103,8 @@ RulesClassExtension::RulesClassExtension(const RulesClass* this_ptr) :
     PlaceBeaconSound(VOC_NONE),
     PlaceBeaconVoice(VOX_NONE),
     DetectBeaconVoice(VOX_NONE),
+    SelfHealingCap(-1),
+    SelfHealingRate(-1),
     IsBeachIsCrush(false),
     BuildingFlameSpawnBlockFrames(0)
 {
@@ -670,6 +672,8 @@ bool RulesClassExtension::General(CCINIClass &ini)
     IsBeaconsEnabled = ini.Get_Bool(GENERAL, "BeaconsEnabled", IsBeaconsEnabled);
     IsSPBeacons = ini.Get_Bool(GENERAL, "SPBeacons", IsSPBeacons);
     MaxBeacons = ini.Get_Int(GENERAL, "MaxBeacons", MaxBeacons);
+    SelfHealingCap = ini.Get_Float(GENERAL, "SelfHealingCap", SelfHealingCap);    
+    SelfHealingRate = ini.Get_Float(GENERAL, "SelfHealingRate", SelfHealingRate);
 
     /**
      *  Allow replacing any signle movement zone with a copy of RA2's water MZone.

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -196,6 +196,18 @@ public:
     VoxType DetectBeaconVoice;
 
     /**
+     *  Defines the game-wide cap (in percentages) that technos can self-heal.
+     *  This is the default used by technos that don't have this key explicitly specified for them.
+     */
+    float SelfHealingCap;
+
+    /**
+     *  Defines the game-wide rate (in minutes) that technos will self-heal.
+     *  This is the default used by technos that don't have this key explicitly specified for them.
+     */
+    float SelfHealingRate;
+
+    /**
      *  Is LandType Beach considered as "requires crushing" for passability purposes, as opposed to water?
      */
     bool IsBeachIsCrush;

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -199,13 +199,13 @@ public:
      *  Defines the game-wide cap (in percentages) that technos can self-heal.
      *  This is the default used by technos that don't have this key explicitly specified for them.
      */
-    float SelfHealingCap;
+    double SelfHealingCap;
 
     /**
      *  Defines the game-wide rate (in minutes) that technos will self-heal.
      *  This is the default used by technos that don't have this key explicitly specified for them.
      */
-    float SelfHealingRate;
+    double SelfHealingRate;
 
     /**
      *  Is LandType Beach considered as "requires crushing" for passability purposes, as opposed to water?

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -128,6 +128,7 @@ public:
     bool _Can_Deploy_Now() const;
     int _Refund_Amount() const;
     bool _Evaluate_Object(ThreatType method, int mask, int range, TechnoClass const* object, int& value, int zone, Coord const& coord) const;
+    bool _Should_Self_Heal_Now() const;
 };
 
 
@@ -2763,6 +2764,67 @@ static bool Is_Valid_Target_Zone(const TechnoClass* techno, AbstractClass * targ
 
 
 /**
+ * #discussions-1450 
+ * Patch that allows modders and mappers to customize repair cap and repair rate across technos,
+ * rather than relying on values that have other side effects.
+ * Technos can have individual repair cap and rates specified for them.
+ * If they don't have those keys, then those values fall back to the game-wide customizable keys.
+ * If those also aren't specified either, then the game falls back to the keys it used in vanilla.
+ *
+ * @author: JoyfulShush
+ */
+bool TechnoClassExt::_Should_Self_Heal_Now() const
+{    
+    auto technotypeext = Extension::Fetch(TClass);
+
+    // Prevents overhealing - allowing Strength to get above 100%.
+    if (Get_Health_Ratio() >= 1) {
+        return false;
+    }
+
+    if (!TClass->IsSelfHealing) {
+        if (!Has_Ability(ABILITY_SELF_HEAL)) {
+            return false;
+        }
+    }    
+
+    // Determine the repair rate of this techno. 
+    // If the techno has its own repair rate, it is used. 
+    // Otherwise, the game-wide repair rate is used.
+    // If both are not specified, then the game falls back to the original RepairRate key used by this function in vanilla.
+    float repairRate;
+
+    if (technotypeext->SelfHealingRate != -1) {
+        repairRate = technotypeext->SelfHealingRate;      
+    } else if (RuleExtension->SelfHealingRate != -1) {
+        repairRate = RuleExtension->SelfHealingRate;
+    } else {
+        repairRate = Rule->RepairRate;
+    }
+
+    if ((Frame % (int)(std::ceil(repairRate * TICKS_PER_MINUTE))) != 0) {
+        return false;
+    }
+
+    // Determines the repair cap (in percentage) of this techno. A techno cannot repair itself beyond its repair cap.
+    // If the techno has its own repair cap, it is used.
+    // Otherwise, the game-wide repair cap is used.
+    // If both are not specified, then the game falls back to the original ConditionYellow key used by this function in vanilla.
+    float repairCap;
+    
+    if (technotypeext->SelfHealingCap != -1) {
+        repairCap = technotypeext->SelfHealingCap;
+    } else if (RuleExtension->SelfHealingCap != -1) {
+        repairCap = RuleExtension->SelfHealingCap;
+    } else {
+        repairCap = Rule->ConditionYellow;
+    }
+    
+    return repairCap > HealthRatio;
+}
+
+
+/**
  *  Custom Evaluate_Object implementation to allow player-owned defenses to target
  *  enemy defenses without ignoring weaponless objects.
  *
@@ -3111,7 +3173,6 @@ bool TechnoClassExt::_Evaluate_Object(ThreatType method, int mask, int range, Te
     return false;
 }
 
-
 /**
  *  Fixes a bug where placed buildings are not revealed for allies.
  *
@@ -3129,6 +3190,7 @@ DEFINE_HOOK(0x0062AB5E, _TechnoClass_Revealed_Look_For_Allies_Patch, 0)
     // trigger TEVENT_DISCOVERED
     return 0x0062AB68;
 }
+
 
 
 
@@ -3162,4 +3224,5 @@ void TechnoClassExtension_Hooks()
     Patch_Jump(0x0062FD70, &TechnoClassExt::_Assign_Target);
     Patch_Jump(0x00638090, &TechnoClassExt::_Refund_Amount);
     Patch_Jump(0x0062D0F0, &TechnoClassExt::_Evaluate_Object);
+    Patch_Jump(0x00638CA0, &TechnoClassExt::_Should_Self_Heal_Now);
 }

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -2764,20 +2764,22 @@ static bool Is_Valid_Target_Zone(const TechnoClass* techno, AbstractClass * targ
 
 
 /**
- * #discussions-1450 
- * Patch that allows modders and mappers to customize repair cap and repair rate across technos,
- * rather than relying on values that have other side effects.
- * Technos can have individual repair cap and rates specified for them.
- * If they don't have those keys, then those values fall back to the game-wide customizable keys.
- * If those also aren't specified either, then the game falls back to the keys it used in vanilla.
+ *  #discussions-1450 
+ *  Patch that allows customizing repair cap and repair rate across technos,
+ *  rather than relying on values that have other side effects.
+ *  Technos can have individual repair cap and rates specified for them.
+ *  If they don't have those keys, then those values fall back to the game-wide customizable keys.
+ *  If those also aren't specified either, then the game falls back to the keys it used in vanilla.
  *
- * @author: JoyfulShush
+ *  @author: JoyfulShush
  */
 bool TechnoClassExt::_Should_Self_Heal_Now() const
 {    
     auto technotypeext = Extension::Fetch(TClass);
 
-    // Prevents overhealing - allowing Strength to get above 100%.
+    /**
+     *  Prevents overhealing - allowing Strength to get above 100%.
+     */
     if (Get_Health_Ratio() >= 1) {
         return false;
     }
@@ -2786,15 +2788,15 @@ bool TechnoClassExt::_Should_Self_Heal_Now() const
         if (!Has_Ability(ABILITY_SELF_HEAL)) {
             return false;
         }
-    }    
+    }
 
     /**
-     * Determine the repair rate of this techno. 
-     * If the techno has its own repair rate, it is used. 
-     * Otherwise, the game-wide repair rate is used.
-     * If both are not specified, then the game falls back to the original RepairRate key used by this function in vanilla.     
-     */    
-    float repair_rate;
+     *  Determine the repair rate of this techno. 
+     *  If the techno has its own repair rate, it is used. 
+     *  Otherwise, the game-wide repair rate is used.
+     *  If both are not specified, then the game falls back to the original RepairRate key used by this function in vanilla.     
+     */
+    double repair_rate;
 
     if (technotypeext->SelfHealingRate != -1) {
         repair_rate = technotypeext->SelfHealingRate;
@@ -2811,10 +2813,10 @@ bool TechnoClassExt::_Should_Self_Heal_Now() const
     }
 
     /**
-     * Determines the repair cap (in percentage) of this techno. A techno cannot repair itself beyond its repair cap.
-     * If the techno has its own repair cap, it is used.
-     * Otherwise, the game-wide repair cap is used.
-     * If both are not specified, then the game falls back to the original ConditionYellow key used by this function in vanilla.
+     *  Determines the repair cap (in percentage) of this techno. A techno cannot repair itself beyond its repair cap.
+     *  If the techno has its own repair cap, it is used.
+     *  Otherwise, the game-wide repair cap is used.
+     *  If both are not specified, then the game falls back to the original ConditionYellow key used by this function in vanilla.
      */
     float repair_cap;
     
@@ -3179,6 +3181,7 @@ bool TechnoClassExt::_Evaluate_Object(ThreatType method, int mask, int range, Te
     return false;
 }
 
+
 /**
  *  Fixes a bug where placed buildings are not revealed for allies.
  *
@@ -3196,8 +3199,6 @@ DEFINE_HOOK(0x0062AB5E, _TechnoClass_Revealed_Look_For_Allies_Patch, 0)
     // trigger TEVENT_DISCOVERED
     return 0x0062AB68;
 }
-
-
 
 
 /**

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -2788,39 +2788,45 @@ bool TechnoClassExt::_Should_Self_Heal_Now() const
         }
     }    
 
-    // Determine the repair rate of this techno. 
-    // If the techno has its own repair rate, it is used. 
-    // Otherwise, the game-wide repair rate is used.
-    // If both are not specified, then the game falls back to the original RepairRate key used by this function in vanilla.
-    float repairRate;
+    /**
+     * Determine the repair rate of this techno. 
+     * If the techno has its own repair rate, it is used. 
+     * Otherwise, the game-wide repair rate is used.
+     * If both are not specified, then the game falls back to the original RepairRate key used by this function in vanilla.     
+     */    
+    float repair_rate;
 
     if (technotypeext->SelfHealingRate != -1) {
-        repairRate = technotypeext->SelfHealingRate;      
+        repair_rate = technotypeext->SelfHealingRate;
     } else if (RuleExtension->SelfHealingRate != -1) {
-        repairRate = RuleExtension->SelfHealingRate;
+        repair_rate = RuleExtension->SelfHealingRate;
     } else {
-        repairRate = Rule->RepairRate;
+        repair_rate = Rule->RepairRate;
     }
 
-    if ((Frame % (int)(std::ceil(repairRate * TICKS_PER_MINUTE))) != 0) {
+    int repair_interval = std::max(1, (int)(repair_rate * TICKS_PER_MINUTE));
+
+    if ((Frame % repair_interval) != 0) {
         return false;
     }
 
-    // Determines the repair cap (in percentage) of this techno. A techno cannot repair itself beyond its repair cap.
-    // If the techno has its own repair cap, it is used.
-    // Otherwise, the game-wide repair cap is used.
-    // If both are not specified, then the game falls back to the original ConditionYellow key used by this function in vanilla.
-    float repairCap;
+    /**
+     * Determines the repair cap (in percentage) of this techno. A techno cannot repair itself beyond its repair cap.
+     * If the techno has its own repair cap, it is used.
+     * Otherwise, the game-wide repair cap is used.
+     * If both are not specified, then the game falls back to the original ConditionYellow key used by this function in vanilla.
+     */
+    float repair_cap;
     
     if (technotypeext->SelfHealingCap != -1) {
-        repairCap = technotypeext->SelfHealingCap;
+        repair_cap = technotypeext->SelfHealingCap;
     } else if (RuleExtension->SelfHealingCap != -1) {
-        repairCap = RuleExtension->SelfHealingCap;
+        repair_cap = RuleExtension->SelfHealingCap;
     } else {
-        repairCap = Rule->ConditionYellow;
+        repair_cap = Rule->ConditionYellow;
     }
     
-    return repairCap > HealthRatio;
+    return repair_cap > HealthRatio;
 }
 
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -110,7 +110,9 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     WakeAnim(nullptr),
     WakeAnimRate(10),                   // Default DriveLocomotion value.
     IdleWakeAnim(nullptr),
-    IsHideWakeWhenCloaked(false)
+    IsHideWakeWhenCloaked(false),
+    SelfHealingCap(-1),
+    SelfHealingRate(-1)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -302,6 +304,8 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(IsOpportunityFire);
     crc(WakeAnimRate);
     crc(IsHideWakeWhenCloaked);
+    crc(SelfHealingCap);
+    crc(SelfHealingRate);
 }
 
 
@@ -445,6 +449,9 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     WakeAnimRate = ArtINI.Get_Int(graphic_name, "WakeAnimRate", WakeAnimRate);
     IdleWakeAnim = TGet_Class(ArtINI, graphic_name, "IdleWakeAnim", IdleWakeAnim);
     IsHideWakeWhenCloaked = ArtINI.Get_Bool(graphic_name, "HideWakeWhenCloaked", IsHideWakeWhenCloaked);
+
+    SelfHealingCap = ini.Get_Float(ini_name, "SelfHealingCap", SelfHealingCap);
+    SelfHealingRate = ini.Get_Float(ini_name, "SelfHealingRate", SelfHealingRate);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -272,6 +272,16 @@ public:
     TargetZoneScanType TargetZoneScan;
 
     /**
+     *  Defines the health cap (in precentages) that this techno can self-heal up to
+     */
+    float SelfHealingCap;
+
+    /**
+     *  Defines the rate (in minutes) that this techno will self-heal
+     */
+    float SelfHealingRate;
+
+    /**
      *  Does this object need to decloak before firing?
      */
     bool IsDecloakToFire;


### PR DESCRIPTION
Implements #1450 

Adds the ability to control the Self Healing mechanism for all technos, allowing to control both the maximum healing capacity and healing rate, both game-wide and per techno.

- Techno-specific values apply first. 
- If not specified, then game-wide values apply.
- If both are not specified, then Vinifera falls back to the original values used by the game, which depends on the attribute:
  - Self Healing Cap: based on `ConditionYellow`.
  - Self Healing Rate: based on `RepairRate`.

# Game-wide definition
In `RULES.INI`:
```ini
[General]
SelfHealingCap=50% ; percentage, Determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
SelfHealingRate=.016 ; float, minutes between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
```

# Techno-specific definition
In `RULES.INI`:
```ini
[SOMETECHNO]
SelfHealingCap=50% ; percentage, Determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
SelfHealingRate=.016 ; float, minutes between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
```