### PR TITLE
Fix crash with medic area guard cursor

### DIFF
--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -859,7 +859,7 @@ DEFINE_HOOK(0x004D71CF, _Infantry_Class_What_Action_Medic_Toggle_Select_Patch, 9
 {
     GET(ActionType, action, EBX);
 
-    if (action == ACTION_TOGGLE_SELECT) {
+    if (action == ACTION_TOGGLE_SELECT || action == ACTION_GUARD_AREA || action == ACTION_MOVE) {
         return 0x004D76F9;
     }
 


### PR DESCRIPTION
* Fix an issue where the game would crash if a healer unit (e.g. medics) was selected and player would put their cursor over another unit while in area-guard mode.