### PR TITLE
Fixes a crash where no infantry can be placed as starting units in skirmish

### DIFF
--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -3150,6 +3150,11 @@ void ScenarioClassExtension::Create_Units(bool official)
                     technotype = infantry[Random_Pick(0, infantry.Count() - 1)];
                 }
 
+                if (technotype == nullptr) {
+                    DEBUG_WARNING("No technotype available to place for house {}, skipping further placement\n", hptr->Class->IniName);
+                    break;
+                }
+
                 /**
                  *  Create units (Note: Unlimbo calls Enter_Idle_Mode(), which
                  *  assigns the unit to HUNT; we must use Set_Mission() to override


### PR DESCRIPTION
Fixes a crash that appeared in DTA, and can also be reproduced in TSC by setting all infantry of a certain side as `AllowedToStartInMultiplayer=no`.

The way the setup phase for starting units in skirmish works is:
* Place enough vehicles until it is 2/3s of the allowed cost.
* Place infantry until you get through the allowed cost.

However, the code is missing a check for when all vehicles were placed, and infantry should be placed instead - it does not properly handle a case where there are also no infantry to place, instead trying to place a nullptr technotype.

The code detects this case, prints a warning, and leaves the loop. In practice, it would load the game with just vehicles, but modders should be able to notice and fix that on their own by allowing infantry to spawn.