### PR TITLE
Attack Support and Area Guard improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -175,6 +175,9 @@ This page lists all the individual contributions to the project by their author.
   - Allow repairs to be paused instead of stopped when a house has insufficient funds.
   - Add Q-Move support for aircraft.
   - Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving. 
+  - Healing units now apply area-guard on a nearby combatant unit when attacking enemy targets, rather than area-guarding on themselves.
+  - Fix a vanilla bug where area-guarding units that are guarding another unit will constantly go back to their designated unit instead of acquiring additional targets in range.
+  - Added the ability to specify the range area-guarding units will move to their assigned unit, as well as the range that area-guarding units will abandon their targets and move towards their assigned unit.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -123,3 +123,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where the sidebar could only contain up to 75 items on a strip.
 - Fix a bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree)
 - Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving.
+- Fix a bug where area-guarding units that are guarding another unit will constantly go back to their designated unit instead of acquiring additional targets in range.

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -18,6 +18,7 @@ This page describes every change in Vinifera that wasn't categorized into a prop
 - Aircraft can now click on Helipad that are occupied or about to be occupied by other aircraft, which reassigns them to a different free Helipad, or near the existing Helipad if no free Helipads exist. 
 - Players can now click on a Service Depot with units and aircraft even if it is occupied or about to be occupied by other units. Doing so will add these units to the list of units waiting to be repaired.
 - Vinifera allows aircraft to use Q-Move, similarly to other types of units in the game. Q-Moving aircraft will stay in the air as they move on to their next destination. Unlike ground units, aircraft cannot target enemies while Q-Moving. Ordering queue-moves to an aircraft currently targetting an enemy will remove the attack order. Carryalls get extended handling while Q-Moving, allowing it to pick up units along the way and carry them until the end of their path.
+- Healing units now apply area-guard on a nearby combatant unit when attacking enemy targets, rather than area-guarding on themselves.
 
 ## Modern Video Playback
 
@@ -351,6 +352,19 @@ In `RULES.INI`:
 ```ini
 [General]
 PausedRepairsFrame=6  ; integer, the frame index on the wrench shape to show while building repairs are paused.
+```
+
+## Area Guard Escort Logic Improvements
+- Vinifera allows modders to specify the range in which an area-guarding unit that is assigned to guard another unit will follow it, as well as the range where it will abandon targets it is currently attacking (or healing) and go back to their assigned unit.
+- This only applies on Area Guards on a unit; Area Guards on a cell does not count.
+- Can be specified globally or for each unit individually. When both are applied, unit-specific values are used over the global values. 
+- When those values are not stated or are non-positive, Vinifera falls back to the original behavior, which causes area-guarding units to follow their assigned unit once it leaves 2x the area-guarding unit's Guard Range (up to a maximum of 12 cells).
+
+in `RULES.INI`:
+```ini
+[General]
+EscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
+AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
 ```
 
 ## File System

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -365,6 +365,10 @@ in `RULES.INI`:
 [General]
 EscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
 AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
+
+[SOMETECHNO]
+EscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
+AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
 ```
 
 ```{note}

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -363,11 +363,11 @@ PausedRepairsFrame=6  ; integer, the frame index on the wrench shape to show whi
 in `RULES.INI`:
 ```ini
 [General]
-EscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
+EscortRange=-1  			 ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
 AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
 
 [SOMETECHNO]
-EscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
+EscortRange=-1  			 ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
 AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
 ```
 

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -367,7 +367,9 @@ EscortRange=-1  ; integer, the range in cells that an area guarding unit assigne
 AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
 ```
 
+```{note}
 To achieve good results with `AbandonTargetEscortRange`, it is recommended to set a value that is higher than 2x its `GuardRange`. Otherwise, the unit will keep re-acquiring and abdndoning it repeatedly as long as it is in range.
+```
 
 ## File System
 

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -367,6 +367,8 @@ EscortRange=-1  ; integer, the range in cells that an area guarding unit assigne
 AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
 ```
 
+To achieve good results with `AbandonTargetEscortRange`, it is recommended to set a value that is higher than 2x its `GuardRange`. Otherwise, the unit will keep re-acquiring and abdndoning it repeatedly as long as it is in range.
+
 ## File System
 
 - `GENERIC.MIX` and `ISOGEN.MIX` mixfiles can now be used to place common assets between theaters.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -104,6 +104,8 @@ New:
 - Removed incremental revealing logic when setting `RevealByHeight=no` (by JoyfulShush)
 - Allow building repairs to be paused rather than stopped when a house has insufficient funds (by JoyfulShush, Rampastring)
 - Allows aircraft to use Q-Move (by JoyfulShush)
+- Healing units now apply area-guard on a nearby combatant unit when attacking enemy targets, rather than area-guarding on themselves (by JoyfulShush)
+- Added the ability to specify the range area-guarding units will move to their assigned unit, as well as the range that area-guarding units will abandon their targets and move towards their assigned unit (by JoyfulShush)
 
 Vinifera fixes:
 - Fix unit placement in non-TS Client builds of Vinifera (by ZivDero)
@@ -177,6 +179,7 @@ Vanilla fixes:
 - Fix a vanilla bug where harvesters would become permanently idle if they exhausted all resources to mine, even if new resources appeared (e.g. spawned by a Tiberium tree) (by JoyfulShush)
 - Fix a bug where if you started the game owning a Techno at its BuildLimit, it would not appear on your sidebar (by ZivDero)
 - Fix destroyed APCs sometimes not ejecting the infantry inside them when destroyed while moving (by JoyfulShush)
+- Fix an issue where area-guarding units that are guarding another unit will constantly go back to their designated unit instead of acquiring additional targets in range (by JoyfulShush)
 
 :::
 

--- a/src/extensions/foot/footext_hooks.cpp
+++ b/src/extensions/foot/footext_hooks.cpp
@@ -36,6 +36,7 @@
 #include "unittype.h"
 #include "vinifera_globals.h"
 #include "vox.h"
+#include "rulesext.h"
 
 
 /**
@@ -556,7 +557,9 @@ DEFINE_HOOK(0x004A2BE7, _FootClass_Mission_Guard_Area_Can_Passive_Acquire_Patch,
     /**
      *  Find a fresh target in my area using the backup target.
      */
-    this_ptr->Target_Something_Nearby(this_ptr->ArchiveTarget->Center_Coord(), THREAT_AREA);
+    if (this_ptr->ArchiveTarget != nullptr) {
+        this_ptr->Target_Something_Nearby(this_ptr->ArchiveTarget->Center_Coord(), THREAT_AREA);
+    }
 
 tarcom_check:
     return 0x004A2C04;
@@ -754,7 +757,131 @@ bool FootClassExt::_Limbo()
     return TechnoClass::Limbo();
 }
 
+/**
+ *  Patches FootClass::Do_MISSION_GUARD_AREA during the archive target check.
+ *  This overrides the distance that a unit can move away before a area-guarding unit will still to chase it,
+ *  as well as allowing units to keep engaging a target before abandoning it and returning to the unit it is guarding.
+ *  When not provided, falls back to the original game logic.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x004A2B90, _FootClass_Do_MISSION_GUARD_AREA_Escort_Distance_Patch, 6)
+{
+    GET(FootClass*, this_ptr, ESI);
+    TechnoTypeClassExtension* ext = Extension::Fetch(this_ptr->TClass);
 
+    enum {
+        TarComCheck = 0x004A2BDD,
+        GoToArchiveTarget = 0x004A2BBE,
+        ApproachTarcomTarget = 0x004A2C25
+    };
+
+    if (this_ptr->ArchiveTarget == nullptr) {
+        return TarComCheck;
+    }
+    
+    if (this_ptr->TarCom != nullptr) {
+        int abandon_target_escort_range = -1;
+        if (ext->AbandonTargetEscortRange > 0) {
+            abandon_target_escort_range = ext->AbandonTargetEscortRange;
+        }
+
+        if (abandon_target_escort_range <= 0 && RuleExtension->AbandonTargetEscortRange > 0) {
+            abandon_target_escort_range = RuleExtension->AbandonTargetEscortRange;
+        }
+
+        if (abandon_target_escort_range > 0) {
+            if (this_ptr->Distance_To(this_ptr->ArchiveTarget) >= abandon_target_escort_range) {
+                return GoToArchiveTarget;
+            }
+        }
+
+        return ApproachTarcomTarget;
+    }
+    
+    int escort_range = -1;
+    if (ext->EscortRange > 0) {
+        escort_range = ext->EscortRange;
+    }
+
+    if (escort_range <= 0 && RuleExtension->EscortRange > 0) {
+        escort_range = RuleExtension->EscortRange;
+    }
+
+    if (escort_range > 0) {
+        if (this_ptr->Distance_To(this_ptr->ArchiveTarget) >= escort_range) {
+            return GoToArchiveTarget;
+        }
+
+        return TarComCheck;
+    }
+    
+    return 0;
+}
+
+/**
+ *  Patches FootClass::Active_Click_With inside the 'ACTION_ATTACK_SUPPORT' case.
+ *  Makes healing units (negative damage) prefer to guard other units instead of themselves.
+ *  Healing units will guard other combatants, if any, and will assign themselves to the unit closest to them.
+ *  
+ *  If they can't find any, or they are not healing units, then they'll simply guard themselves instead.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x004A3518, _FootClass_Active_Click_With_Attack_Support_Patch, 0)
+{
+    GET(FootClass*, this_ptr, ESI);
+    bool has_negative_damage = R->AL();
+
+    ObjectClass* guard_object = this_ptr;
+    MissionType mission = MISSION_GUARD;    
+    if (has_negative_damage) {
+        mission = MISSION_GUARD_AREA;
+        for (int i = 0; i < CurrentObjects.Count(); ++i) {
+            ObjectClass* object = CurrentObjects[i];
+            if (!object || object == this_ptr || !object->Is_Techno() || object->Fetch_RTTI() == RTTI_BUILDING) {
+                continue;
+            }
+
+            TechnoClass* techno = static_cast<TechnoClass*>(object);
+            if (techno->Combat_Damage() <= 0) {
+                continue;
+            }
+
+            if (techno->House->Is_Player_Control() && techno->House == this_ptr->House) {
+                // if the object that is currently assigned is the unit doing the guard, simply assign it an eligible unit to guard
+                if (guard_object == this_ptr) {
+                    guard_object = object;
+                } else {
+                    if (this_ptr->Distance_To(object) < this_ptr->Distance_To(guard_object)) {
+                        guard_object = object;
+                    }
+                }
+            }
+        }
+    }
+
+    this_ptr->Player_Assign_Mission(mission, guard_object, nullptr);
+
+    return 0x004A2F95;
+}
+
+/**
+ *  Patches FootClass::Do_MISSION_GUARD_AREA inside the 'this->TarCom' case, where the unit is assigned to approach its tarcom target.
+ *  Clears the current destination, which made object-specific Area Guarding units have to go back to their guard object
+ *  between each time a tarcom target is acquired, as Approach_Target in vanilla code only kicked in
+ *  after the unit started moving towards its guard object.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x004A2C25, _FootClass_Do_MISSION_GUARD_AREA_Approach_Target_Patch, 10)
+{
+    GET(FootClass*, this_ptr, ESI);
+
+    this_ptr->Assign_Destination(nullptr);
+
+    return 0;
+}
 
 /**
  *  Main function for patching the hooks.

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -101,7 +101,9 @@ RulesClassExtension::RulesClassExtension(const RulesClass* this_ptr) :
     ComesNearWaypointDistance(CELL_LEPTON_W * 5),
     IsAIDetectDisguise(true),
     IsAIOneHarvesterInSingleplayer(true),
-    PausedRepairsFrame(6)
+    PausedRepairsFrame(6),
+    EscortRange(-1),
+    AbandonTargetEscortRange(-1)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("RulesClassExtension::RulesClassExtension - 0x%08X\n", (uintptr_t)(ThisPtr));
 
@@ -268,6 +270,8 @@ void RulesClassExtension::Object_CRC(CRCEngine &crc) const
     crc(AIHarvestersPerRefinery.Count());
     crc(IsAIOneHarvesterInSingleplayer);
     crc(PausedRepairsFrame);
+    crc(EscortRange);
+    crc(AbandonTargetEscortRange);
 }
 
 
@@ -706,6 +710,8 @@ bool RulesClassExtension::General(CCINIClass &ini)
     SelfHealingCap = ini.Get_Float(GENERAL, "SelfHealingCap", SelfHealingCap);    
     SelfHealingRate = ini.Get_Float(GENERAL, "SelfHealingRate", SelfHealingRate);
     PausedRepairsFrame = ini.Get_Int(GENERAL, "PausedRepairsFrame", PausedRepairsFrame);
+    EscortRange = ini.Get_Lepton(GENERAL, "EscortRange", EscortRange);
+    AbandonTargetEscortRange = ini.Get_Lepton(GENERAL, "AbandonTargetEscortRange", AbandonTargetEscortRange);
 
     /**
      *  Allow replacing any signle movement zone with a copy of RA2's water MZone.

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -260,13 +260,14 @@ public:
     int PausedRepairsFrame;
 
     /**
-     *  Determines how far away, in leptons, an Area Guarding unit wait to its guard target before moving towards it again.
+     *  Determines the distance, in leptons, that an escorting unit (Area Guarding unit assigned to another unit) can be separated from its guard target
+     *  before it moves again to its guard target's position.
      */
     int EscortRange;
 
     /**
-     *  Determines how far away, in leptons, an Area Guarding unit will keep engaging its target unit before abandoning it
-     *  and going back to escort its guard target.
+     *  Determines the distance, in leptons, that an escorting unit (Area Guarding unit assigned to another unit) will keep engaging its current target
+     *  before abandoning it and going back to escort its guard target.
      */
     int AbandonTargetEscortRange;
 };

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -258,4 +258,15 @@ public:
      *  Determines the wrench shape frame that should be used while repairs are paused.
      */
     int PausedRepairsFrame;
+
+    /**
+     *  Determines how far away, in leptons, an Area Guarding unit wait to its guard target before moving towards it again.
+     */
+    int EscortRange;
+
+    /**
+     *  Determines how far away, in leptons, an Area Guarding unit will keep engaging its target unit before abandoning it
+     *  and going back to escort its guard target.
+     */
+    int AbandonTargetEscortRange;
 };

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -94,7 +94,9 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     SelfHealingCap(-1),
     SelfHealingRate(-1),
     IsDetectDisguise(false),
-    IronCurtainPriorityTarget(false)
+    IronCurtainPriorityTarget(false),
+    EscortRange(-1),
+    AbandonTargetEscortRange(-1)
 {
     //if (this_ptr) EXT_DEBUG_TRACE("TechnoTypeClassExtension::TechnoTypeClassExtension - Name: %s (0x%08X)\n", Name(), (uintptr_t)(This()));
 }
@@ -281,6 +283,8 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(SelfHealingRate);
     crc(IsDetectDisguise);
     crc(IronCurtainPriorityTarget);
+    crc(EscortRange);
+    crc(AbandonTargetEscortRange);
 }
 
 
@@ -431,6 +435,9 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     IsDetectDisguise = ini.Get_Bool(ini_name, "DetectDisguise", IsDetectDisguise);
 
     IronCurtainPriorityTarget = ini.Get_Bool(ini_name, "IronCurtainPriorityTarget", IronCurtainPriorityTarget);
+
+    EscortRange = ini.Get_Lepton(ini_name, "EscortRange", EscortRange);
+    AbandonTargetEscortRange = ini.Get_Lepton(ini_name, "AbandonTargetEscortRange", AbandonTargetEscortRange);
 
     return true;
 }

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -267,6 +267,17 @@ public:
      */
     bool IsDecloakToFire;
 
+    /**
+     *  Determines how far away, in leptons, an Area Guarding unit wait to its guard target before moving towards it again.
+     */
+    int EscortRange;
+
+    /**
+     *  Determines how far away, in leptons, an Area Guarding unit will keep engaging its target unit before abandoning it
+     *  and going back to escort its guard target.
+     */
+    int AbandonTargetEscortRange;
+
 private:
 
     /**


### PR DESCRIPTION
Applies a bunch of fixes around Area Guard. Requires testing before being merged!

- Healing units now apply area-guard on a nearby combatant unit when attacking enemy targets, rather than area-guarding on themselves.
- Fix an issue where area-guarding units that are guarding another unit will constantly go back to their designated unit instead of acquiring additional targets in range
- Fix an issue where ArchiveTarget could be nullptr during `IsPassiveAcquire` checks for area guards.

Additionally, improves the logic around Area Guard when guarding another object (AKA escorting it):
- Allows modders to specify the range in which an area-guarding unit that is assigned to guard another unit will follow it, as well as the range where it will abandon targets it is currently attacking (or healing) and go back to their assigned unit.
- This only applies on Area Guards on a unit; Area Guards on a cell does not count.
- Can be specified globally or for each unit individually. When both are applied, unit-specific values are used over the global values. 
- When those values are not stated or are non-positive, Vinifera falls back to the original behavior, which causes area-guarding units to follow their assigned unit once it leaves 2x the area-guarding unit's Guard Range (up to a maximum of 12 cells).

in `RULES.INI`:
```ini
[General]
EscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.

[SOMETECHNO]
EscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will wait before closing the distance to its assigned unit while not engaging another unit.
AbandonTargetEscortRange=-1  ; integer, the range in cells that an area guarding unit assigned to guard a unit will keep engaging targets before abandoning the targets and go back to their assigned unit.
```