### PR TITLE
Fix bugs around adding to selection of healing units

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -173,6 +173,8 @@ This page lists all the individual contributions to the project by their author.
   - Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
   - Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use. 
   - Allow repairs to be paused instead of stopped when a house has insufficient funds.
+  - Fix a bug that would make healing units unselect themselves when adding other units to current selection.
+  - Fix a bug that would make infantry healing units flash and go into Area Guard mode when they were added to current selection.
   - Add Q-Move support for aircraft.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -174,7 +174,7 @@ This page lists all the individual contributions to the project by their author.
   - Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use. 
   - Allow repairs to be paused instead of stopped when a house has insufficient funds.
   - Fix a bug that would make healing units unselect themselves when adding other units to current selection.
-  - Fix a bug that would make infantry healing units flash and go into Area Guard mode when they were added to current selection.
+  - Fix a bug that would make infantry healer units flash and go into Area Guard mode when they were added to current selection.
   - Add Q-Move support for aircraft.
   - Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving. 
 - **Kerbiter (Metadorius)**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -122,3 +122,5 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the map would accept input while the user was in a dialog window.
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.
 - Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
+- Fix a bug that would make healing units unselect themselves when adding other units to current selection.
+- Fix a bug that would make infantry healing units flash and go into Area Guard mode when they were added to current selection.

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -123,5 +123,5 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.
 - Fix a bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
 - Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving.
-- Fix a bug that would make healing units unselect themselves when adding other units to current selection.
-- Fix a bug that would make infantry healing units flash and go into Area Guard mode when they were added to current selection.
+- Fix a bug that would make healer units unselect themselves when adding other units to current selection.
+- Fix a bug that would make infantry healer units flash and go into Area Guard mode when they were added to current selection.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -412,5 +412,7 @@ Vanilla fixes:
 - Fix a bug where units that have DeathFrames (such as Reapers) could be issued move orders by players while playing their death animations.
 - Fix a bug where capturing buildings with sensor capabilities (`SensorArray=yes`) would not update to the owners of the sensors (by JoyfulShush)
 - Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use (by JoyfulShush)
+- Fix a bug that would make healing units unselect themselves when adding other units to current selection (by JoyfulShush)
+- Fix a bug that would make infantry healing units flash and go into Area Guard mode when they were added to current selection (by JoyfulShush)
 
 :::

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -413,7 +413,7 @@ Vanilla fixes:
 - Fix a bug where units that have DeathFrames (such as Reapers) could be issued move orders by players while playing their death animations.
 - Fix a bug where capturing buildings with sensor capabilities (`SensorArray=yes`) would not update to the owners of the sensors (by JoyfulShush)
 - Allow helipads and service depots to accept additional units to add to the queue or re-assign to a different helipad when clicking on one that is currently in use (by JoyfulShush)
-- Fix a bug that would make healing units unselect themselves when adding other units to current selection (by JoyfulShush)
-- Fix a bug that would make infantry healing units flash and go into Area Guard mode when they were added to current selection (by JoyfulShush)
+- Fix a bug that would make healer units unselect themselves when adding other units to current selection (by JoyfulShush)
+- Fix a bug that would make infantry healer units flash and go into Area Guard mode when they were added to current selection (by JoyfulShush)
 
 :::

--- a/src/extensions/display/displayext_hooks.cpp
+++ b/src/extensions/display/displayext_hooks.cpp
@@ -363,6 +363,25 @@ DEFINE_HOOK(0x0047A856, _DisplayClass_47A790_Patch, 0)
     }
 }
 
+/**
+ *  Patches DisplayClass::Mouse_Left_Release to skip the 'Active_Click' call when the action
+ *  is ACTION_TOGGLE_SELECT (adding to selection). In most cases, this was unnecessary and did nothing.
+ * 
+ *  However, in the case of medics, since they can click on themselves to switch to Area Guard,
+ *  this caused adding them to selection to immediately move them to Area Guard, while also flashing.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x00478BC7, _Display_Class_Mouse_Left_Release_Toggle_Select_Patch, 5)
+{
+    GET(ActionType, action, EDI);
+
+    if (action == ACTION_TOGGLE_SELECT) {
+        return 0x00478BD8;
+    }
+
+    return 0;
+}
 
 /**
  *  Main function for patching the hooks.

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -721,6 +721,27 @@ DEFINE_HOOK(0x004D4251, _Assign_Destination_Hospital_Armory_Queue_Patch, 9)
     return 0x004D425A;
 }
 
+/**
+ *  Patches InfantryClass::What_Action at the part where medics/mechanics (AKA infantry with negative combat damage)
+ *  are evaluated whether they should commit to their action or switch to ACTION_SELECT.
+ *  
+ *  Fixes an issue where ACTION_TOGGLE_SELECT (selecting units while shift is held) was converted into ACTION_SELECT,
+ *  causing the game to instead unselect the currently selected units if the medic was the "best object" in the current selection.
+ * 
+ *  Causes What_Action to return with the ACTION_TOGGLE_SELECT action if this is the current mission.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x004D71CF, _Infantry_Class_What_Action_Medic_Toggle_Select_Patch, 9)
+    GET(ActionType, action, EBX);
+
+    if (action == ACTION_TOGGLE_SELECT) {
+        return 0x004D76F9;
+    }
+
+    return 0;
+}
+
 
 /**
  *  Main function for patching the hooks.

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -743,7 +743,6 @@ DEFINE_HOOK(0x004D71CF, _Infantry_Class_What_Action_Medic_Toggle_Select_Patch, 9
     return 0;
 }
 
-
 /**
  *  Main function for patching the hooks.
  */

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -733,6 +733,7 @@ DEFINE_HOOK(0x004D4251, _Assign_Destination_Hospital_Armory_Queue_Patch, 9)
  *  @author: JoyfulShush
  */
 DEFINE_HOOK(0x004D71CF, _Infantry_Class_What_Action_Medic_Toggle_Select_Patch, 9)
+{
     GET(ActionType, action, EBX);
 
     if (action == ACTION_TOGGLE_SELECT) {

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1278,7 +1278,6 @@ DEFINE_HOOK(0x0065601D, _UnitClass_What_Action_ACTION_SELF_Prevent_Deploying_Hij
     return 0x0065602B;
 }
 
-
 /**
  *  Patches UnitClass::Take_Damage right before iterating on the cargo.
  *  Fixes an issue where units that have cargo (such as APCs) do not spawn their cargo if they are destroyed

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1278,6 +1278,29 @@ DEFINE_HOOK(0x0065601D, _UnitClass_What_Action_ACTION_SELF_Prevent_Deploying_Hij
     return 0x0065602B;
 }
 
+/**
+ *  Patches UnitClass::What_Action at the part where MRVs (AKA units with negative combat damage)
+ *  are evaluated whether they should commit to their action or switch to ACTION_SELECT.
+ *
+ *  Fixes an issue where ACTION_TOGGLE_SELECT (selecting units while shift is held) was converted into ACTION_SELECT,
+ *  causing the game to instead unselect the currently selected units if the MRV was the "best object" in the current selection.
+ *  For MRVs, this only triggers while trying to add infantry to your selection.
+ *
+ *  Causes What_Action to return with the ACTION_TOGGLE_SELECT action if this is the current mission.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x006563FD, _UnitClass_What_Action_MRV_Toggle_Select_Patch, 7) 
+{
+    GET_STACK(ActionType, action, 0x28);
+
+    if (action == ACTION_TOGGLE_SELECT) {
+        return 0x0065648B;
+    }
+
+    return 0;
+}
+
 
 /**
  *  Main function for patching the hooks.

--- a/src/extensions/unit/unitext_hooks.cpp
+++ b/src/extensions/unit/unitext_hooks.cpp
@@ -1299,7 +1299,6 @@ DEFINE_HOOK(0x0064FDB4, _Unit_Class_Take_Damage_Cargo_Hold_Patch, 6)
     return 0;
 }
 
-
 /**
  *  Patches UnitClass::What_Action at the part where MRVs (AKA units with negative combat damage)
  *  are evaluated whether they should commit to their action or switch to ACTION_SELECT.


### PR DESCRIPTION
  - Fix a bug that would make healing units unselect themselves when adding other units to current selection.
    - Includes a fix to both infantry (e.g. medics) and vehicles (e.g. MRVs).
  - Fix a bug that would make infantry healing units flash and go into Area Guard mode when they were added to current selection.