### PR TITLE
Fix idle harvesters

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -159,6 +159,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a few vanilla bugs where units with death frames (such as Reapers) would count as dead multiple times, and be allowed to be issued move orders by players.
   - Fix a vanilla bug where capturing buildings with sensor capabilities would not update the owners of the sensors.
   - Allow hospitals and armories to accept multiple infantry in one order to set a queue and to set rally points.
+  - Fix a vanilla bug where harvesters will become permanently idle if they exhaust all resources to mine, even if new resources appears (e.g. tib tree)
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -159,7 +159,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a few vanilla bugs where units with death frames (such as Reapers) would count as dead multiple times, and be allowed to be issued move orders by players.
   - Fix a vanilla bug where capturing buildings with sensor capabilities would not update the owners of the sensors.
   - Allow hospitals and armories to accept multiple infantry in one order to set a queue and to set rally points.
-  - Fix a vanilla bug where harvesters will become permanently idle if they exhaust all resources to mine, even if new resources appears (e.g. tiberium tree)
+  - Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
   - Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use. 
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -122,4 +122,3 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the map would accept input while the user was in a dialog window.
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.
 - Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
-- Fix a bug where the sidebar could only contain up to 75 items on a strip.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -121,5 +121,5 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where a trigger's "Elapsed Time" event timers were reset when the trigger was already enabled and the "Enable Trigger" TAction was used on it.
 - Fix a bug where the map would accept input while the user was in a dialog window.
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.
-- Fix a vanilla bug where harvesters will become permanently idle if they exhaust all resources to mine, even if new resources appears (e.g. tib tree)
+- Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -121,3 +121,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where a trigger's "Elapsed Time" event timers were reset when the trigger was already enabled and the "Enable Trigger" TAction was used on it.
 - Fix a bug where the map would accept input while the user was in a dialog window.
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.
+- Fix a vanilla bug where harvesters will become permanently idle if they exhaust all resources to mine, even if new resources appears (e.g. tib tree)

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -163,7 +163,7 @@ Vanilla fixes:
 - Fix a bug that allowed players to issue movement and attack orders to units not owned by them through crafted network requests (by Rampastring)
 - Fix a bug where a trigger's "Elapsed Time" event timers were reset when the trigger was already enabled and the "Enable Trigger" TAction was used on it (by Rampastring)
 - Fix a bug where the sidebar could only contain up to 75 items on a strip (by ZivDero)
-- Fix a vanilla bug where harvesters will become permanently idle if they exhaust all resources to mine, even if new resources appears (e.g. tib tree)
+- Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree) (by JoyfulShush)
 - Fix a bug where if you started the game owning a Techno at its BuildLimit, it would not appear on your sidebar (by ZivDero)
 
 :::

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -163,6 +163,7 @@ Vanilla fixes:
 - Fix a bug that allowed players to issue movement and attack orders to units not owned by them through crafted network requests (by Rampastring)
 - Fix a bug where a trigger's "Elapsed Time" event timers were reset when the trigger was already enabled and the "Enable Trigger" TAction was used on it (by Rampastring)
 - Fix a bug where the sidebar could only contain up to 75 items on a strip (by ZivDero)
+- Fix a vanilla bug where harvesters will become permanently idle if they exhaust all resources to mine, even if new resources appears (e.g. tib tree)
 
 :::
 

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1278,6 +1278,7 @@ DEFINE_HOOK(0x0065601D, _UnitClass_What_Action_ACTION_SELF_Prevent_Deploying_Hij
     return 0x0065602B;
 }
 
+
 /**
  *  Main function for patching the hooks.
  */

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1279,32 +1279,6 @@ DEFINE_HOOK(0x0065601D, _UnitClass_What_Action_ACTION_SELF_Prevent_Deploying_Hij
 }
 
 /**
- *  Patches the MISSION_HARVEST logic that handles harvesters becoming idle due to being unable to find tiberium in its area.
- *  It does this by removing the MISSION_GUARD assignment inside the function and instead sets it to MISSION_GUARD_AREA,
- *  which naturally seeks out tiberium to harvest.
- * 
- *  Skips to the end of the function in this case to prevent additional mission assignments.
- *
- *  Author: JoyfulShush
- */
-DEFINE_HOOK(0x0065516A, _UnitClass_Do_MISSION_HARVEST_Idle_Harvester_Prevention, 0)
-{
-    GET(UnitClass*, this_ptr, ESI);
-    
-    BuildingClass* bptr = Map[(Coord&)this_ptr->PositionCoord].Cell_Building();
-    if (bptr != NULL) {
-        if (bptr->Class->IsRefinery || bptr->Class->IsWeeder) {
-            this_ptr->Assign_Destination(&Map[this_ptr->Nearby_Location(bptr)]);
-        }
-    }
-    this_ptr->Assign_Mission(MISSION_GUARD_AREA);
-    this_ptr->Current_Mission_Control();
-
-    return 0x00654AA3;
-}
-
-
-/**
  *  Main function for patching the hooks.
  */
 void UnitClassExtension_Hooks()
@@ -1319,4 +1293,10 @@ void UnitClassExtension_Hooks()
     Patch_Jump(0x006571E0, &UnitClassExt::_Approach_Target);
 
     Patch_Byte(0x00658961, 0xEB); // Allow pre-placed units to have missions in multiplayer, change JZ to JMP
+    /*
+    *  Patches the MISSION_HARVEST logic that handles harvesters becoming idle due to being unable to find tiberium in its area.
+    *  It does this by removing the MISSION_GUARD assignment inside the function and instead sets it to MISSION_GUARD_AREA,
+    *  which naturally seeks out tiberium to harvest.
+    */  
+    Patch_Byte(0x0065521C + 1, (unsigned char)MISSION_GUARD_AREA); 
 }

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1278,6 +1278,31 @@ DEFINE_HOOK(0x0065601D, _UnitClass_What_Action_ACTION_SELF_Prevent_Deploying_Hij
     return 0x0065602B;
 }
 
+/**
+ *  Patches the MISSION_HARVEST logic that handles harvesters becoming idle due to being unable to find tiberium in its area.
+ *  It does this by removing the MISSION_GUARD assignment inside the function and instead sets it to MISSION_GUARD_AREA,
+ *  which naturally seeks out tiberium to harvest.
+ * 
+ *  Skips to the end of the function in this case to prevent additional mission assignments.
+ *
+ *  Author: JoyfulShush
+ */
+DEFINE_HOOK(0x0065516A, _UnitClass_Do_MISSION_HARVEST_Idle_Harvester_Prevention, 0)
+{
+    GET(UnitClass*, this_ptr, ESI);
+    
+    BuildingClass* bptr = Map[(Coord&)this_ptr->PositionCoord].Cell_Building();
+    if (bptr != NULL) {
+        if (bptr->Class->IsRefinery || bptr->Class->IsWeeder) {
+            this_ptr->Assign_Destination(&Map[this_ptr->Nearby_Location(bptr)]);
+        }
+    }
+    this_ptr->Assign_Mission(MISSION_GUARD_AREA);
+    this_ptr->Current_Mission_Control();
+
+    return 0x00654AA3;
+}
+
 
 /**
  *  Main function for patching the hooks.


### PR DESCRIPTION
Fix a bug where harvesters that have exhausted all resources in the area would become idle (MISSION_GUARD), making them never seek out resources again.