### PR TITLE
Fix a bug where players could not click on a cell that included tiberium, bridges or enemy cloaked units or structure to undeploy a building

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,6 +187,7 @@ This page lists all the individual contributions to the project by their author.
   - Add support for health tracking for bridges, as well as allowing bridges to have an armor type.
   - Allow cloaked units to trigger cell tags when using Entered By trigger events.
   - Add the ability to specify sight ranges for technos when they are veteran and elite.
+  - Fix a bug where players could not click on a cell that included tiberium, bridges or enemy cloaked units or structure to undeploy a building.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -128,3 +128,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug that would make healer units unselect themselves when adding other units to current selection.
 - Fix a bug that would make infantry healer units flash and go into Area Guard mode when they were added to current selection.
 - EVA no longer says "Harvester under attack" when harvesters receive environmental damage.
+- Fix a bug where players could not click on a cell that included tiberium, bridges or enemy cloaked units or structure to undeploy a building.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -115,6 +115,7 @@ New:
 - Fix Win32 dialog scaling with SDL (by Rampastring)
 - Reimplement the software blitters with SIMD (SSE2/AVX2) for faster rendering on modern CPUs (by ZivDero)
 - Add the ability to specify sight ranges for technos when they are veteran and elite (by JoyfulShush)
+- Fix a bug where players could not click on a cell that included tiberium, bridges or enemy cloaked units or structure to undeploy a building (by JoyfulShush)
 
 
 Vinifera fixes:

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -55,6 +55,7 @@
 #include "unit.h"
 #include "unitext.h"
 #include "unittype.h"
+#include "unittypeext.h"
 #include "vinifera_saveload.h"
 #include "voc.h"
 #include "vox.h"
@@ -90,6 +91,7 @@ public:
     SuperWeaponType _Fetch_Super_Weapon2() const;
     void _Swizzle_Light_Source();
     RadioMessageType _Receive_Message(RadioClass * from, RadioMessageType message, long& param);
+    MoveType _Can_Enter_Cell(CellClass const* cell, FacingType dir, int cell_height, CellClass const*, bool) const;
 };
 
 
@@ -2587,6 +2589,38 @@ DEFINE_HOOK(0x0042A0B0, Building_Class_Unlimbo_Sight_Range_Patch, 0)
 }
 
 
+/*
+ *  Reimplements BuildingClass::Can_Enter_Cell, which is used for undeploy logic as well as building unlimbo logic
+ *  Improved the undeploy logic to check for the cell being hovered on with the cursor
+ *  rather than using building placement logic.
+ *  This fixes the cursor showing "NO MOVE" when hovering over tiberium, bridges, or invisible units or structures
+ *  Naval buildings checks water passage while making sure the cursor is not on a bridge,
+ *  while regular buildings checks land passage as well as bridges.
+ */
+MoveType BuildingClassExt::_Can_Enter_Cell(CellClass const* cell, FacingType dir, int cell_height, CellClass const*, bool) const
+{    
+    if (Class->UndeploysInto && IsDown && !IsInLimbo) {
+        auto class_ext = Extension::Fetch(Class);
+        auto passability = cell->Passability;        
+        
+        if (class_ext->IsNaval) {
+            if (passability != PASSABLE_WATER || cell->Is_Bridge_Here()) {
+                return MOVE_NO;
+            }
+        } else {
+            if (passability != PASSABLE_LAND && !cell->Is_Bridge_Here()) {
+                return MOVE_NO;
+            }
+        }
+
+        return MOVE_OK;
+    }
+
+    Cell cell_id = cell->CellID;
+    return Class->Legal_Placement(cell_id, House) ? MOVE_OK : MOVE_NO;
+}
+
+
 /**
  *  Main function for patching the hooks.
  */
@@ -2616,4 +2650,5 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x0043AF60, &BuildingClassExt::_Fetch_Super_Weapon);
     Patch_Jump(0x0043AFC0, &BuildingClassExt::_Fetch_Super_Weapon2);
     Patch_Jump(0x004268C0, &BuildingClassExt::_Receive_Message);
+    Patch_Jump(0x0042FE70, &BuildingClassExt::_Can_Enter_Cell);
 }


### PR DESCRIPTION
Fixes #969 
