### PR TITLE
Fix jumpjet infantry bugs

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,6 +187,10 @@ This page lists all the individual contributions to the project by their author.
   - Add support for health tracking for bridges, as well as allowing bridges to have an armor type.
   - Allow cloaked units to trigger cell tags when using Entered By trigger events.
   - Add the ability to specify sight ranges for technos when they are veteran and elite.
+  - Fix a vanilla bug where Jumpjet infantry exiting a barracks with rally point set goes back to the barracks afterwards.
+  - Fix a vanilla bug where Jumpjet infantry being ordered to enter structures (e.g. hospital, armory) behaving extremely erratically as they try to go into it.
+  - Fix a vanilla bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them block further infantry production until they land on their rally point.
+  - Fix a vanilla bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them fly, land near the barracks, and only then go to their destination.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -128,3 +128,7 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug that would make healer units unselect themselves when adding other units to current selection.
 - Fix a bug that would make infantry healer units flash and go into Area Guard mode when they were added to current selection.
 - EVA no longer says "Harvester under attack" when harvesters receive environmental damage.
+- Fix a bug where Jumpjet infantry exiting a barracks with rally point set goes back to the barracks afterwards
+- Fix a bug where Jumpjet infantry being ordered to enter structures (e.g. hospital, armory) behaving extremely erratically as they try to go into it
+- Fix a bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them block further infantry production until they land on their rally point
+- Fix a bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them fly, land near the barracks, and only then go to their destination

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -115,6 +115,10 @@ New:
 - Fix Win32 dialog scaling with SDL (by Rampastring)
 - Reimplement the software blitters with SIMD (SSE2/AVX2) for faster rendering on modern CPUs (by ZivDero)
 - Add the ability to specify sight ranges for technos when they are veteran and elite (by JoyfulShush)
+- Fix a vanilla bug where Jumpjet infantry exiting a barracks with rally point set goes back to the barracks afterwards (by JoyfulShush)
+- Fix a vanilla bug where Jumpjet infantry being ordered to enter structures (e.g. hospital, armory) behaving extremely erratically as they try to go into it (by JoyfulShush)
+- Fix a vanilla bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them block further infantry production until they land on their rally point (by JoyfulShush)
+- Fix a vanilla bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them fly, land near the barracks, and only then go to their destination (by JoyfulShush)
 
 
 Vinifera fixes:

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2603,11 +2603,7 @@ DEFINE_HOOK(0x0042D192, Building_Class_Exit_Object_Jumpjet_Exit_Coords_Assignmen
     GET(FootClass*, this_ptr, EDI);
 
     // If there is no archive target set for the unit, then there was no rally point set.
-    if (this_ptr->ArchiveTarget == nullptr) {
-        return 0;
-    }
-    
-    if (this_ptr->RTTI == RTTI_INFANTRY) {
+    if (this_ptr->ArchiveTarget != nullptr && this_ptr->RTTI == RTTI_INFANTRY) {
         auto infantry = static_cast<InfantryClass*>(this_ptr);
         if (infantry->Class->IsJumpJet) {
             bool should_fly = infantry->Should_JumpJet_Fly(infantry->Get_Coord().As_Cell(), infantry->ArchiveTarget->Center_Coord().As_Cell());
@@ -2623,7 +2619,7 @@ DEFINE_HOOK(0x0042D192, Building_Class_Exit_Object_Jumpjet_Exit_Coords_Assignmen
 
 
 /*
- *  When a unit is goes out of a structure such as a Barracks, an Armory or a Hospital, they are in radio contact.
+ *  When a unit goes out of a structure such as a Barracks, an Armory or a Hospital, they are in radio contact.
  *  This prevents other units from coming out from this structure until the unit reports that they are officially out of the building,
  *  which is done by cutting off radio contact.
  * 

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -36,6 +36,7 @@
 #include "house.h"
 #include "houseext.h"
 #include "housetype.h"
+#include "infantry.h"
 #include "infantrytype.h"
 #include "jumpjetlocomotion.h"
 #include "map.h"
@@ -2584,6 +2585,74 @@ DEFINE_HOOK(0x0042A0B0, Building_Class_Unlimbo_Sight_Range_Patch, 0)
     Map.Sight_From(*coord, building_class_ext->Get_Sight_Range(), this_ptr->House);
 
     return 0x0042A0D7;
+}
+
+/*
+ *  Typically, whenever an infantry exits a Barracks, an Armory or a Hospital, they are assigned
+ *  to move into the exit cell of the building before moving towards the rally point (the ArchiveTarget).
+ *  For jumpjets, this causes issues when the rally point is far away, as they will start flying, then take a few seconds to land
+ *  on the exit coords before moving to the rally point.
+ * 
+ *  This patch makes jumpjets skip the exit coord assignment when they are going to be flying to a rally point when they exit the building,
+ *  allowing them to go straight to the designated position.
+ * 
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x0042D192, Building_Class_Exit_Object_Jumpjet_Exit_Coords_Assignment_Patch, 6)
+{
+    GET(FootClass*, this_ptr, EDI);
+
+    // If there is no archive target set for the unit, then there was no rally point set.
+    if (this_ptr->ArchiveTarget == nullptr) {
+        return 0;
+    }
+    
+    if (this_ptr->RTTI == RTTI_INFANTRY) {
+        auto infantry = static_cast<InfantryClass*>(this_ptr);
+        if (infantry->Class->IsJumpJet) {
+            bool should_fly = infantry->Should_JumpJet_Fly(infantry->Get_Coord().As_Cell(), infantry->ArchiveTarget->Center_Coord().As_Cell());
+
+            if (should_fly) {
+                return 0x0042D1AC;
+            }
+        }
+    }
+
+    return 0;
+}
+
+
+/*
+ *  When a unit is goes out of a structure such as a Barracks, an Armory or a Hospital, they are in radio contact.
+ *  This prevents other units from coming out from this structure until the unit reports that they are officially out of the building,
+ *  which is done by cutting off radio contact.
+ * 
+ *  When the rally point is far away, jumpjet infantry will decide to fly - and when they do, it can take them some time until they reach
+ *  the designated position - during which units cannot be produced and are lost.
+ *  Note that this is caused even without the "Building_Class_Exit_Object_Jumpjet_Exit_Coords_Assignment_Patch" patch,
+ *  as even landing at the exit coords takes some time.
+ * 
+ *  Instead, this patch causes jumpjet infantry that decide to fly away to the rally point immediately report that they are out of the structure,
+ *  without having to wait first to reach the exit coords or the rally points. This allows further production or units processing to resume with no issues.
+ *  
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x0042D26B, Building_Class_Exit_Object_Jumpjet_Radio_Contact_Patch, 0)
+{
+    GET(FootClass*, this_ptr, EDI);
+
+    if (this_ptr->RTTI == RTTI_INFANTRY && this_ptr->ArchiveTarget != nullptr) {
+        auto infantry = static_cast<InfantryClass*>(this_ptr);
+        if (infantry->Class->IsJumpJet) {
+            bool should_fly = infantry->Should_JumpJet_Fly(infantry->Get_Coord().As_Cell(), infantry->ArchiveTarget->Center_Coord().As_Cell());
+
+            if (should_fly) {
+                infantry->Transmit_Message(RADIO_OVER_OUT);
+            }
+        }
+    }
+
+    return 0x0042CF07;
 }
 
 

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -929,7 +929,7 @@ DEFINE_HOOK(0x004D4356, InfantryClass_Assign_Destination_Jumpjet_Move_Queue_Patc
     GET(InfantryClass*, this_ptr, EBP);
 
     enum {
-        SKIP_QMOVE = 0x004D43DB
+        SKIP_NAVQUEUE_CHAIN = 0x004D43DB
     };
 
     // If the unit has an archive target, this typically means it was instructed to reach a position
@@ -937,7 +937,7 @@ DEFINE_HOOK(0x004D4356, InfantryClass_Assign_Destination_Jumpjet_Move_Queue_Patc
     // We should not add Q-Move to the destination when this is the case.
     // Fixes a bug where jumpjets would go back to the building they exited from after reaching the building's rally point.
     if (this_ptr->ArchiveTarget != nullptr) {
-        return SKIP_QMOVE;
+        return SKIP_NAVQUEUE_CHAIN;
     }
 
     // If the unit is about to enter a building, it shouldn't have any Q-Moves lines up.
@@ -945,7 +945,7 @@ DEFINE_HOOK(0x004D4356, InfantryClass_Assign_Destination_Jumpjet_Move_Queue_Patc
     if (this_ptr->Get_Mission() == MISSION_ENTER) {
         this_ptr->Clear_Navigation_List();
 
-        return SKIP_QMOVE;
+        return SKIP_NAVQUEUE_CHAIN;
     }
 
     return 0;

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -916,65 +916,41 @@ DEFINE_HOOK(0x004D6CBD, InfantryClass_Unlimbo_Sight_Range_Patch, 0)
     return 0x004D6CD4;
 }
 
-
+/**
+ *  Patches InfantryClass::Assign_Destination at the part where jumpjets determine whether to add a Q-Move.
+ *  This occurs when jumpjets are assigned a new destination while using the Walk Locomotion to move.
+ *  The Q-Move is used to make the jumpjets effectively stop near their position in order to reconsider swapping locomotions to fly
+ *  to the newly ordered position. However, in some cases, this behavior is not desired and causes issues, which this patch fixes.
+ *
+ *  @author: JoyfulShush
+ */
 DEFINE_HOOK(0x004D4356, InfantryClass_Assign_Destination_Jumpjet_Move_Queue_Patch, 6)
 {
     GET(InfantryClass*, this_ptr, EBP);
 
+    enum {
+        SKIP_QMOVE = 0x004D43DB
+    };
+
+    // If the unit has an archive target, this typically means it was instructed to reach a position
+    // as soon as it finishes what it's currently doing, such as when being rallied out of a Barracks, Hospital or Armory.
+    // We should not add Q-Move to the destination when this is the case.
+    // Fixes a bug where jumpjets would go back to the building they exited from after reaching the building's rally point.
     if (this_ptr->ArchiveTarget != nullptr) {
-        return 0x004D43DB;
+        return SKIP_QMOVE;
     }
 
+    // If the unit is about to enter a building, it shouldn't have any Q-Moves lines up.
+    // Fixes a bug where jumpjets behave very erratically when trying to enter a hospital or an armory.
     if (this_ptr->Get_Mission() == MISSION_ENTER) {
         this_ptr->Clear_Navigation_List();
 
-        return 0x004D43DB;
+        return SKIP_QMOVE;
     }
 
     return 0;
 }
 
-
-DEFINE_HOOK(0x0042D192, TEST_ME_ARCHIVE_TARGET, 6)
-{
-    GET(FootClass*, this_ptr, EDI);
-
-    if (this_ptr->ArchiveTarget == nullptr) {
-        return 0;
-    }
-
-    if (this_ptr->RTTI == RTTI_INFANTRY) {
-        auto infantry = static_cast<InfantryClass*>(this_ptr);
-        if (infantry->Class->IsJumpJet) {
-            bool should_fly = infantry->Should_JumpJet_Fly(&infantry->Get_Coord().As_Cell(), &infantry->ArchiveTarget->Center_Coord().As_Cell());
-
-            if (should_fly) {                
-                return 0x0042D1AC;
-            }
-        }
-    }
-
-    return 0;
-}
-
-
-DEFINE_HOOK(0x0042D26B, TEST_ME_STOP_RADIO, 0)
-{
-    GET(FootClass*, this_ptr, EDI);
-
-    if (this_ptr->RTTI == RTTI_INFANTRY) {
-        auto infantry = static_cast<InfantryClass*>(this_ptr);
-        if (infantry->Class->IsJumpJet) {
-            bool should_fly = infantry->Should_JumpJet_Fly(&infantry->Get_Coord().As_Cell(), &infantry->ArchiveTarget->Center_Coord().As_Cell());
-
-            if (should_fly) {
-                infantry->Transmit_Message(RADIO_OVER_OUT);
-            }
-        }
-    }
-
-    return 0x0042CF07;
-}
 
 /**
  *  Main function for patching the hooks.

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -917,6 +917,65 @@ DEFINE_HOOK(0x004D6CBD, InfantryClass_Unlimbo_Sight_Range_Patch, 0)
 }
 
 
+DEFINE_HOOK(0x004D4356, InfantryClass_Assign_Destination_Jumpjet_Move_Queue_Patch, 6)
+{
+    GET(InfantryClass*, this_ptr, EBP);
+
+    if (this_ptr->ArchiveTarget != nullptr) {
+        return 0x004D43DB;
+    }
+
+    if (this_ptr->Get_Mission() == MISSION_ENTER) {
+        this_ptr->Clear_Navigation_List();
+
+        return 0x004D43DB;
+    }
+
+    return 0;
+}
+
+
+DEFINE_HOOK(0x0042D192, TEST_ME_ARCHIVE_TARGET, 6)
+{
+    GET(FootClass*, this_ptr, EDI);
+
+    if (this_ptr->ArchiveTarget == nullptr) {
+        return 0;
+    }
+
+    if (this_ptr->RTTI == RTTI_INFANTRY) {
+        auto infantry = static_cast<InfantryClass*>(this_ptr);
+        if (infantry->Class->IsJumpJet) {
+            bool should_fly = infantry->Should_JumpJet_Fly(&infantry->Get_Coord().As_Cell(), &infantry->ArchiveTarget->Center_Coord().As_Cell());
+
+            if (should_fly) {                
+                return 0x0042D1AC;
+            }
+        }
+    }
+
+    return 0;
+}
+
+
+DEFINE_HOOK(0x0042D26B, TEST_ME_STOP_RADIO, 0)
+{
+    GET(FootClass*, this_ptr, EDI);
+
+    if (this_ptr->RTTI == RTTI_INFANTRY) {
+        auto infantry = static_cast<InfantryClass*>(this_ptr);
+        if (infantry->Class->IsJumpJet) {
+            bool should_fly = infantry->Should_JumpJet_Fly(&infantry->Get_Coord().As_Cell(), &infantry->ArchiveTarget->Center_Coord().As_Cell());
+
+            if (should_fly) {
+                infantry->Transmit_Message(RADIO_OVER_OUT);
+            }
+        }
+    }
+
+    return 0x0042CF07;
+}
+
 /**
  *  Main function for patching the hooks.
  */


### PR DESCRIPTION
Fixes an assortment of jumpjet infantry specific bugs:

- Fix a vanilla bug where Jumpjet infantry exiting a barracks with rally point set goes back to the barracks afterwards.
- Fix a vanilla bug where Jumpjet infantry being ordered to enter structures (e.g. hospital, armory) behaving extremely erratically as they try to go into it.
- Fix a vanilla bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them block further infantry production until they land on their rally point.
- Fix a vanilla bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them fly, land near the barracks, and only then go to their destination.