### PR TITLE
Fix APCs not spawning their loaded infantry when destroyed while moving

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -174,6 +174,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use. 
   - Allow repairs to be paused instead of stopped when a house has insufficient funds.
   - Add Q-Move support for aircraft.
+  - Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving. 
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -121,4 +121,5 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where a trigger's "Elapsed Time" event timers were reset when the trigger was already enabled and the "Enable Trigger" TAction was used on it.
 - Fix a bug where the map would accept input while the user was in a dialog window.
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.
-- Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
+- Fix a bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
+- Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -176,6 +176,7 @@ Vanilla fixes:
 - Fix a bug where the sidebar could only contain up to 75 items on a strip (by ZivDero)
 - Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree) (by JoyfulShush)
 - Fix a bug where if you started the game owning a Techno at its BuildLimit, it would not appear on your sidebar (by ZivDero)
+- Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving (by JoyfulShush)
 
 :::
 

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1280,8 +1280,8 @@ DEFINE_HOOK(0x0065601D, _UnitClass_What_Action_ACTION_SELF_Prevent_Deploying_Hij
 
 /**
  *  Patches UnitClass::Take_Damage right before iterating on the cargo.
- *  Fixes an issue where moving units that have cargo (such as APCs) will not spawn their cargo
- *  and they will instead die if the unit is transitioning from one cell to another
+ *  Fixes an issue where units that have cargo (such as APCs) do not spawn their cargo if they are destroyed
+ *  while moving from one cell to another, resulting in the cargo getting erased instead.
  * 
  *  @author: JoyfulShush
  */

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1278,6 +1278,27 @@ DEFINE_HOOK(0x0065601D, _UnitClass_What_Action_ACTION_SELF_Prevent_Deploying_Hij
     return 0x0065602B;
 }
 
+/**
+ *  Patches UnitClass::Take_Damage right before iterating on the cargo.
+ *  Fixes an issue where moving units that have cargo (such as APCs) will not spawn their cargo
+ *  and they will instead die if the unit is transitioning from one cell to another
+ * 
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x0064FDB4, _Unit_Class_Take_Damage_Cargo_Hold_Patch, 6)
+{
+    GET(UnitClass*, this_ptr, ESI);
+
+    if (this_ptr->Cargo.Is_Something_Attached()) {
+        this_ptr->Stop_Driver();
+        if (this_ptr->Locomotion) {
+            this_ptr->Locomotion->Mark_All_Occupation_Bits(MARK_UP);
+        }
+    }
+    
+    return 0;
+}
+
 
 /**
  *  Main function for patching the hooks.


### PR DESCRIPTION
Fixed a bug where destroyed APCs sometimes don't eject the infantry inside them when destroyed while moving.