### PR TITLE
Fixes MultipleFactoryCap

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -189,6 +189,8 @@ This page lists all the individual contributions to the project by their author.
   - Add the ability to specify sight ranges for technos when they are veteran and elite.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
+- **Krnyoshi**:
+  - Fix a bug where MultipleFactoryCap was giving full production speed bonuses after building the second factory instead of incrementally giving speed bonuses until the cap was reached.
 - **Noble Fish**:
   - Document proofreading and formatting/styling assistance.
 - **MarkJFox**:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -142,6 +142,7 @@ Vinifera fixes:
 - Fix a bug where ts-patches Spawn houses stopped working as trigger event parameters after loading a saved game (by Rampastring)
 - Fix a bug where the map would accept input while the user was in a dialog window (by ZivDero)
 - Fix a bug where ice was destroyable despite the scenario having `IceDestructionEnabled=no` (by Rampastring)
+- Fix a bug where MultipleFactoryCap was giving full production speed bonuses after building the second factory instead of incrementally giving speed bonuses until the cap was reached. (by Krnyoshi)
 
 
 Vanilla fixes:

--- a/src/extensions/techno/technoext.cpp
+++ b/src/extensions/techno/technoext.cpp
@@ -537,7 +537,9 @@ int TechnoClassExtension::Time_To_Build() const
          *  @author: CCHyper
          */
         if (RuleExtension->MultipleFactoryCap > 0) {
-            divisor = RuleExtension->MultipleFactoryCap - 1;
+            if (divisor > RuleExtension->MultipleFactoryCap - 1) {
+                divisor = RuleExtension->MultipleFactoryCap - 1;
+            }
         }
 
         while (divisor) {


### PR DESCRIPTION
**The Issue:**

`MultipleFactoryCap` and `MultipleFactory` was not working as intended. The issue is that if you were to build a second factory, it would not incrementally give you the production speed bonus up to the cap. Instead, it would give you the full production speed bonus. 

**technoext.cpp:**
```
if (RuleExtension->MultipleFactoryCap > 0) {
    divisor = RuleExtension->MultipleFactoryCap - 1;
}
```

When `MultipleFactoryCap` was greater than 0, and `Factory_Count - 1` was greater than 0, it would always assign the divisor to the `MultipleFactoryCap - 1`. This ended up giving the player the full production speed bonus once a second factory was built.

===============================================

**The Proposed Solution:**

A check is created to make sure that when the `divisor` (Factory_Count - 1) becomes greater than `MultipleFactoryCap - 1`, it will keep the `divisor` within the cap. Otherwise, it will pass the `divisor` to the while loop that comes after.

**technoext.cpp:**
```
if (RuleExtension->MultipleFactoryCap > 0) {
    if (divisor > RuleExtension->MultipleFactoryCap - 1) {
        divisor = RuleExtension->MultipleFactoryCap - 1;
    }
}
```

===============================================

**Testing:**

A test map was created with the following conditions:

**Rules.ini entries:**
- MultipleFactory=0.75
- MultipleFactoryCap=5

**Map's modifications:**
> [E1]
> Cost=1000

> [GAPILE]
> Cost=1

===============================================

**Result:**

The intended behavior has been restored. The production speed bonus was given incrementally up to the cap.

**Before Code Revision Behavior:**
(https://youtu.be/ifYUdxuBI_g)

- 1 GAPILE : ~18 seconds
- 2 GAPILE: ~7 seconds
- 3 GAPILE: ~7 seconds
- 4 GAPILE: ~7 seconds
- 5 GAPILE (cap) : ~7 seconds
- 6+ GAPILE: ~7 seconds 

**After Code Revision Behavior:**
(https://youtu.be/fUqYGtQ19H8)

- 1 GAPILE: ~18 seconds
- 2 GAPILE: ~15 seconds
- 3 GAPILE: ~11 seconds
- 4 GAPILE: ~8.5 seconds
- 5 GAPILE (cap) : ~7 seconds
- 6+ GAPILE: ~7 seconds 

