### PR TITLE
Set Base Placementer Center for AI players when setting up ConYards

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -202,6 +202,7 @@ This page lists all the individual contributions to the project by their author.
   - Add a key to allow AI-controlled units to persist their tags when they deploy into a building.
   - Improve same-type select command logic, and allow map-wide select when pressing twice in succession.
   - Fix the game crashing on scenario start when a HouseType has no valid starting infantry and UnitCount is above 0.
+  - Fix a bug where an AI house could get stuck trying to build base nodes after being interrupted by a friendly immovable object.
 - **Kerbiter (Metadorius)**:
   - Initial documentation setup.
 - **Krnyoshi**:

--- a/docs/Bugfixes.md
+++ b/docs/Bugfixes.md
@@ -137,5 +137,6 @@ This page lists all vanilla bugs fixed by Vinifera.
 - Fix a bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them block further infantry production until they land on their rally point.
 - Fix a bug where Jumpjet infantry exiting a barracks with a far enough rally point makes them fly, land near the barracks, and only then go to their destination.
 - Fix a bug where players could not click on a cell that included tiberium, bridges or enemy cloaked units or structure to undeploy a building.
-- Fix a vanilla bug where cloaked units sensed by nearby enemy units can cloak again immediately.
+- Fix a bug where cloaked units sensed by nearby enemy units can cloak again immediately.
 - Fix a bug where the game often reported multiple synchronization errors when one player got out of sync.
+- Fix a bug where an AI house could get stuck trying to build base nodes after being interrupted by a friendly immovable object.

--- a/docs/Whats-New.md
+++ b/docs/Whats-New.md
@@ -75,6 +75,7 @@ Fixes:
 - Fix alternative war factory selection not respecting the `Naval=` key (by Rampastring)
 - Fix crash when loading a game when a game object's or animation's graphics are present in side-specific MIX file (by Rampastring)
 - Fix game exiting with a "The legacy version of HouseClass::Fetch_Factory has been called" error when a spectator selected a factory building (by Rampastring)
+- Fix a bug where an AI house could get stuck trying to build base nodes after being interrupted by a friendly immovable object (by JoyfulShush)
 
 :::
 

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -2786,6 +2786,29 @@ MoveType BuildingClassExt::_Can_Enter_Cell(CellClass const* cell, FacingType dir
 
 
 /**
+ *  Patches BuildingClass::Unlimbo right after a building was identified as a ConYard, before being added to the ConYard list.
+ *  AI houses that build base nodes need to know the placement center of their base in order to correctly place structures around it.
+ *  In a skirmish setting, it is immediately set as the AI deploys its ConYards (in UnitClass::Try_To_Deploy).
+ *  However, in campaign, it is only set when the Auto Base Building trigger action is used, which can cause bases to get stuck
+ *  trying to build the next node at the ConYard's position, which is registered as the center. (in HouseClass::Where_To_Place_Building).
+ *  This makes sure that the AI has this value correctly set during any reason a ConYard is being unlimboed.
+ *  Note that this happens after Recalc_Center was already done as part of Unlimbo, so it is already set correctly.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x0042AA8B, _BuildingClass_Unlimbo_ConYard_PlacementCenter_Patch, 6)
+{
+    GET(BuildingClass*, this_ptr, ESI);
+
+    if (this_ptr->House->Base.PlacementCenter == CELL_NONE && !this_ptr->House->Is_Human_Player()) {
+        this_ptr->House->Base.PlacementCenter = this_ptr->House->Center.As_Cell();
+    }
+
+    return 0;
+}
+
+
+/**
  *  Main function for patching the hooks.
  */
 void BuildingClassExtension_Hooks()

--- a/src/extensions/command/commandext.cpp
+++ b/src/extensions/command/commandext.cpp
@@ -3483,12 +3483,7 @@ bool DumpAIBaseNodesCommandClass::Process()
             DEBUG_INFO("\n");
 
             DEBUG_INFO("{:02} \"{}\":\n", house_index, house->Class->Name());
-
-            //DEBUG_INFO("  field_50: {}\n", house->Base.field_50);
-            //DEBUG_INFO("  field_64: {}\n", house->Base.field_64);
-            //DEBUG_INFO("  field_68: {}\n", house->Base.field_68);
-            //DEBUG_INFO("  field_6C: {}\n", house->Base.field_6C);
-            //DEBUG_INFO("  field_70: {}\n", house->Base.field_70);
+            
             DEBUG_INFO("  PercentBuilt: {:03}\n", house->Base.PercentBuilt);
 
             DEBUG_INFO("  Nodes.Count: {}\n", house->Base.Nodes.Count());

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -2059,31 +2059,6 @@ DEFINE_HOOK(0x004C9937, HouseClass_Updated_Spied_By_Sight_Range_Patch, 0)
 
 
 /**
- *  Patches HouseClass::AI right at the start.
- *  AI houses that build base nodes need to know the placement center of their base in order to correctly place structures around it.
- *  In a skirmish setting, it is immediately set as the AI deploys its ConYards (in UnitClass::Try_To_Deploy).
- *  However, in campaign, it is only set when the Auto Base Building trigger action is used, which can cause bases to get stuck
- *  trying to build the next node at the ConYard's position, which is registered as the center. (in HouseClass::Where_To_Place_Building). 
- *  This makes sure that the AI has this value correctly set if it can build base nodes.
- *
- *  @author: JoyfulShush
- */
-DEFINE_HOOK(0x004BC5E6, _HouseClass_AI_Center_Patch, 8)
-{
-    GET(HouseClass*, this_ptr, ESI);
-
-    if (this_ptr->Base.PlacementCenter == CELL_NONE  && !this_ptr->Is_Human_Player() && this_ptr->ConstructionYards.Count() > 0) {
-        BuildingClass* building = this_ptr->ConstructionYards[0];
-        Cell base_cell = building->Get_Coord().As_Cell();
-        this_ptr->Center = Coord(base_cell);
-        this_ptr->Base.PlacementCenter = base_cell;
-    }
-
-    return 0;
-}
-
-
-/**
  *  Main function for patching the hooks.
  */
 void HouseClassExtension_Hooks()

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -130,7 +130,7 @@ int HouseClassExt::_AI_Building()
     if (node->Type == BASE_DEFENSE || BuildingTypes[node->Type] == Rule->WallTower && node->CellID == Cell(0, 0)) {
 
         const int nodeid = Base.Nodes.ID(node);
-        if (!AI_Build_Defense(nodeid, Base.field_38.Count() > 0 ? &Base.field_38 : nullptr)) {
+        if (!AI_Build_Defense(nodeid, Base.OuterCells.Count() > 0 ? &Base.OuterCells : nullptr)) {
 
             /**
              *  If it's a wall tower, delete it twice?
@@ -2055,6 +2055,31 @@ DEFINE_HOOK(0x004C9937, HouseClass_Updated_Spied_By_Sight_Range_Patch, 0)
     Map.Sight_From(coord, sight_range, this_ptr);
 
     return 0x004C996B;
+}
+
+
+/**
+ *  Patches HouseClass::AI right at the start.
+ *  AI houses that build base nodes need to know the placement center of their base in order to correctly place structures around it.
+ *  In a skirmish setting, it is immediately set as the AI deploys its ConYards (in UnitClass::Try_To_Deploy).
+ *  However, in campaign, it is only set when the Auto Base Building trigger action is used, which can cause bases to get stuck
+ *  trying to build the next node at the ConYard's position, which is registered as the center. (in HouseClass::Where_To_Place_Building). 
+ *  This makes sure that the AI has this value correctly set if it can build base nodes.
+ *
+ *  @author: JoyfulShush
+ */
+DEFINE_HOOK(0x004BC5E6, _HouseClass_AI_Center_Patch, 8)
+{
+    GET(HouseClass*, this_ptr, ESI);
+
+    if (this_ptr->Base.PlacementCenter == CELL_NONE  && !this_ptr->Is_Human_Player() && this_ptr->ConstructionYards.Count() > 0) {
+        BuildingClass* building = this_ptr->ConstructionYards[0];
+        Cell base_cell = building->Get_Coord().As_Cell();
+        this_ptr->Center = Coord(base_cell);
+        this_ptr->Base.PlacementCenter = base_cell;
+    }
+
+    return 0;
 }
 
 

--- a/src/extensions/scenario/scenarioext.cpp
+++ b/src/extensions/scenario/scenarioext.cpp
@@ -3091,7 +3091,7 @@ void ScenarioClassExtension::Create_Units(bool official)
                                     building->House->Begin_Construction();
 
                                     building->House->Base.Nodes[0].CellID = cell;
-                                    building->House->Base.field_50 = cell;
+                                    building->House->Base.PlacementCenter = cell;
 
                                     building->House->IsStarted = true;
                                     building->House->IsAITriggersOn = true;


### PR DESCRIPTION
Fixes an issue where base nodes could get stuck trying to constantly be placed onto the house's center, which is typically the ConYard. 

Additionally, removes stale uses of variables related to BaseClass, and renames ones that got a proper name (naming from OpenTS).