### PR TITLE
Unit self healing repair step

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -187,6 +187,7 @@ This page lists all the individual contributions to the project by their author.
   - Add support for health tracking for bridges, as well as allowing bridges to have an armor type.
   - Allow cloaked units to trigger cell tags when using Entered By trigger events.
   - Add the ability to specify sight ranges for technos when they are veteran and elite.
+  - Allow customizing the amount of strength technos recover in each self-heal instance per techno and globally.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Noble Fish**:

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1249,7 +1249,7 @@ In `RULES.INI`:
 [General]
 SelfHealingCap=50% 			; % or float, determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
 SelfHealingRate=.016 		; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
-UnitSelfHealRepairStep=1 	; integer, the amount of strength to recover in each regeneration tick.
+SelfHealingStep=1 	; integer, the amount of strength to recover in each regeneration tick. Minimum 1.
 ```
 
 Techno-specific definition:
@@ -1258,7 +1258,7 @@ In `RULES.INI`:
 [SOMETECHNO]
 SelfHealingCap=50% 			; % or float, determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
 SelfHealingRate=.016 		; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
-UnitSelfHealRepairStep=1 	; integer, the amount of strength to recover in each regeneration tick.
+SelfHealingStep=1 	; integer, the amount of strength to recover in each regeneration tick. Minimum 1.
 ```
 
 ## Terrain

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1249,7 +1249,7 @@ In `RULES.INI`:
 [General]
 SelfHealingCap=50% 			; % or float, determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
 SelfHealingRate=.016 		; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
-SelfHealingStep=1 	; integer, the amount of strength to recover in each regeneration tick. Minimum 1.
+SelfHealingStep=1 			; integer, the amount of strength to recover in each regeneration tick. Minimum 1.
 ```
 
 Techno-specific definition:
@@ -1258,7 +1258,7 @@ In `RULES.INI`:
 [SOMETECHNO]
 SelfHealingCap=50% 			; % or float, determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
 SelfHealingRate=.016 		; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
-SelfHealingStep=1 	; integer, the amount of strength to recover in each regeneration tick. Minimum 1.
+SelfHealingStep=1 			; integer, the amount of strength to recover in each regeneration tick. Minimum 1.
 ```
 
 ## Terrain

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -1241,21 +1241,24 @@ Vanilla prerequisite groups always exist by default. If you re-define them in `[
 - If both are not specified, then Vinifera falls back to the original values used by the game, which depends on the attribute:
   - Self Healing Cap: based on `ConditionYellow`.
   - Self Healing Rate: based on `RepairRate`.
+  - Self Healing Step: defaults to 1.
 
 Game-wide definition:
 In `RULES.INI`:
 ```ini
 [General]
-SelfHealingCap=50% ; % or float, determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
-SelfHealingRate=.016 ; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
+SelfHealingCap=50% 			; % or float, determines the maximum amount of strength technos can automatically regenerate. Caps at 100%. Only used for technos that do not have this key defined for them.
+SelfHealingRate=.016 		; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. Only used for technos that do not have this key defined for them. The lower the value, the faster technos will heal.
+UnitSelfHealRepairStep=1 	; integer, the amount of strength to recover in each regeneration tick.
 ```
 
 Techno-specific definition:
 In `RULES.INI`:
 ```ini
 [SOMETECHNO]
-SelfHealingCap=50% ; % or float, determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
-SelfHealingRate=.016 ; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
+SelfHealingCap=50% 			; % or float, determines the maximum amount of strength this techno can automatically regenerate. Caps at 100%.
+SelfHealingRate=.016 		; float, minutes at 15 FPS between each regeneration tick. Caps at once per frame. The lower the value, the faster this techno will heal.
+UnitSelfHealRepairStep=1 	; integer, the amount of strength to recover in each regeneration tick.
 ```
 
 ## Terrain

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -115,6 +115,7 @@ New:
 - Fix Win32 dialog scaling with SDL (by Rampastring)
 - Reimplement the software blitters with SIMD (SSE2/AVX2) for faster rendering on modern CPUs (by ZivDero)
 - Add the ability to specify sight ranges for technos when they are veteran and elite (by JoyfulShush)
+- Allow customizing the amount of strength technos recover in each self-heal instance per techno and globally (by JoyfulShush)
 
 
 Vinifera fixes:

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -91,6 +91,7 @@ RulesClassExtension::RulesClassExtension(const RulesClass* this_ptr) :
     DetectBeaconVoice(VOX_NONE),
     SelfHealingCap(-1),
     SelfHealingRate(-1),
+    UnitSelfHealRepairStep(1),
     IsBeachIsCrush(false),
     BuildingFlameSpawnBlockFrames(0),
     IronCurtainDuration(675),
@@ -269,6 +270,7 @@ void RulesClassExtension::Object_CRC(CRCEngine &crc) const
     crc(IsUseBridgeHealth);
     crc(BridgeArmor);
     crc(IsCellTagsIgnoreStealth);
+    crc(UnitSelfHealRepairStep);
 }
 
 
@@ -698,6 +700,7 @@ bool RulesClassExtension::General(CCINIClass &ini)
     MaxBeacons = ini.Get_Int(GENERAL, "MaxBeacons", MaxBeacons);
     SelfHealingCap = ini.Get_Float(GENERAL, "SelfHealingCap", SelfHealingCap);    
     SelfHealingRate = ini.Get_Float(GENERAL, "SelfHealingRate", SelfHealingRate);
+    UnitSelfHealRepairStep = ini.Get_Int(GENERAL, "UnitSelfHealRepairStep", UnitSelfHealRepairStep);
     PausedRepairsFrame = ini.Get_Int(GENERAL, "PausedRepairsFrame", PausedRepairsFrame);
     EscortRange = ini.Get_Lepton(GENERAL, "EscortRange", EscortRange);
     AbandonTargetEscortRange = ini.Get_Lepton(GENERAL, "AbandonTargetEscortRange", AbandonTargetEscortRange);

--- a/src/extensions/rules/rulesext.cpp
+++ b/src/extensions/rules/rulesext.cpp
@@ -91,7 +91,7 @@ RulesClassExtension::RulesClassExtension(const RulesClass* this_ptr) :
     DetectBeaconVoice(VOX_NONE),
     SelfHealingCap(-1),
     SelfHealingRate(-1),
-    UnitSelfHealRepairStep(1),
+    SelfHealingStep(1),
     IsBeachIsCrush(false),
     BuildingFlameSpawnBlockFrames(0),
     IronCurtainDuration(675),
@@ -270,7 +270,7 @@ void RulesClassExtension::Object_CRC(CRCEngine &crc) const
     crc(IsUseBridgeHealth);
     crc(BridgeArmor);
     crc(IsCellTagsIgnoreStealth);
-    crc(UnitSelfHealRepairStep);
+    crc(SelfHealingStep);
 }
 
 
@@ -700,7 +700,7 @@ bool RulesClassExtension::General(CCINIClass &ini)
     MaxBeacons = ini.Get_Int(GENERAL, "MaxBeacons", MaxBeacons);
     SelfHealingCap = ini.Get_Float(GENERAL, "SelfHealingCap", SelfHealingCap);    
     SelfHealingRate = ini.Get_Float(GENERAL, "SelfHealingRate", SelfHealingRate);
-    UnitSelfHealRepairStep = ini.Get_Int(GENERAL, "UnitSelfHealRepairStep", UnitSelfHealRepairStep);
+    SelfHealingStep = ini.Get_Int(GENERAL, "SelfHealingStep", SelfHealingStep);
     PausedRepairsFrame = ini.Get_Int(GENERAL, "PausedRepairsFrame", PausedRepairsFrame);
     EscortRange = ini.Get_Lepton(GENERAL, "EscortRange", EscortRange);
     AbandonTargetEscortRange = ini.Get_Lepton(GENERAL, "AbandonTargetEscortRange", AbandonTargetEscortRange);

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -194,7 +194,7 @@ public:
     /**
      *  The amount of strength this techno should regenerate whenever it self-heals.
      */
-    int UnitSelfHealRepairStep;
+    int SelfHealingStep;
 
     /**
      *  Is LandType Beach considered as "requires crushing" for passability purposes, as opposed to water?

--- a/src/extensions/rules/rulesext.h
+++ b/src/extensions/rules/rulesext.h
@@ -192,6 +192,11 @@ public:
     double SelfHealingRate;
 
     /**
+     *  The amount of strength this techno should regenerate whenever it self-heals.
+     */
+    int UnitSelfHealRepairStep;
+
+    /**
      *  Is LandType Beach considered as "requires crushing" for passability purposes, as opposed to water?
      */
     bool IsBeachIsCrush;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -3490,6 +3490,7 @@ DEFINE_HOOK(0x0062E9F2, TechnoClass_AI_Self_Heal_Repair_Step, 0)
     return 0x0062E9F8;
 }
 
+
 /**
  *  Main function for patching the hooks.
  */

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -3465,26 +3465,26 @@ DEFINE_HOOK(0x0062E799, _TechnoClass_AI_Medics_Lose_Targets_AI_Houses, 0)
  *
  *  @author: JoyfulShush
  */
-DEFINE_HOOK(0x0062E9F2, TechnoClass_AI_Self_Heal_Repair_Step, 0)
+DEFINE_HOOK(0x0062E9EF, TechnoClass_AI_Self_Heal_Repair_Step, 0)
 {
     GET(TechnoClass*, this_ptr, ESI);
 
     auto this_ptr_ext = Extension::Fetch(this_ptr->TClass);
 
-    int strength_to_recover = this_ptr_ext->SelfHealRepairStep > 0 
-        ? this_ptr_ext->SelfHealRepairStep 
-        : RuleExtension->UnitSelfHealRepairStep;
+    int strength_to_recover = this_ptr_ext->SelfHealingStep > 0 
+        ? this_ptr_ext->SelfHealingStep
+        : RuleExtension->SelfHealingStep;
     
     int max_strength = this_ptr->TClass->MaxStrength;
 
-    // Don't allow unit to recover strength beyond its max strength
-    if (this_ptr->Strength + strength_to_recover > max_strength) {
-        this_ptr->Strength = max_strength;
-    } else {
-        this_ptr->Strength += strength_to_recover;
+    // Don't allow to self-heal 0 health or negative values
+    if (strength_to_recover > 0) {
+        // Don't allow unit to recover strength beyond its max strength
+        this_ptr->Strength = std::min(this_ptr->Strength + strength_to_recover, max_strength);
     }
 
     // Stolen bytes
+    R->EAX(this_ptr->Strength);
     R->ECX(this_ptr);
 
     return 0x0062E9F8;

--- a/src/extensions/techno/technoext_hooks.cpp
+++ b/src/extensions/techno/technoext_hooks.cpp
@@ -3459,6 +3459,38 @@ DEFINE_HOOK(0x0062E799, _TechnoClass_AI_Medics_Lose_Targets_AI_Houses, 0)
 
 
 /**
+ *  Patches TechnoClass::AI to allow customizing the amount of health regenerated whenever a unit self-heals.
+ *  Can be configured on both the techno level and globally.
+ *  Defaults to 1 when the key is omitted.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x0062E9F2, TechnoClass_AI_Self_Heal_Repair_Step, 0)
+{
+    GET(TechnoClass*, this_ptr, ESI);
+
+    auto this_ptr_ext = Extension::Fetch(this_ptr->TClass);
+
+    int strength_to_recover = this_ptr_ext->SelfHealRepairStep > 0 
+        ? this_ptr_ext->SelfHealRepairStep 
+        : RuleExtension->UnitSelfHealRepairStep;
+    
+    int max_strength = this_ptr->TClass->MaxStrength;
+
+    // Don't allow unit to recover strength beyond its max strength
+    if (this_ptr->Strength + strength_to_recover > max_strength) {
+        this_ptr->Strength = max_strength;
+    } else {
+        this_ptr->Strength += strength_to_recover;
+    }
+
+    // Stolen bytes
+    R->ECX(this_ptr);
+
+    return 0x0062E9F8;
+}
+
+/**
  *  Main function for patching the hooks.
  */
 void TechnoClassExtension_Hooks()

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -93,7 +93,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsHideWakeWhenCloaked(false),
     SelfHealingCap(-1),
     SelfHealingRate(-1),
-    SelfHealRepairStep(-1),
+    SelfHealingStep(-1),
     IsDetectDisguise(false),
     IronCurtainPriorityTarget(false),
     EscortRange(-1),
@@ -271,7 +271,7 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(IsHideWakeWhenCloaked);
     crc(SelfHealingCap);
     crc(SelfHealingRate);
-    crc(SelfHealRepairStep);
+    crc(SelfHealingStep);
     crc(IsDetectDisguise);
     crc(IronCurtainPriorityTarget);
     crc(EscortRange);
@@ -422,7 +422,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
 
     SelfHealingCap = ini.Get_Float(ini_name, "SelfHealingCap", SelfHealingCap);
     SelfHealingRate = ini.Get_Float(ini_name, "SelfHealingRate", SelfHealingRate);
-    SelfHealRepairStep = ini.Get_Int(ini_name, "UnitSelfHealRepairStep", SelfHealRepairStep);
+    SelfHealingStep = ini.Get_Int(ini_name, "SelfHealingStep", SelfHealingStep);
 
     IsDetectDisguise = ini.Get_Bool(ini_name, "DetectDisguise", IsDetectDisguise);
 

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -93,6 +93,7 @@ TechnoTypeClassExtension::TechnoTypeClassExtension(const TechnoTypeClass *this_p
     IsHideWakeWhenCloaked(false),
     SelfHealingCap(-1),
     SelfHealingRate(-1),
+    SelfHealRepairStep(-1),
     IsDetectDisguise(false),
     IronCurtainPriorityTarget(false),
     EscortRange(-1),
@@ -270,6 +271,7 @@ void TechnoTypeClassExtension::Object_CRC(CRCEngine &crc) const
     crc(IsHideWakeWhenCloaked);
     crc(SelfHealingCap);
     crc(SelfHealingRate);
+    crc(SelfHealRepairStep);
     crc(IsDetectDisguise);
     crc(IronCurtainPriorityTarget);
     crc(EscortRange);
@@ -420,6 +422,7 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
 
     SelfHealingCap = ini.Get_Float(ini_name, "SelfHealingCap", SelfHealingCap);
     SelfHealingRate = ini.Get_Float(ini_name, "SelfHealingRate", SelfHealingRate);
+    SelfHealRepairStep = ini.Get_Int(ini_name, "UnitSelfHealRepairStep", SelfHealRepairStep);
 
     IsDetectDisguise = ini.Get_Bool(ini_name, "DetectDisguise", IsDetectDisguise);
 

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -265,7 +265,7 @@ public:
     /**
      *  Define the amount of strength regenerated whenever this techno self-heals
      */
-    int SelfHealRepairStep;
+    int SelfHealingStep;
 
     /**
      *  Does this object need to decloak before firing?

--- a/src/extensions/technotype/technotypeext.h
+++ b/src/extensions/technotype/technotypeext.h
@@ -263,6 +263,11 @@ public:
     float SelfHealingRate;
 
     /**
+     *  Define the amount of strength regenerated whenever this techno self-heals
+     */
+    int SelfHealRepairStep;
+
+    /**
      *  Does this object need to decloak before firing?
      */
     bool IsDecloakToFire;


### PR DESCRIPTION
Transfers the existing `UnitSelfHealRepairStep` key from ts-patches to Vinifera and empowers it to be customizable per techno in addition to being customizable globally.

Allows modders and mappers to configure the amount of strength that a self-healing techno will recover whenever it self-heals.

Completes the trifecta of Self Healing properties: healing cap (max %), healing rate (frequency), and healing step (amount).