### PR TITLE
Support RadarInvisible for buildings

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,6 +187,7 @@ This page lists all the individual contributions to the project by their author.
   - Add support for health tracking for bridges, as well as allowing bridges to have an armor type.
   - Allow cloaked units to trigger cell tags when using Entered By trigger events.
   - Add the ability to specify sight ranges for technos when they are veteran and elite.
+  - Fix a bug where `RadarInvisible=yes` did not make a building be radar invisible.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -128,3 +128,4 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug that would make healer units unselect themselves when adding other units to current selection.
 - Fix a bug that would make infantry healer units flash and go into Area Guard mode when they were added to current selection.
 - EVA no longer says "Harvester under attack" when harvesters receive environmental damage.
+- Fix a bug where `RadarInvisible=yes` did not make a building be radar invisible.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -115,6 +115,7 @@ New:
 - Fix Win32 dialog scaling with SDL (by Rampastring)
 - Reimplement the software blitters with SIMD (SSE2/AVX2) for faster rendering on modern CPUs (by ZivDero)
 - Add the ability to specify sight ranges for technos when they are veteran and elite (by JoyfulShush)
+- Fix a bug where `RadarInvisible=yes` did not make a building be radar invisible (by JoyfulShush)
 
 
 Vinifera fixes:

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2587,6 +2587,25 @@ DEFINE_HOOK(0x0042A0B0, Building_Class_Unlimbo_Sight_Range_Patch, 0)
 }
 
 
+/*
+ *  Patches BuildingClass::Is_Radar_Visible after checking the 'IsRadarVisible' property.
+ *  Checks if the Building Class of this building has the 'RadarInvisible' (which is translated to IsStealthy in code) set to true.
+ *  In such a case, we should not draw the building in the minimap.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x0043AC9F, _BuildingClass_Is_Radar_Visible_Stealthy_Patch, 6)
+{
+    GET(BuildingTypeClass*, building_class, EAX);
+
+    if (building_class->IsStealthy) {
+        return 0x0043ADCA; // return false - do not draw
+    }
+
+    return 0;
+}
+
+
 /**
  *  Main function for patching the hooks.
  */


### PR DESCRIPTION
Fixes a bug where `RadarInvisible=yes` did not, in fact, make buildings be invisible in the radar.