### PR TITLE
Fix descriptions not carrying over from inheritance

### DIFF
--- a/src/extensions/supertype/supertypeext.cpp
+++ b/src/extensions/supertype/supertypeext.cpp
@@ -175,7 +175,7 @@ bool SuperWeaponTypeClassExtension::Read_INI(CCINIClass &ini)
     ActionOutOfRange = ini.Get_ActionType(ini_name, "ActionOutOfRange", ActionOutOfRange);
     VoxMissileLaunched = ini.Get_VoxType(ini_name, "MissileLaunchedVoice", VoxMissileLaunched);
 
-    if (ini.Is_Present(ini_name, "Description")) ini.Get_String(ini_name, "Description", "", Description, std::size(Description));
+    ini.Get_String(ini_name, "Description", Description, Description, std::size(Description));
 
     IsInitialized = true;
     

--- a/src/extensions/technotype/technotypeext.cpp
+++ b/src/extensions/technotype/technotypeext.cpp
@@ -376,10 +376,8 @@ bool TechnoTypeClassExtension::Read_INI(CCINIClass &ini)
     VoiceHarvest = Get_VocTypes(ini, ini_name, "VoiceHarvest", VoiceHarvest);
     SpecialPipIndex = ini.Get_Int(ini_name, "SpecialPipIndex", SpecialPipIndex);
     PipWrap = ini.Get_Int(ini_name, "PipWrap", PipWrap);
-
-    if (ini.Is_Present(ini_name, "Description")) {
-        ini.Get_String(ini_name, "Description", "", Description, std::size(Description));
-    }
+    
+    ini.Get_String(ini_name, "Description", Description, Description, std::size(Description));
 
     IdleRate = ini.Get_Int(ini_name, "IdleRate", IdleRate);
     IdleRate = ArtINI.Get_Int(graphic_name, "IdleRate", IdleRate);


### PR DESCRIPTION
Fixes an issue where descriptions would not be carried over when inherited from another INI section.

For example:

```ini
[E1]
Name=Light Infantry
Description=This is a description

[E2]
$Inherits=E1
```

With this, both the E1 and E2 would have the same name, weapon, cost etc., but E1 did show its `Description` field, while (E2) did not. This fixes it so E2 can correctly inherit the description from E1.