### PR TITLE
Allow Service Depots and Helipads to accept additional orders

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -158,6 +158,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a few vanilla bugs where units with death frames (such as Reapers) would count as dead multiple times, and be allowed to be issued move orders by players.
   - Fix a vanilla bug where capturing buildings with sensor capabilities would not update the owners of the sensors.
   - Allow hospitals and armories to accept multiple infantry in one order to set a queue and to set rally points.
+  - Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use. 
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -16,6 +16,8 @@ This page describes every change in Vinifera that wasn't categorized into a prop
 - Improve alternative factory selection when the primary factory is blocked.
 - Make `SOUND01.INI` load additively with `SOUND.INI`, reload sounds after loading side `MIX` files.
 - When revealing shroud via a unit, structure, or triggers, TS had a maximum allowed sight radius of 10. This meant units could not have a `Sight=` value above 10, and Reveal Around Waypoint trigger actions could not reveal in radius higher than 10 even if specified in `RevealTriggerRadius`. Vinifera now allows and handles revealing shroud in any desired range, with no limit.
+- Aircraft can now click on Helipad that are occupied or about to be occupied by other aircraft, which reassigns them to a different free Helipad, or near the existing Helipad if no free Helipads exist. 
+- Units and aircraft can now click on a Service Depot even it is occupied or about to be occupied by other units. Doing so will add these units to the list of units waiting to be repaired.
 
 ## INI
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -24,6 +24,10 @@ In `RULES.INI`:
 ReloadRate=     ; float, the rate that this aircraft will reload its ammo when docked with a helipad. Defaults to [General]->ReloadRate.
 ```
 
+### Helipad Docking
+- Aircraft can now click on Helipad that are occupied or about to be occupied by other aircraft, which reassigns them to a different free Helipad, or near the existing Helipad if no free Helipads exist. 
+
+
 ## Animations
 
 ### Additional Animation Spawning
@@ -1525,6 +1529,9 @@ TurretFacings=32     ; integer, the turret facing count.
 
 - Similarly, the `Anim=` INI key for WeaponTypes now also supports 16, 32 and 64 entries.
 - Because of the new extended facing support, it was observed that the buffer size was too small and has now been increased to allow a larger entry to accommodate a larger facing count. Mind that the maximum string length is 506 characters now, so be sure to use short names if you want to have 64 entries.
+
+### Service Depot Docking
+* Units and aircraft can now click on a Service Depot it is occupied or about to be occupied by other units. Doing so will add these units to the list of units waiting to be repaired.
 
 ## Voxel Animations
 

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -24,10 +24,6 @@ In `RULES.INI`:
 ReloadRate=     ; float, the rate that this aircraft will reload its ammo when docked with a helipad. Defaults to [General]->ReloadRate.
 ```
 
-### Helipad Docking
-- Aircraft can now click on Helipad that are occupied or about to be occupied by other aircraft, which reassigns them to a different free Helipad, or near the existing Helipad if no free Helipads exist. 
-
-
 ## Animations
 
 ### Additional Animation Spawning
@@ -1529,9 +1525,6 @@ TurretFacings=32     ; integer, the turret facing count.
 
 - Similarly, the `Anim=` INI key for WeaponTypes now also supports 16, 32 and 64 entries.
 - Because of the new extended facing support, it was observed that the buffer size was too small and has now been increased to allow a larger entry to accommodate a larger facing count. Mind that the maximum string length is 506 characters now, so be sure to use short names if you want to have 64 entries.
-
-### Service Depot Docking
-* Units and aircraft can now click on a Service Depot it is occupied or about to be occupied by other units. Doing so will add these units to the list of units waiting to be repaired.
 
 ## Voxel Animations
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -404,5 +404,6 @@ Vanilla fixes:
 - Fix a bug where units that have DeathFrames (such as Reapers) could be killed multiple times, dropping small patches of tiberium with each death.
 - Fix a bug where units that have DeathFrames (such as Reapers) could be issued move orders by players while playing their death animations.
 - Fix a bug where capturing buildings with sensor capabilities (`SensorArray=yes`) would not update to the owners of the sensors (by JoyfulShush)
+- Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use (by JoyfulShush)
 
 :::

--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -268,7 +268,7 @@ ActionType AircraftClassExt::_What_Action(ObjectClass const* target, bool disall
         /**
          *  #FIX: Allow any repair depot to repair aircraft, not just Rule->RepairBay
          */
-        if ((building->Class->IsCanUnitRepair || building->Class->IsHelipad) && !building->In_Radio_Contact() && !building->Cargo.Is_Something_Attached()) {
+        if ((building->Class->IsCanUnitRepair || building->Class->IsHelipad) && !building->Cargo.Is_Something_Attached()) {
             if (Transmit_Message(RADIO_CAN_LOAD, building) == RADIO_ROGER) {
                 action = ACTION_ENTER;
             }

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2030,8 +2030,9 @@ RadioMessageType BuildingClassExt::_Receive_Message(RadioClass* from, RadioMessa
     case RADIO_CAN_LOAD:
         TechnoClass::Receive_Message(from, message, param);
         if (!House->Is_Ally(from)) return RADIO_STATIC;
-        if (Mission == MISSION_CONSTRUCTION || Mission == MISSION_DECONSTRUCTION || BState == BSTATE_CONSTRUCTION || (!ScenarioInit && In_Radio_Contact() && Contact_With_Whom() != from)) return RADIO_NEGATIVE;
+        if (Mission == MISSION_CONSTRUCTION || Mission == MISSION_DECONSTRUCTION || BState == BSTATE_CONSTRUCTION) return RADIO_NEGATIVE;
         if (!IsOn) return RADIO_NEGATIVE;
+
         if (Class->IsCanUnitRepair) {
             if (from->RTTI == RTTI_UNIT || from->RTTI == RTTI_AIRCRAFT) {
                 if (Transmit_Message(RADIO_ON_DEPOT, from) != RADIO_ROGER) {
@@ -2039,7 +2040,8 @@ RadioMessageType BuildingClassExt::_Receive_Message(RadioClass* from, RadioMessa
                 }
             }
             return RADIO_NEGATIVE;
-        }
+        }        
+
         if ((Class->IsArmory || Class->IsHospital) && from->RTTI == RTTI_INFANTRY) {
             if (Ammo != 0 && Mission != MISSION_REPAIR) {
                 return RADIO_ROGER;
@@ -2056,6 +2058,8 @@ RadioMessageType BuildingClassExt::_Receive_Message(RadioClass* from, RadioMessa
             }
             return RADIO_NEGATIVE;
         }
+
+        if (!ScenarioInit && In_Radio_Contact() && Contact_With_Whom() != from) return RADIO_NEGATIVE;
 
         /**
          *  #issue-129

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2059,6 +2059,13 @@ RadioMessageType BuildingClassExt::_Receive_Message(RadioClass* from, RadioMessa
             return RADIO_NEGATIVE;
         }
 
+        /*
+        *  Prevents units from requesting to load into the building if it's already in a radio contact with a unit.
+        *  This is typically used in order to only allow one unit to set up loading into it.
+        *  Originally, it was at the very top of this function to prevent any building from interacting with units while during contact,
+        *  however it was moved here in order to allow Helipads, Armories, Hospitals and Service Depots to communicate with
+        *  all units without limitation. Only one unit can still be accepted into being loaded at a time.
+        */ 
         if (!ScenarioInit && In_Radio_Contact() && Contact_With_Whom() != from) return RADIO_NEGATIVE;
 
         /**


### PR DESCRIPTION
- Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use. 

Note: Refineries are currently out of scope due to issues with their logic, which will be fixed on a separate PR.