### PR TITLE
Aircraft Speed extension

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,6 +187,7 @@ This page lists all the individual contributions to the project by their author.
   - Add support for health tracking for bridges, as well as allowing bridges to have an armor type.
   - Allow cloaked units to trigger cell tags when using Entered By trigger events.
   - Add the ability to specify sight ranges for technos when they are veteran and elite.
+  - Extend aircraft speed to include house Airspeed bias, game speed bias, and the FASTER veteran/elite ability when calculating aircraft speed values.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Miscellaneous.md
+++ b/docs/Miscellaneous.md
@@ -19,6 +19,7 @@ This page describes every change in Vinifera that wasn't categorized into a prop
 - Players can now click on a Service Depot with units and aircraft even if it is occupied or about to be occupied by other units. Doing so will add these units to the list of units waiting to be repaired.
 - Vinifera allows aircraft to use Q-Move, similarly to other types of units in the game. Q-Moving aircraft will stay in the air as they move on to their next destination. Unlike ground units, aircraft cannot target enemies while Q-Moving. Ordering queue-moves to an aircraft currently targetting an enemy will remove the attack order. Carryalls get extended handling while Q-Moving, allowing it to pick up units along the way and carry them until the end of their path.
 - Healing units now apply area-guard on a nearby combatant unit when attacking enemy targets, rather than area-guarding on themselves.
+- Aircraft speed now takes house Airspeed bias, game speed bias, and the FASTER veteran/elite ability values into account when calculating the aircraft speed.
 
 ## SIMD Blitters
 

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -115,6 +115,7 @@ New:
 - Fix Win32 dialog scaling with SDL (by Rampastring)
 - Reimplement the software blitters with SIMD (SSE2/AVX2) for faster rendering on modern CPUs (by ZivDero)
 - Add the ability to specify sight ranges for technos when they are veteran and elite (by JoyfulShush)
+- Extend aircraft speed to include house Airspeed bias, game speed bias, and the FASTER veteran/elite ability when calculating aircraft speed values (by JoyfulShush)
 
 
 Vinifera fixes:

--- a/src/debug/debug_overlay.cpp
+++ b/src/debug/debug_overlay.cpp
@@ -410,7 +410,7 @@ namespace
         const bool is_foot = obj->RTTI == RTTI_UNIT || obj->RTTI == RTTI_INFANTRY || obj->RTTI == RTTI_AIRCRAFT;
         if (is_foot) {
             FootClass* foot = static_cast<FootClass*>(obj);
-            ImGui::Text("Speed   : %.2f (bias x%.2f)", foot->Speed, foot->SpeedBias);
+            ImGui::Text("Speed   : %d (bias x%.2f)", foot->Locomotion->Apparent_Speed(), foot->SpeedBias);
         }
 
         /**

--- a/src/extensions/extension_hooks.cpp
+++ b/src/extensions/extension_hooks.cpp
@@ -44,6 +44,7 @@
 #include "factoryext_hooks.h"
 #include "fetchres_hooks.h"
 #include "filepcx_hooks.h"
+#include "flylocomotionext_hooks.h"
 #include "footext_hooks.h"
 #include "gadgetext_hooks.h"
 #include "houseext_hooks.h"
@@ -212,6 +213,7 @@ void Extension_Hooks()
      *  Locomotors.
      */
     DriveLocomotionClassExtension_Hooks();
+    FlyLocomotionClassExtension_Hooks();
 
     /**
      *  All global class extensions here.

--- a/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
+++ b/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
@@ -46,7 +46,7 @@ public:
 int STDMETHODCALLTYPE FlyLocomotionClassExt::_Apparent_Speed(void)
 {    
     // Since this is an interface method, we cast 'this' to the actual fly locomotion class instance.
-    FlyLocomotionClass* trueThis = static_cast<FlyLocomotionClass*>(reinterpret_cast<ILocomotion*>(this)); 
+    FlyLocomotionClass* true_this = static_cast<FlyLocomotionClass*>(reinterpret_cast<ILocomotion*>(this)); 
     FootClass* foot = trueThis->LinkedTo;
 
     int speed = foot->Get_Max_Speed() * foot->House->AirspeedBias * foot->SpeedBias;

--- a/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
+++ b/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
@@ -33,8 +33,19 @@ public:
     int STDMETHODCALLTYPE _Apparent_Speed(void);
 };
 
+
+/*
+ *  Reimplements FlyLocomotionClass::Apparent_Speed.
+ *  Extends the logic to take into account the house' airspeed bias, the generic game speed bias, and the FASTER ability speed bonus.  
+ *  
+ *  Note that aircraft with too low or too high speed may not work properly; they can fail to reach the landing position and behave weirdly.
+ *  This is due to the game's flawed flying locomotion logic.
+ * 
+ *  @author: JoyfulShush
+ */
 int STDMETHODCALLTYPE FlyLocomotionClassExt::_Apparent_Speed(void)
 {    
+    // Since this is an interface method, we cast 'this' to the actual fly locomotion class instance.
     FlyLocomotionClass* trueThis = static_cast<FlyLocomotionClass*>(reinterpret_cast<ILocomotion*>(this)); 
     FootClass* foot = trueThis->LinkedTo;
 

--- a/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
+++ b/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *  @brief  Contains the hooks for the extended FlyLocomotionClass.
+ *
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ *  Copyright (c) 2020-2026 Vinifera contributors
+ ******************************************************************************/
+
+#include "always.h"
+
+#include "anim.h"
+#include "extension.h"
+#include "flylocomotion.h"
+#include "foot.h"
+#include "hooker.h"
+#include "house.h"
+#include "object.h"
+#include "rules.h"
+#include "tibsun_globals.h"
+
+
+/**
+ *  A fake class for implementing new member functions which allow
+ *  access to the "this" pointer of the intended class.
+ *
+ *  @note: This must not contain a constructor or destructor!
+ *  @note: All functions must be prefixed with "_" to prevent accidental virtualization.
+ */
+DECLARE_EXTENDING_CLASS_AND_PAIR(FlyLocomotionClass)
+{
+public: 
+    int STDMETHODCALLTYPE _Apparent_Speed(void);
+};
+
+int STDMETHODCALLTYPE FlyLocomotionClassExt::_Apparent_Speed(void)
+{
+    // 'this' is currently shifted by 4 bytes due to the engine's vtable optimization.
+    // We cast to char* to do byte-level arithmetic, subtract 4, and cast back.
+    FlyLocomotionClass* trueThis = reinterpret_cast<FlyLocomotionClass*>(reinterpret_cast<char*>(this) - 4);
+    FootClass* foot = trueThis->LinkedTo;
+
+    int speed = foot->Get_Max_Speed() * foot->House->AirspeedBias * foot->SpeedBias;
+    if (foot->Has_Ability(ABILITY_FASTER)) {
+        speed *= Rule->VeteranSpeed + 1.0;
+    }
+
+    return speed * trueThis->CurrentSpeed;
+}
+
+
+/**
+ *  Main function for patching the hooks.
+ */
+void FlyLocomotionClassExtension_Hooks() 
+{
+    Patch_Jump(0x0049CEC0, &FlyLocomotionClassExt::_Apparent_Speed);
+}

--- a/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
+++ b/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
@@ -34,10 +34,8 @@ public:
 };
 
 int STDMETHODCALLTYPE FlyLocomotionClassExt::_Apparent_Speed(void)
-{
-    // 'this' is currently shifted by 4 bytes due to the engine's vtable optimization.
-    // We cast to char* to do byte-level arithmetic, subtract 4, and cast back.
-    FlyLocomotionClass* trueThis = reinterpret_cast<FlyLocomotionClass*>(reinterpret_cast<char*>(this) - 4);
+{    
+    FlyLocomotionClass* trueThis = static_cast<FlyLocomotionClass*>(reinterpret_cast<ILocomotion*>(this)); 
     FootClass* foot = trueThis->LinkedTo;
 
     int speed = foot->Get_Max_Speed() * foot->House->AirspeedBias * foot->SpeedBias;

--- a/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
+++ b/src/extensions/flylocomotor/flylocomotionext_hooks.cpp
@@ -47,14 +47,14 @@ int STDMETHODCALLTYPE FlyLocomotionClassExt::_Apparent_Speed(void)
 {    
     // Since this is an interface method, we cast 'this' to the actual fly locomotion class instance.
     FlyLocomotionClass* true_this = static_cast<FlyLocomotionClass*>(reinterpret_cast<ILocomotion*>(this)); 
-    FootClass* foot = trueThis->LinkedTo;
+    FootClass* foot = true_this->LinkedTo;
 
     int speed = foot->Get_Max_Speed() * foot->House->AirspeedBias * foot->SpeedBias;
     if (foot->Has_Ability(ABILITY_FASTER)) {
         speed *= Rule->VeteranSpeed + 1.0;
     }
 
-    return speed * trueThis->CurrentSpeed;
+    return speed * true_this->CurrentSpeed;
 }
 
 

--- a/src/extensions/flylocomotor/flylocomotionext_hooks.h
+++ b/src/extensions/flylocomotor/flylocomotionext_hooks.h
@@ -1,0 +1,13 @@
+/*******************************************************************************
+/*                 O P E N  S O U R C E  --  V I N I F E R A                  **
+/*******************************************************************************
+ *  @brief  Contains the hooks for the extended FlyLocomotionClass.
+ *
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ *  Copyright (c) 2020-2026 Vinifera contributors
+ ******************************************************************************/
+
+#pragma once
+
+
+void FlyLocomotionClassExtension_Hooks();


### PR DESCRIPTION
Extend aircraft speed to include house Airspeed bias, game speed bias, and the FASTER veteran/elite ability when calculating aircraft speed values.

Additionally, changes the Speed value in the Game Info (Debug Overlay) to use `Apparent_Speed` instead of Speed; this more accurately shows the actual speed of the selected unit, as well as allowing to record the speed of aircraft.

Fixes #986 