### PR TITLE
Select Same-Type command improvements

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -196,6 +196,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a vanilla bug where cloaked units sensed by nearby enemy units can cloak again immediately.
   - Extend aircraft speed to include house Airspeed bias, game speed bias, and the FASTER veteran/elite ability when calculating aircraft speed values.
   - Add a key to allow AI-controlled units to persist their tags when they deploy into a building.
+  - Improve same-type select command logic, and allow map-wide select when pressing twice in succession.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Krnyoshi**:

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -2070,9 +2070,9 @@ In `RULES.INI`:
 HarvesterUnderAttackThrottleTime=0.0  ; float, minutes that EVA is forbidden from alerting about a harvester being under attack after last alerting about it. Automatically scaled by game speed (iow. it's real-life minutes)
 ```
 
-### Same-Type Select Command
+### Select Same Type Command
 
-- The Same-Type Select command (default hotkey: `T`) is used by players to select all units and structures across the screen that are of the same types of the currently selected units and structures. The command has been improved in the following ways:
+- The Select Same Type command is used by players to select all units and structures across the screen that are of the same types of the currently selected units and structures. The command has been improved in the following ways:
 	- No longer deselects units that are outside of the screen.
 	- Command is now ignored when non-player controlled units or structures are selected.
-	- Players can now press the Same-Type Select command twice in quick succession to select units and structures across the map.
+	- Players can now press the Select Same Type command twice in quick succession to select units and structures across the map.

--- a/docs/New-Features-and-Enhancements.md
+++ b/docs/New-Features-and-Enhancements.md
@@ -2069,3 +2069,10 @@ In `RULES.INI`:
 [AudioVisual]
 HarvesterUnderAttackThrottleTime=0.0  ; float, minutes that EVA is forbidden from alerting about a harvester being under attack after last alerting about it. Automatically scaled by game speed (iow. it's real-life minutes)
 ```
+
+### Same-Type Select Command
+
+- The Same-Type Select command (default hotkey: `T`) is used by players to select all units and structures across the screen that are of the same types of the currently selected units and structures. The command has been improved in the following ways:
+	- No longer deselects units that are outside of the screen.
+	- Command is now ignored when non-player controlled units or structures are selected.
+	- Players can now press the Same-Type Select command twice in quick succession to select units and structures across the map.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -124,6 +124,7 @@ New:
 - Fix a bug where cloaked units sensed by nearby enemy units can cloak again immediately (by JoyfulShush)
 - Extend aircraft speed to include house Airspeed bias, game speed bias, and the FASTER veteran/elite ability when calculating aircraft speed values (by JoyfulShush)
 - Add a key to allow AI-controlled units to persist their tags when they deploy into a building (by JoyfulShush)
+- Improve same-type select command logic, and allow map-wide select when pressing twice in succession (by JoyfulShush)
 
 Vinifera fixes:
 - Fix unit placement in non-TS Client builds of Vinifera (by ZivDero)

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -429,14 +429,14 @@ bool SelectSameTypeImprovedCommandClass::Process()
     
     for (int i = 0; i < CurrentObjects.Count(); i++) {
         auto current_object = CurrentObjects[i];
-        auto technoClass = current_object->Techno_Type_Class();
+        auto techno_class = current_object->Techno_Type_Class();
 
         if (current_object->Is_Techno() && !current_object->As_Techno()->House->Is_Player_Control()) {
             continue;
         }
 
-        if (!SelectionTypes.contains(technoClass))  {
-            SelectionTypes.insert(technoClass);
+        if (!SelectionTypes.contains(techno_class))  {
+            SelectionTypes.insert(techno_class);
         }
     }
 

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -385,6 +385,66 @@ bool DeleteCommandClass::Process()
 
 
 /**
+ *  Replacement for SelectSameTypeCommandClass.
+ *
+ *  @author: JoyfulShush
+ */
+const char* SelectSameTypeImprovedCommandClass::Get_Name() const
+{
+    return "SelectType";
+}
+
+const char* SelectSameTypeImprovedCommandClass::Get_UI_Name() const
+{
+    return "Select Same Type";
+}
+
+const char* SelectSameTypeImprovedCommandClass::Get_Category() const
+{
+    return "Selection";
+}
+
+const char* SelectSameTypeImprovedCommandClass::Get_Description() const
+{
+    return "Selects all units of the same type as currently selected.";
+}
+
+bool SelectSameTypeImprovedCommandClass::Process()
+{    
+    SelectionTypes.clear();
+    
+    for (int i = 0; i < CurrentObjects.Count(); i++) {
+        auto current_object = CurrentObjects[i];
+        auto technoClass = current_object->Techno_Type_Class();
+
+        if (!SelectionTypes.contains(technoClass))  {
+            SelectionTypes.insert(technoClass);
+        }
+    }
+    
+    TacticalMap->Select_These(TacticalRect, Process_Callback);
+
+    return true;
+}
+
+
+void SelectSameTypeImprovedCommandClass::Process_Callback(ObjectClass* object_ptr) 
+{
+    if (object_ptr == nullptr) return;
+    if (!object_ptr->Is_Techno()) return;
+    if (!object_ptr->IsDown) return;
+    
+    auto techno = object_ptr->As_Techno();
+
+    if (techno->IsSelected) return;
+    if (!SelectionTypes.contains(techno->Techno_Type_Class())) return;
+    if (!techno->House->Is_Player_Control()) return;
+
+    techno->Select();
+}
+
+
+/**
  *  #issue-112
  * 
  *  Enter the manual placement mode when a building is complete

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -415,6 +415,7 @@ const char* SelectSameTypeImprovedCommandClass::Get_Description() const
  *  1. No longer deselects units that are out of the screen when running the command.
  *  2. Rather than calling 'TacticalMap->Select_These' for each type, runs it once for all types.
  *  3. When processed twice in a small amount of time, selects the units of those types in the entire map rather than just the current tactical view.
+ *  4. Ignores selected technos that do not belong to the player.
  */
 bool SelectSameTypeImprovedCommandClass::Process()
 {   

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -83,6 +83,7 @@
 #include "wwcrc.h"
 #include "wwmouse.h"
 
+#include "mapext_hooks.h"
 #include <algorithm>
 #include <map>
 
@@ -409,9 +410,19 @@ const char* SelectSameTypeImprovedCommandClass::Get_Description() const
     return "Selects all units of the same type as currently selected.";
 }
 
+/*
+ *  Improves the Select Same Type command in the following ways:
+ *  1. No longer deselects units that are out of the screen when running the command.
+ *  2. Rather than calling 'TacticalMap->Select_These' for each type, runs it once for all types.
+ *  3. When processed twice in a small amount of time, selects the units of those types in the entire map rather than just the current tactical view.
+ */
 bool SelectSameTypeImprovedCommandClass::Process()
-{    
+{   
     SelectionTypes.clear();
+    DWORD current_time = timeGetTime();
+    DWORD previous_execution_time = LastExecutionTime;
+
+    LastExecutionTime = current_time;
     
     for (int i = 0; i < CurrentObjects.Count(); i++) {
         auto current_object = CurrentObjects[i];
@@ -421,8 +432,12 @@ bool SelectSameTypeImprovedCommandClass::Process()
             SelectionTypes.insert(technoClass);
         }
     }
-    
-    TacticalMap->Select_These(TacticalRect, Process_Callback);
+
+    if (previous_execution_time != 0 && current_time - previous_execution_time < 500) {
+        Map_Select_These(Process_Callback);
+    } else {
+        TacticalMap->Select_These(TacticalRect, Process_Callback);
+    }
 
     return true;
 }

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -431,7 +431,7 @@ bool SelectSameTypeImprovedCommandClass::Process()
         auto current_object = CurrentObjects[i];
         auto technoClass = current_object->Techno_Type_Class();
 
-        if (current_object->Is_Techno() && current_object->As_Techno()->House != PlayerPtr) {
+        if (current_object->Is_Techno() && current_object->As_Techno()->House->Is_Player_Control()) {
             continue;
         }
 

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -431,7 +431,7 @@ bool SelectSameTypeImprovedCommandClass::Process()
         auto current_object = CurrentObjects[i];
         auto technoClass = current_object->Techno_Type_Class();
 
-        if (current_object->Is_Techno() && current_object->As_Techno()->House->Is_Player_Control()) {
+        if (current_object->Is_Techno() && !current_object->As_Techno()->House->Is_Player_Control()) {
             continue;
         }
 

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -428,15 +428,21 @@ bool SelectSameTypeImprovedCommandClass::Process()
         auto current_object = CurrentObjects[i];
         auto technoClass = current_object->Techno_Type_Class();
 
+        if (current_object->Is_Techno() && current_object->As_Techno()->House != PlayerPtr) {
+            continue;
+        }
+
         if (!SelectionTypes.contains(technoClass))  {
             SelectionTypes.insert(technoClass);
         }
     }
 
-    if (previous_execution_time != 0 && current_time - previous_execution_time < 500) {
-        Map_Select_These(Process_Callback);
-    } else {
-        TacticalMap->Select_These(TacticalRect, Process_Callback);
+    if (SelectionTypes.size() > 0) {
+        if (previous_execution_time != 0 && current_time - previous_execution_time < 500) {
+            Map_Select_These(Process_Callback);
+        } else {
+            TacticalMap->Select_These(TacticalRect, Process_Callback);
+        }
     }
 
     return true;

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -416,6 +416,8 @@ const char* SelectSameTypeImprovedCommandClass::Get_Description() const
  *  2. Rather than calling 'TacticalMap->Select_These' for each type, runs it once for all types.
  *  3. When processed twice in a small amount of time, selects the units of those types in the entire map rather than just the current tactical view.
  *  4. Ignores selected technos that do not belong to the player.
+ * 
+ *  @author: JoyfulShush
  */
 bool SelectSameTypeImprovedCommandClass::Process()
 {   
@@ -450,6 +452,11 @@ bool SelectSameTypeImprovedCommandClass::Process()
 }
 
 
+/*
+ *  For each object being checked by the game, decide if the techno should be selected when running the Select Same Type command.
+ *
+ *  @author: JoyfulShush
+ */
 void SelectSameTypeImprovedCommandClass::Process_Callback(ObjectClass* object_ptr) 
 {
     if (object_ptr == nullptr) return;
@@ -457,9 +464,10 @@ void SelectSameTypeImprovedCommandClass::Process_Callback(ObjectClass* object_pt
     if (!object_ptr->IsDown) return;
     
     auto techno = object_ptr->As_Techno();
+    auto techno_class = techno->Techno_Type_Class();
 
     if (techno->IsSelected) return;
-    if (!SelectionTypes.contains(techno->Techno_Type_Class())) return;
+    if (!SelectionTypes.contains(techno_class)) return;
     if (!techno->House->Is_Player_Control()) return;
 
     techno->Select();

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -14,6 +14,7 @@
 #include "vinifera_globals.h"
 
 #include <map>
+#include <unordered_set>
 
 
 /**
@@ -1458,4 +1459,23 @@ public:
     virtual const char *Get_Category() const override;
     virtual const char *Get_Description() const override;
     virtual bool Process() override;
+};
+
+
+/**
+ *  Replacement for SelectSameTypeCommandClass.
+ */
+class SelectSameTypeImprovedCommandClass : public ViniferaCommandClass
+{
+public:
+    SelectSameTypeImprovedCommandClass() : ViniferaCommandClass() {}
+    virtual ~SelectSameTypeImprovedCommandClass() {}
+
+    virtual const char* Get_Name() const override;
+    virtual const char* Get_UI_Name() const override;
+    virtual const char* Get_Category() const override;
+    virtual const char* Get_Description() const override;
+    virtual bool Process() override;
+    static void Process_Callback(ObjectClass* object);
+    inline static std::unordered_set<const TechnoTypeClass*> SelectionTypes;
 };

--- a/src/extensions/command/commandext.h
+++ b/src/extensions/command/commandext.h
@@ -1478,4 +1478,5 @@ public:
     virtual bool Process() override;
     static void Process_Callback(ObjectClass* object);
     inline static std::unordered_set<const TechnoTypeClass*> SelectionTypes;
+    inline static DWORD LastExecutionTime = 0;
 };

--- a/src/extensions/command/commandext_hooks.cpp
+++ b/src/extensions/command/commandext_hooks.cpp
@@ -338,4 +338,13 @@ void CommandExtension_Hooks()
     Hook_Virtual(0x004EAF00, DeleteCommandClass::Get_Category);
     Hook_Virtual(0x004EAF10, DeleteCommandClass::Get_Description);
     Hook_Virtual(0x004EAF20, DeleteCommandClass::Process);
+
+    /**
+     *  Replace SelectSameTypeCommandClass with SelectSameTypeImprovedCommandClass.
+     */
+    Hook_Virtual(0x004EAD80, SelectSameTypeImprovedCommandClass::Get_Name);
+    Hook_Virtual(0x004EADA0, SelectSameTypeImprovedCommandClass::Get_UI_Name);
+    Hook_Virtual(0x004EAD90, SelectSameTypeImprovedCommandClass::Get_Category);
+    Hook_Virtual(0x004EADB0, SelectSameTypeImprovedCommandClass::Get_Description);
+    Hook_Virtual(0x004EADC0, SelectSameTypeImprovedCommandClass::Process);
 }

--- a/src/extensions/map/mapext_hooks.cpp
+++ b/src/extensions/map/mapext_hooks.cpp
@@ -16,10 +16,12 @@
 #include "extension.h"
 #include "hooker.h"
 #include "map.h"
+#include "mouse.h"
 #include "object.h"
 #include "objecttype.h"
 #include "rules.h"
 #include "syringe.h"
+#include "techno.h"
 #include "tibsun_functions.h"
 #include "vinifera_globals.h"
 
@@ -172,6 +174,36 @@ void MapClassExt::_Calculate_Sight_Radius_If_Needed(int sight_range)
         RadiusCountTable.push_back(static_cast<int>(RadiusOffsets.size()));
     }
 }
+
+
+/*
+ *  Similar implementation to Tactical::Select_These, however instead of being specific to the tactical view,
+ *  applies the selection callback on all technos in the map.
+ *  Used to conditionally select technos based on the callback logic.
+ * 
+ *  @author: JoyfulShush
+ */
+void Map_Select_These(void (*select_callback)(ObjectClass*))
+{
+    if (select_callback == nullptr) {
+        return;
+    }
+
+    for (int index = 0; index < Technos.Count(); ++index) {
+        TechnoClass* techno = Technos[index];
+
+        if (techno == nullptr || !techno->IsActive || !techno->IsDown) {
+            continue;
+        }
+
+        if (!Map.In_Radar(techno->Center_Coord())) {
+            continue;
+        }
+
+        select_callback(techno);
+    }
+}
+
 
 /*
  *  Patches MapClass::From_Sight to no longer clamp the sight range to 10.

--- a/src/extensions/map/mapext_hooks.h
+++ b/src/extensions/map/mapext_hooks.h
@@ -9,5 +9,7 @@
 
 #pragma once
 
+class ObjectClass;
 
+void Map_Select_These(void (*select_callback)(ObjectClass*));
 void MapClassExtension_Hooks();


### PR DESCRIPTION
Improves The Same-Type Select command (default hotkey: `T`) is used by players to select all units and structures across the screen that are of the same types of the currently selected units and structures. The command has been improved in the following ways:
  - No longer deselects units that are outside of the screen.
  - Command is now ignored when non-player controlled units or structures are selected.
  - Players can now press the Same-Type Select command twice in quick succession to select units and structures across the map.