### PR TITLE
Update sensors of captured sensors array

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -152,6 +152,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow customizing self healing cap and rate game-wide and per-unit.
   - Allow customizing whether AI can repair buildings created as base nodes.
   - Fix a vanilla bug where self-healing aircraft would enter an infinite tumbling animation loop and stay alive.
+  - Fix a vanilla bug where capturing buildings with sensor capabilities would not update the owners of the sensors.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -112,3 +112,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug that allowed players to issue Stop orders to units not owned by them through crafted network requests.
 - Fix a bug that allowed players to issue movement and attack orders to units not owned by them through crafted network requests.
 - Fix a bug where aircraft that had `SelfHealing=yes` would become indestructible on death and heal back up, causing them to get stuck in a tumbling animation.
+- Fix a bug where capturing buildings with sensor capabilities (`SensorArray=yes`) would not update to the owners of the sensors.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -390,5 +390,6 @@ Vanilla fixes:
 - Fix building light sources no longer being attached to the building after loading the game (by ZivDero)
 - Fix shroud looking bugged if you attempt to reveal too many cells at once (by ZivDero)
 - Fix a bug where aircraft that had `SelfHealing=yes` would become indestructible on death and heal back up, causing them to get stuck in a tumbling animation (by JoyfulShush)
+- Fix a bug where capturing buildings with sensor capabilities (`SensorArray=yes`) would not update to the owners of the sensors (by JoyfulShush)
 
 :::

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2432,7 +2432,7 @@ DEFINE_HOOK(0x0042A3D1, _BuildingClass_Unlimbo_AI_Repair_Base_Nodes, 5)
 }
 
 /*
-* Reimplements a portion of BuildingClass::Captured where laser fence connections are updated (or more correctly - removed)
+* Patches a portion of BuildingClass::Captured where laser fence connections are updated (or more correctly - removed)
 * At this point, the House of the captured building is NOT updated yet - and belongs to the original owner of this building.
 * This allows us to add an additional check where if a sensor array is captured, the original owner loses that sensor array's sensing capabilities.
 * 
@@ -2442,21 +2442,17 @@ DEFINE_HOOK(0x0042F749, _BuildingClass_Captured_Disable_Sensors, 6)
 {
     GET(BuildingClass*, this_ptr, ESI);
 
-    auto building_type = reinterpret_cast<const BuildingTypeClass*>(this_ptr->TClass);
-
-    if (building_type->IsLaserFencePost) {        
-        this_ptr->Update_Laser_Fence_Connections(0);
-    }
+    auto building_type = this_ptr->Class;    
 
     if (building_type->IsSensorArray) {
         this_ptr->Disable_Sensor_Array();
     }
 
-    return 0x0042F75C;
+    return 0;
 }
 
 /*
- * Reimplements a portion of BuildingClass::Captured where a building that gets captured lets players reveal shroud around it.
+ * Patches a portion of BuildingClass::Captured where a building that gets captured lets players reveal shroud around it with Look().
  * At this point, the House of the captured building is already updated - and belongs to the new owner of this building.
  * This allows us to add an additional check where if a sensor array is captured, the new owner gains that sensor array's sensing capabilities.
  *
@@ -2466,17 +2462,13 @@ DEFINE_HOOK(0x0042FB9F, _BuildingClass_Captured_Enable_Sensors, 6)
 {
     GET(BuildingClass*, this_ptr, ESI);
 
-    auto building_type = reinterpret_cast<const BuildingTypeClass*>(this_ptr->TClass);
-
-    if (this_ptr->House->Is_Player_Control()) {
-        this_ptr->Look(false, false);
-    }
+    auto building_type = this_ptr->Class;
 
     if (building_type->IsSensorArray) {
         this_ptr->Enable_Sensor_Array();
     }
 
-    return 0x0042FBBA;
+    return 0;
 }
 
 /**

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2431,6 +2431,53 @@ DEFINE_HOOK(0x0042A3D1, _BuildingClass_Unlimbo_AI_Repair_Base_Nodes, 5)
     return 0;
 }
 
+/*
+* Reimplements a portion of BuildingClass::Captured where laser fence connections are updated (or more correctly - removed)
+* At this point, the House of the captured building is NOT updated yet - and belongs to the original owner of this building.
+* This allows us to add an additional check where if a sensor array is captured, the original owner loses that sensor array's sensing capabilities.
+* 
+* @author: JoyfulShush
+*/
+DEFINE_HOOK(0x0042F749, _BuildingClass_Captured_Disable_Sensors, 6)
+{
+    GET(BuildingClass*, this_ptr, ESI);
+
+    auto building_type = reinterpret_cast<const BuildingTypeClass*>(this_ptr->TClass);
+
+    if (building_type->IsLaserFencePost) {        
+        this_ptr->Update_Laser_Fence_Connections(0);
+    }
+
+    if (building_type->IsSensorArray) {
+        this_ptr->Disable_Sensor_Array();
+    }
+
+    return 0x0042F75C;
+}
+
+/*
+ * Reimplements a portion of BuildingClass::Captured where a building that gets captured lets players reveal shroud around it.
+ * At this point, the House of the captured building is already updated - and belongs to the new owner of this building.
+ * This allows us to add an additional check where if a sensor array is captured, the new owner gains that sensor array's sensing capabilities.
+ *
+ * @author: JoyfulShush
+ */
+DEFINE_HOOK(0x0042FB9F, _BuildingClass_Captured_Enable_Sensors, 6)
+{
+    GET(BuildingClass*, this_ptr, ESI);
+
+    auto building_type = reinterpret_cast<const BuildingTypeClass*>(this_ptr->TClass);
+
+    if (this_ptr->House->Is_Player_Control()) {
+        this_ptr->Look(false, false);
+    }
+
+    if (building_type->IsSensorArray) {
+        this_ptr->Enable_Sensor_Array();
+    }
+
+    return 0x0042FBBA;
+}
 
 /**
  *  Main function for patching the hooks.

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2432,11 +2432,11 @@ DEFINE_HOOK(0x0042A3D1, _BuildingClass_Unlimbo_AI_Repair_Base_Nodes, 5)
 }
 
 /*
-* Patches a portion of BuildingClass::Captured where laser fence connections are updated (or more correctly - removed)
-* At this point, the House of the captured building is NOT updated yet - and belongs to the original owner of this building.
-* This allows us to add an additional check where if a sensor array is captured, the original owner loses that sensor array's sensing capabilities.
+*  Patches a portion of BuildingClass::Captured where laser fence connections are updated (or more correctly - removed)
+*  At this point, the House of the captured building is NOT updated yet - and belongs to the original owner of this building.
+*  This allows us to add an additional check where if a sensor array is captured, the original owner loses that sensor array's sensing capabilities.
 * 
-* @author: JoyfulShush
+*  @author: JoyfulShush
 */
 DEFINE_HOOK(0x0042F749, _BuildingClass_Captured_Disable_Sensors, 6)
 {
@@ -2452,11 +2452,11 @@ DEFINE_HOOK(0x0042F749, _BuildingClass_Captured_Disable_Sensors, 6)
 }
 
 /*
- * Patches a portion of BuildingClass::Captured where a building that gets captured lets players reveal shroud around it with Look().
- * At this point, the House of the captured building is already updated - and belongs to the new owner of this building.
- * This allows us to add an additional check where if a sensor array is captured, the new owner gains that sensor array's sensing capabilities.
+ *  Patches a portion of BuildingClass::Captured where a building that gets captured lets players reveal shroud around it with Look().
+ *  At this point, the House of the captured building is already updated - and belongs to the new owner of this building.
+ *  This allows us to add an additional check where if a sensor array is captured, the new owner gains that sensor array's sensing capabilities.
  *
- * @author: JoyfulShush
+ *  @author: JoyfulShush
  */
 DEFINE_HOOK(0x0042FB9F, _BuildingClass_Captured_Enable_Sensors, 6)
 {


### PR DESCRIPTION
Fix a bug where capturing buildings with sensor capabilities (`SensorArray=yes`) would not update to the owners of the sensors.

Fixes #1577 