### PR TITLE
[Minor] Fix MSVC 19.40 build failure in the spawner config

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -207,6 +207,7 @@ This page lists all the individual contributions to the project by their author.
   - Fix a bug where MultipleFactoryCap was giving full production speed bonuses after building the second factory instead of incrementally giving speed bonuses until the cap was reached.
 - **Noble Fish**:
   - Document proofreading and formatting/styling assistance.
+  - Fix the MSVC 19.40 build failure by using `std::extent_v` for member-array bounds in the spawner config.
 - **MarkJFox**:
   - Graphics for the new sidebar fitting vanilla sidebar.
 - **[Phobos Contributors](https://github.com/Phobos-developers/Phobos/blob/develop/CREDITS.md)**:

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -59,6 +59,7 @@ This page lists the history of changes across stable Vinifera releases and also 
 
 Fixes:
 - Fix a bug where loading a saved game through the client would fail due to overly strict spawner config validation (by ZivDero)
+- Fix the MSVC 19.40 build failure by using `std::extent_v` for member-array bounds in the spawner config (by Noble_Fish)
 
 :::
 

--- a/src/spawner/spawnerconfig.cpp
+++ b/src/spawner/spawnerconfig.cpp
@@ -92,7 +92,10 @@ void SpawnerConfig::Read_INI(CCINIClass& spawn_ini)
      *  into the front of the final array, followed by AIs.
      *  House data is read per final slot index since it's already in game slot order.
      */
-    PlayerConfig temp[std::size(Players)];
+    // Use std::extent_v instead of std::size() here: MSVC 19.40 (VS 17.10)
+    // rejects std::size() of a member array as a constant expression in array
+    // bounds ("reads this"), while std::extent_v only inspects the array type.
+    PlayerConfig temp[std::extent_v<decltype(Players)>];
     for (int i = 0; i < std::size(temp); ++i) {
         temp[i].Read_Player_INI(spawn_ini, i);
         if (temp[i].IsHuman) {
@@ -100,7 +103,7 @@ void SpawnerConfig::Read_INI(CCINIClass& spawn_ini)
         }
     }
 
-    bool claimed[std::size(Players)] = {};
+    bool claimed[std::extent_v<decltype(Players)>] = {};
     int slot = 0;
 
     for (int s = 0; s < HumanPlayers && slot < std::size(Players); ++s) {


### PR DESCRIPTION
**Problem**

Building Vinifera with **MSVC 19.40 (Visual Studio 2022 17.10)** fails in `src/spawner/spawnerconfig.cpp` when `std::size(Players)` is used as an **array bound** in a member function:

```cpp
PlayerConfig temp[std::size(Players)];
bool claimed[std::size(Players)] = {};
```

The compiler rejects the expression as non-constant because the array is a member and the constexpr evaluator treats the size deduction as a read of `this`:

```
error C2131: expression did not evaluate to a constant
error C2672: "std::size": no matching overloaded function found
error C3863: array type 'bool [function]' is not assignable
note: failure was caused by a read of a variable outside its lifetime
note: see usage of 'this'
```

*(The build machine only has the Simplified Chinese VS language pack; the captured diagnostics read: `error C2131: 表达式的计算结果不是常数`, `note: 因读取超过生命周期的变量而失败`, `note: 请参见"this"的用法`. The messages above are the standard English MSVC texts for the same diagnostics.)*

`std::size()` on an array is a constexpr function that only derives the extent from the array *type* and never reads elements. MSVC 19.40's constexpr evaluator is stricter here and rejects the member-array case, while MSVC 19.36–19.38 (older windows-2022 CI images) and other compilers accept it, which is why CI has not caught this yet. If the windows-2022 image is updated to VS 17.10 / MSVC 19.40 in the future, the official CI will hit the same failure.

---

**Fix**

Use `std::extent_v<decltype(Players)>` for the two array bounds instead of `std::size(Players)` — it queries the array dimension purely at the type level and is accepted by MSVC 19.40. Verified: `cmake --build` (Win32, RelWithDebInfo) passes with the change and fails without it.
