### PR TITLE
Experience Share

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -149,6 +149,7 @@ This page lists all the individual contributions to the project by their author.
 - **JoyfulShush**:
   - Allow customizing self healing cap and rate game-wide and per-unit.
   - Allow customizing whether AI can repair buildings created as base nodes.
+  - Add the ability for Elite units to share experience they earn with nearby units.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -362,6 +362,20 @@ Due to the nature of its use, this feature is only available when Vinifera is ru
 
 ![image](https://user-images.githubusercontent.com/73803386/129727642-8e929cc7-1b1c-4231-be44-abe4312ea265.png)
 
+### Experience Share
+
+- Elite units that destroys a target enemy can now give their experience to one of the nearby units in a range around them. This prevents the XP from being wasted and reduces the need to micromanage teams that have Elites units in them.
+- Allows customizing the range in which this XP is shared and the amount of XP that is shared when used this way.
+- Only grants XP to other units that are not Elite yet and that can gain XP (i.e. `Trainable=yes`).
+
+In Rules.ini:
+```ini
+[General]
+ExperienceShare=no ; boolean, is the Experience Share feature active?
+ExperienceShareRange=-1 ; integer, the amount of cells to search for a valid unit to give the experience to.
+ExperienceSharePercentage=100% ; % or float, the portion of the experience to grant a unit that was shared out of the original amount.
+```
+
 ### Command Line Options
 
 - Vinifera adds a number of command-line arguments allowing the user to skip the startup movies, or skip directly to a specific game mode and/or dialog.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -289,6 +289,7 @@ New:
 - Allow customizing if Veins can grow on a tile (by ZivDero)
 - Allow customizing Self Healing cap and rate globally and per-unit (by JoyfulShush)
 - Allow customizing whether AI can repair buildings created as base nodes (by JoyfulShush)
+- Add the ability for Elite units to share experience they earn with nearby units (by JoyfulShush)
 
 Vanilla fixes:
 - Fix HouseType `Nod` having the `Prefix=B` and `Side=GDI` in vanilla `rules.ini` by setting them to `N` and `Nod`, respectively (by CCHyper/tomsons26)

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -106,6 +106,9 @@ RulesClassExtension::RulesClassExtension(const RulesClass* this_ptr) :
     DetectBeaconVoice(VOX_NONE),
     SelfHealingCap(-1),
     SelfHealingRate(-1),
+    ExperienceShare(false),
+    ExperienceShareRange(-1),
+    ExperienceSharePercentage(1.0),
     IsBeachIsCrush(false),
     BuildingFlameSpawnBlockFrames(0)
 {
@@ -676,6 +679,9 @@ bool RulesClassExtension::General(CCINIClass &ini)
     MaxBeacons = ini.Get_Int(GENERAL, "MaxBeacons", MaxBeacons);
     SelfHealingCap = ini.Get_Float(GENERAL, "SelfHealingCap", SelfHealingCap);    
     SelfHealingRate = ini.Get_Float(GENERAL, "SelfHealingRate", SelfHealingRate);
+    ExperienceShare = ini.Get_Bool(GENERAL, "ExperienceShare", ExperienceShare);
+    ExperienceShareRange = ini.Get_Int(GENERAL, "ExperienceShareRange", ExperienceShareRange);
+    ExperienceSharePercentage = ini.Get_Float(GENERAL, "ExperienceSharePercentage", ExperienceSharePercentage);    
 
     /**
      *  Allow replacing any signle movement zone with a copy of RA2's water MZone.

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -212,6 +212,24 @@ public:
     double SelfHealingRate;
 
     /**
+    * Defines whether units that are Elite will share their experience with other non-Elite units.
+    */
+    bool ExperienceShare;
+
+    /**
+     * Defines the range in cells that Elite units will share their experience.
+     * Requires 'ExperienceShare' to be enabled.
+     */
+    int ExperienceShareRange;
+
+    /**
+     * Defines the percentage that Elite units will share their experience with other units.
+     * Does not affect the amount of experience the unit itself gets if it takes the XP for itself.
+     * Requires 'ExperienceShare' to be enabled.
+     */
+    float ExperienceSharePercentage;
+
+    /**
      *  Is LandType Beach considered as "requires crushing" for passability purposes, as opposed to water?
      */
     bool IsBeachIsCrush;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -3176,13 +3176,20 @@ bool TechnoClassExt::_Evaluate_Object(ThreatType method, int mask, int range, Te
     return false;
 }
 
+/*
+* Finds an allied unit in a radius around the source unit.
+* The unit must be both allied to the source
+* and capable of being trained, i.e. not Elite and has IsTrainable set to true.
+* Used to grant that source unit experience for getting veterancy.
+* Requires the 'ExperienceShareRange' key to be a positive value.
+*/
 TechnoClass* TechnoClassExt::Find_Trainable_Ally(TechnoClass* source) const {
     int experience_share_range = RuleExtension->ExperienceShareRange;
     if (experience_share_range <= 0) {
         return nullptr;
     }
 
-    ObjectClass* object; // Working object pointer
+    ObjectClass* object;
 
     Coord coord = source->Center_Coord();
     Cell cell = coord.As_Cell();
@@ -3195,7 +3202,7 @@ TechnoClass* TechnoClassExt::Find_Trainable_Ally(TechnoClass* source) const {
     const bool isbridge = cellptr->IsUnderBridge && coord.Z > BRIDGE_LEPTON_HEIGHT / 2 + Map.Get_Height_GL(coord);
 
     /**
-     *  Find an ally that can be trained from the nearby cells.
+     * Find an ally that can be trained from the nearby cells.
      * The units can be lifted from the cell data directly.
      */
     for (int x = -cell_radius; x <= cell_radius; x++) {
@@ -3210,8 +3217,7 @@ TechnoClass* TechnoClassExt::Find_Trainable_Ally(TechnoClass* source) const {
 
 
             /**
-             *  Add all objects in this cell to the list of objects to possibly apply
-             *  damage to.
+             *  Check all objects in this cell to try and find a valid trainable techno to return.
              */
             object = cellptr->Cell_Occupier(isbridge);
             while (object) {

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -127,7 +127,7 @@ public:
     int _Refund_Amount() const;
     bool _Evaluate_Object(ThreatType method, int mask, int range, TechnoClass const* object, int& value, int zone, Coord const& coord) const;
     bool _Should_Self_Heal_Now() const;
-    TechnoClass* Find_Trainable_Ally(TechnoClass * source);
+    TechnoClass* Find_Trainable_Ally(TechnoClass * source) const;
 };
 
 
@@ -1328,22 +1328,20 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
         const auto source_ext = Extension::Fetch(source);
         const auto source_typeext = Extension::Fetch(source->TClass);
 
-        if (source->TClass->IsTrainable) {            
-            if (RuleExtension->ExperienceShare) {
-                if (!source->Crew.IsElite) {
-                    source->Crew.Made_A_Kill(source->TClass->Cost_Of(House), points);
-                } else {
-                    TechnoClass* techno = Find_Trainable_Ally(source);
-                    if (techno) {
-                        int shared_points = std::max(1, (int)(points * RuleExtension->ExperienceSharePercentage));
-                        techno->Crew.Made_A_Kill(techno->TClass->Cost_Of(House), shared_points);
-                    }
-                }
-            } else {
-                source->Crew.Made_A_Kill(source->TClass->Cost_Of(House), points);
-            }
-        } else if (source_typeext->IsMissileSpawn) {
+        if (source->TClass->IsTrainable) {
+            TechnoClass* techno_to_grant_points = source;
+            int points_to_grant = points;
 
+            if (RuleExtension->ExperienceShare && source->Crew.IsElite) {
+                TechnoClass* techno = Find_Trainable_Ally(source);
+                if (techno) {
+                    points_to_grant = std::max(1, (int)(points * RuleExtension->ExperienceSharePercentage));
+                    techno_to_grant_points = techno;
+                }
+            }
+
+            techno_to_grant_points->Crew.Made_A_Kill(techno_to_grant_points->TClass->Cost_Of(House), points_to_grant);
+        } else if (source_typeext->IsMissileSpawn) {
             if (source_ext->SpawnOwner && source_ext->SpawnOwner->TClass->IsTrainable) {
                 source_ext->SpawnOwner->Crew.Made_A_Kill(source_ext->SpawnOwner->TClass->Cost_Of(House), points);
             }
@@ -3178,7 +3176,7 @@ bool TechnoClassExt::_Evaluate_Object(ThreatType method, int mask, int range, Te
     return false;
 }
 
-TechnoClass* TechnoClassExt::Find_Trainable_Ally(TechnoClass* source) {
+TechnoClass* TechnoClassExt::Find_Trainable_Ally(TechnoClass* source) const {
     int experience_share_range = RuleExtension->ExperienceShareRange;
     if (experience_share_range <= 0) {
         return nullptr;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -1328,19 +1328,18 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
         const auto source_ext = Extension::Fetch(source);
         const auto source_typeext = Extension::Fetch(source->TClass);
 
-        if (source->TClass->IsTrainable) {
-            // pretend there's an if here for checking spreading experience
-            if (true) {
+        if (source->TClass->IsTrainable) {            
+            if (RuleExtension->ExperienceShare) {
                 if (!source->Crew.IsElite) {
                     source->Crew.Made_A_Kill(source->TClass->Cost_Of(House), points);
                 } else {
                     TechnoClass* techno = Find_Trainable_Ally(source);
                     if (techno) {
-                        techno->Crew.Made_A_Kill(techno->TClass->Cost_Of(House), points);
+                        int shared_points = std::max(1, (int)(points * RuleExtension->ExperienceSharePercentage));
+                        techno->Crew.Made_A_Kill(techno->TClass->Cost_Of(House), shared_points);
                     }
                 }
             } else {
-                // original behavior
                 source->Crew.Made_A_Kill(source->TClass->Cost_Of(House), points);
             }
         } else if (source_typeext->IsMissileSpawn) {
@@ -3180,13 +3179,18 @@ bool TechnoClassExt::_Evaluate_Object(ThreatType method, int mask, int range, Te
 }
 
 TechnoClass* TechnoClassExt::Find_Trainable_Ally(TechnoClass* source) {
+    int experience_share_range = RuleExtension->ExperienceShareRange;
+    if (experience_share_range <= 0) {
+        return nullptr;
+    }
+
     ObjectClass* object; // Working object pointer
 
     Coord coord = source->Center_Coord();
     Cell cell = coord.As_Cell();
     CellClass* cellptr = &Map[cell];
 
-    int range = 5 * CELL_LEPTON_W; // replace 5 with search range value from Rules
+    int range = experience_share_range * CELL_LEPTON_W;
 
     int cell_radius = (range + CELL_LEPTON_W - 1) / CELL_LEPTON_W;
 

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -127,6 +127,7 @@ public:
     int _Refund_Amount() const;
     bool _Evaluate_Object(ThreatType method, int mask, int range, TechnoClass const* object, int& value, int zone, Coord const& coord) const;
     bool _Should_Self_Heal_Now() const;
+    TechnoClass* Find_Trainable_Ally(TechnoClass * source);
 };
 
 
@@ -1328,8 +1329,20 @@ void TechnoClassExt::_Record_The_Kill(TechnoClass* source)
         const auto source_typeext = Extension::Fetch(source->TClass);
 
         if (source->TClass->IsTrainable) {
-            source->Crew.Made_A_Kill(source->TClass->Cost_Of(House), points);
-
+            // pretend there's an if here for checking spreading experience
+            if (true) {
+                if (!source->Crew.IsElite) {
+                    source->Crew.Made_A_Kill(source->TClass->Cost_Of(House), points);
+                } else {
+                    TechnoClass* techno = Find_Trainable_Ally(source);
+                    if (techno) {
+                        techno->Crew.Made_A_Kill(techno->TClass->Cost_Of(House), points);
+                    }
+                }
+            } else {
+                // original behavior
+                source->Crew.Made_A_Kill(source->TClass->Cost_Of(House), points);
+            }
         } else if (source_typeext->IsMissileSpawn) {
 
             if (source_ext->SpawnOwner && source_ext->SpawnOwner->TClass->IsTrainable) {
@@ -3164,6 +3177,57 @@ bool TechnoClassExt::_Evaluate_Object(ThreatType method, int mask, int range, Te
     }
     value = 0;
     return false;
+}
+
+TechnoClass* TechnoClassExt::Find_Trainable_Ally(TechnoClass* source) {
+    ObjectClass* object; // Working object pointer
+
+    Coord coord = source->Center_Coord();
+    Cell cell = coord.As_Cell();
+    CellClass* cellptr = &Map[cell];
+
+    int range = 5 * CELL_LEPTON_W; // replace 5 with search range value from Rules
+
+    int cell_radius = (range + CELL_LEPTON_W - 1) / CELL_LEPTON_W;
+
+    const bool isbridge = cellptr->IsUnderBridge && coord.Z > BRIDGE_LEPTON_HEIGHT / 2 + Map.Get_Height_GL(coord);
+
+    /**
+     *  Find an ally that can be trained from the nearby cells.
+     * The units can be lifted from the cell data directly.
+     */
+    for (int x = -cell_radius; x <= cell_radius; x++) {
+        for (int y = -cell_radius; y <= cell_radius; y++) {
+
+            Cell newcell = cell + Cell(x, y);
+
+            /**
+             *  Fetch a pointer to the cell to examine.
+             */
+            cellptr = &Map[newcell];
+
+
+            /**
+             *  Add all objects in this cell to the list of objects to possibly apply
+             *  damage to.
+             */
+            object = cellptr->Cell_Occupier(isbridge);
+            while (object) {
+                if (object != source) {
+                    TechnoClass* techno = dynamic_cast<TechnoClass*>(object);
+                    if (techno) {
+                        if (techno->TClass->IsTrainable && !techno->Crew.IsElite && source->House->Is_Ally(techno) && techno->House->Is_Ally(source)) {
+                            return techno;
+                        }
+                    }
+                }
+
+                object = object->Next;
+            }
+        }
+    }
+
+    return nullptr;
 }
 
 


### PR DESCRIPTION
Allows Elite units that kill their targets to give their experience to a nearby trainable allied unit instead of wasting the experience points.

 - Elite units that destroys a target enemy can now give their experience to one of the nearby units in a range around them. This prevents the XP from being wasted and reduces the need to micromanage teams that have Elites units in them.
- Allows customizing the range in which this XP is shared and the amount of XP that is shared when used this way.
- Only grants XP to other units that are not Elite yet and that can gain XP (i.e. `Trainable=yes`).

In Rules.ini:
```ini
[General]
ExperienceShare=no ; boolean, is the Experience Share feature active?
ExperienceShareRange=-1 ; integer, the amount of cells to search for a valid unit to give the experience to.
ExperienceSharePercentage=100% ; % or float, the portion of the experience to grant a unit that was shared out of the original amount.
```